### PR TITLE
Implement initial patch generation pipeline

### DIFF
--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -51,6 +51,13 @@ describe('SemanticAnalyzer', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
     expect(result.classification).toBe('autofix_import_type');
     expect(result.reasons[0]).toMatch(/converting concrete imports to type-only/);
+    expect(result.plan).toEqual({
+      kind: 'import_type',
+      imports: [
+        { sourceFile: 'a.ts', targetFile: 'b.ts' },
+        { sourceFile: 'b.ts', targetFile: 'a.ts' },
+      ],
+    });
   });
 
   it('detects extract_shared for top-level functions', () => {
@@ -73,6 +80,12 @@ describe('SemanticAnalyzer', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
     expect(result.classification).toBe('autofix_extract_shared');
     expect(result.reasons[0]).toMatch(/extracting symbols/);
+    expect(result.plan).toEqual({
+      kind: 'extract_shared',
+      sourceFile: 'b.ts',
+      targetFile: 'a.ts',
+      symbols: ['helperB'],
+    });
   });
 
   it('identifies suggest_manual for non-type cycles with unsupported declarations', () => {

--- a/analyzer/semantic.ts
+++ b/analyzer/semantic.ts
@@ -3,10 +3,26 @@ import path from 'node:path';
 import { type ImportDeclaration, Node, Project, type SourceFile, SyntaxKind } from 'ts-morph';
 import type { Classification } from '../db/index.js';
 
+export interface ImportTypeFixPlan {
+  kind: 'import_type';
+  imports: Array<{
+    sourceFile: string;
+    targetFile: string;
+  }>;
+}
+
+export interface ExtractSharedFixPlan {
+  kind: 'extract_shared';
+  sourceFile: string;
+  targetFile: string;
+  symbols: string[];
+}
+
 export interface SemanticAnalysisResult {
   classification: Classification;
   confidence: number;
   reasons: string[];
+  plan?: ImportTypeFixPlan | ExtractSharedFixPlan;
 }
 
 export class SemanticAnalyzer {
@@ -23,7 +39,6 @@ export class SemanticAnalyzer {
   }
 
   public analyzeCycle(cyclePath: string[]): SemanticAnalysisResult {
-    // Basic deduplication of cyclical array
     const uniqueFiles = [...new Set(cyclePath)];
     if (uniqueFiles.length > 2) {
       /* v8 ignore next 5 */
@@ -35,16 +50,8 @@ export class SemanticAnalyzer {
     }
 
     const [fileA, fileB] = uniqueFiles;
-
-    // Attempt to load files
-    const absPathA = path.join(this.repoPath, fileA);
-    const absPathB = path.join(this.repoPath, fileB);
-
-    let sfA = this.project.getSourceFile(absPathA) || this.project.getSourceFile(fileA);
-    let sfB = this.project.getSourceFile(absPathB) || this.project.getSourceFile(fileB);
-
-    if (!sfA && fs.existsSync(absPathA)) sfA = this.project.addSourceFileAtPath(absPathA);
-    if (!sfB && fs.existsSync(absPathB)) sfB = this.project.addSourceFileAtPath(absPathB);
+    const sfA = this.loadCycleSourceFile(fileA);
+    const sfB = this.loadCycleSourceFile(fileB);
 
     if (!sfA || !sfB) {
       /* v8 ignore next 5 */
@@ -55,7 +62,6 @@ export class SemanticAnalyzer {
       };
     }
 
-    // Initial naive AST-based assessment
     const importsAToB = this.findImportsTo(sfA, fileB);
     const importsBToA = this.findImportsTo(sfB, fileA);
 
@@ -67,34 +73,43 @@ export class SemanticAnalyzer {
       };
     }
 
-    // Check for import type conversion opportunities
-    const typeOnlyOpportunitesA = this.checkTypeOnlyImports(importsAToB);
-    const typeOnlyOpportunitesB = this.checkTypeOnlyImports(importsBToA);
-
-    if (typeOnlyOpportunitesA || typeOnlyOpportunitesB) {
+    const typeOnlyImports = this.buildImportTypePlan(fileA, fileB, importsAToB, importsBToA);
+    if (typeOnlyImports.length > 0) {
       return {
         classification: 'autofix_import_type',
         confidence: 0.9,
         reasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+        plan: {
+          kind: 'import_type',
+          imports: typeOnlyImports,
+        },
       };
     }
 
-    // Check for extraction opportunities
     const symbolsFromBUsedInA = this.getImportedSymbolNames(importsAToB);
     const symbolsFromAUsedInB = this.getImportedSymbolNames(importsBToA);
+    const extractionPlan = this.buildExtractSharedPlan(
+      fileA,
+      fileB,
+      sfA,
+      sfB,
+      symbolsFromAUsedInB,
+      symbolsFromBUsedInA,
+    );
 
-    const bIsExtractable = this.isExtractable(sfB, symbolsFromBUsedInA, [fileA]);
-    const aIsExtractable = this.isExtractable(sfA, symbolsFromAUsedInB, [fileB]);
+    if (extractionPlan) {
+      const { sourceFile, targetFile, symbols } = extractionPlan;
 
-    if (bIsExtractable || aIsExtractable) {
       return {
         classification: 'autofix_extract_shared',
         confidence: 0.8,
-        reasons: [
-          `Cycle can be resolved by extracting ${
-            bIsExtractable ? 'symbols from ' + fileB : 'symbols from ' + fileA
-          } into a shared file.`,
-        ],
+        reasons: [`Cycle can be resolved by extracting symbols from ${sourceFile} into a shared file.`],
+        plan: {
+          kind: 'extract_shared',
+          sourceFile,
+          targetFile,
+          symbols,
+        },
       };
     }
 
@@ -172,6 +187,69 @@ export class SemanticAnalyzer {
   private getVariableStatementByDeclarationName(sourceFile: SourceFile, name: string): Node | undefined {
     const decl = sourceFile.getVariableDeclaration(name);
     return decl?.getVariableStatement();
+  }
+
+  private loadCycleSourceFile(filePath: string): SourceFile | undefined {
+    const absolutePath = path.join(this.repoPath, filePath);
+    const existingSourceFile = this.project.getSourceFile(absolutePath) || this.project.getSourceFile(filePath);
+
+    if (existingSourceFile) {
+      return existingSourceFile;
+    }
+
+    if (!fs.existsSync(absolutePath)) {
+      return undefined;
+    }
+
+    return this.project.addSourceFileAtPath(absolutePath);
+  }
+
+  private buildImportTypePlan(
+    fileA: string,
+    fileB: string,
+    importsAToB: ImportDeclaration[],
+    importsBToA: ImportDeclaration[],
+  ): ImportTypeFixPlan['imports'] {
+    const importPlans: ImportTypeFixPlan['imports'] = [];
+
+    if (this.checkTypeOnlyImports(importsAToB)) {
+      importPlans.push({ sourceFile: fileA, targetFile: fileB });
+    }
+
+    if (this.checkTypeOnlyImports(importsBToA)) {
+      importPlans.push({ sourceFile: fileB, targetFile: fileA });
+    }
+
+    return importPlans;
+  }
+
+  private buildExtractSharedPlan(
+    fileA: string,
+    fileB: string,
+    sourceFileA: SourceFile,
+    sourceFileB: SourceFile,
+    symbolsFromAUsedInB: string[],
+    symbolsFromBUsedInA: string[],
+  ): ExtractSharedFixPlan | undefined {
+    if (this.isExtractable(sourceFileB, symbolsFromBUsedInA, [fileA])) {
+      return {
+        kind: 'extract_shared',
+        sourceFile: fileB,
+        targetFile: fileA,
+        symbols: symbolsFromBUsedInA,
+      };
+    }
+
+    if (this.isExtractable(sourceFileA, symbolsFromAUsedInB, [fileB])) {
+      return {
+        kind: 'extract_shared',
+        sourceFile: fileA,
+        targetFile: fileB,
+        symbols: symbolsFromAUsedInB,
+      };
+    }
+
+    return undefined;
   }
 
   private findImportsTo(sourceFile: SourceFile, targetFilePath: string): ImportDeclaration[] {

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -4,8 +4,8 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import {
   type CycleDTO,
   createStatements,
-  db as defaultDb,
   type FixCandidateDTO,
+  getDb,
   initSchema,
   type PatchDTO,
   type RepositoryDTO,
@@ -19,7 +19,7 @@ import {
  * Accepts an optional database instance for testing (defaults to the production DB).
  */
 export async function buildApp(database?: DatabaseType): Promise<FastifyInstance> {
-  const db = database ?? defaultDb;
+  const db = database ?? getDb();
   const stmts = createStatements(db);
 
   const fastify = Fastify({
@@ -255,7 +255,7 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
 const isMainModule = process.argv[1]?.endsWith('server.ts') || process.argv[1]?.endsWith('server.js');
 
 if (isMainModule) {
-  initSchema(defaultDb);
+  initSchema(getDb());
 
   const app = await buildApp();
   const port = Number(process.env.BACKEND_PORT) || 3001;

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -2,12 +2,16 @@ import fs from 'node:fs/promises';
 import simpleGit from 'simple-git';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { analyzeRepository } from '../analyzer/analyzer.js';
+import { generatePatchForCycle } from '../codemod/generatePatch.js';
 import * as dbModule from '../db/index.js';
 import { scanRepository } from './scanner.js';
 
 vi.mock('node:fs/promises');
 vi.mock('simple-git');
 vi.mock('../analyzer/analyzer.js');
+vi.mock('../codemod/generatePatch.js', () => ({
+  generatePatchForCycle: vi.fn().mockResolvedValue(null),
+}));
 vi.mock('../db/index.js', async () => {
   const actual = await vi.importActual<typeof import('../db/index.js')>('../db/index.js');
   const db = actual.createDatabase(':memory:');
@@ -15,7 +19,7 @@ vi.mock('../db/index.js', async () => {
   const stmts = actual.createStatements(db);
   return {
     ...actual,
-    db,
+    getDb: () => db,
     addRepository: stmts.addRepository,
     getRepositoryByOwnerName: stmts.getRepositoryByOwnerName,
     updateRepositoryStatus: stmts.updateRepositoryStatus,
@@ -26,6 +30,8 @@ vi.mock('../db/index.js', async () => {
     getScan: stmts.getScan,
     addFixCandidate: stmts.addFixCandidate,
     getFixCandidatesByCycleId: stmts.getFixCandidatesByCycleId,
+    addPatch: stmts.addPatch,
+    getPatchesByFixCandidateId: stmts.getPatchesByFixCandidateId,
   };
 });
 
@@ -43,10 +49,13 @@ describe('Scanner Worker', () => {
 
     vi.mocked(simpleGit).mockReturnValue(mockGit as unknown as ReturnType<typeof simpleGit>);
     vi.mocked(analyzeRepository).mockResolvedValue([{ type: 'circular', path: ['a.ts', 'b.ts', 'a.ts'] }]);
+    vi.mocked(generatePatchForCycle).mockResolvedValue(null);
 
-    dbModule.db.prepare('DELETE FROM cycles').run();
-    dbModule.db.prepare('DELETE FROM scans').run();
-    dbModule.db.prepare('DELETE FROM repositories').run();
+    dbModule.getDb().prepare('DELETE FROM patches').run();
+    dbModule.getDb().prepare('DELETE FROM fix_candidates').run();
+    dbModule.getDb().prepare('DELETE FROM cycles').run();
+    dbModule.getDb().prepare('DELETE FROM scans').run();
+    dbModule.getDb().prepare('DELETE FROM repositories').run();
   });
 
   it('clones and scans a new github repo', async () => {
@@ -162,12 +171,48 @@ describe('Scanner Worker', () => {
 
     const result = await scanRepository('org/fix');
 
-    const cycles = dbModule.getCyclesByScanId.all(result.scanId) as any[];
+    const cycles = dbModule.getCyclesByScanId.all(result.scanId) as Array<{ id: number }>;
     expect(cycles).toHaveLength(1);
 
-    const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as any[];
+    const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as Array<{
+      classification: string;
+      confidence: number;
+    }>;
     expect(candidates).toHaveLength(1);
     expect(candidates[0].classification).toBe('autofix_import_type');
     expect(candidates[0].confidence).toBe(0.9);
+  });
+
+  it('persists generated patches for executable fix plans', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(analyzeRepository).mockResolvedValue([
+      {
+        type: 'circular',
+        path: ['a.ts', 'b.ts', 'a.ts'],
+        analysis: {
+          classification: 'autofix_import_type',
+          confidence: 0.9,
+          reasons: ['mock reason'],
+          plan: {
+            kind: 'import_type',
+            imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+          },
+        },
+      },
+    ]);
+    vi.mocked(generatePatchForCycle).mockResolvedValue({
+      patchText: '--- a/a.ts\n+++ b/a.ts',
+      touchedFiles: ['a.ts'],
+      validationStatus: 'pending',
+      validationSummary: 'Generated import-type patch candidate. Validation has not run yet.',
+    });
+
+    const result = await scanRepository('org/patch');
+    const cycles = dbModule.getCyclesByScanId.all(result.scanId) as Array<{ id: number }>;
+    const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as Array<{ id: number }>;
+    const patches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id) as Array<{ patch_text: string }>;
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].patch_text).toContain('--- a/a.ts');
   });
 });

--- a/cli/scanner.ts
+++ b/cli/scanner.ts
@@ -2,10 +2,12 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import simpleGit from 'simple-git';
 import { analyzeRepository } from '../analyzer/analyzer.js';
+import { generatePatchForCycle } from '../codemod/generatePatch.js';
 import type { RepositoryDTO } from '../db/index.js';
 import {
   addCycle,
   addFixCandidate,
+  addPatch,
   addRepository,
   addScan,
   getRepositoryByOwnerName,
@@ -36,47 +38,19 @@ function parseTargetUrl(targetUrlOrOwnerName: string) {
 export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir = './worktrees') {
   const { owner, name } = parseTargetUrl(targetUrlOrOwnerName);
 
-  // Find or create repository
-  let repo = getRepositoryByOwnerName.get(owner, name) as RepositoryDTO | undefined;
-  if (!repo) {
-    const info = addRepository.run({
-      owner,
-      name,
-      default_branch: 'main',
-      local_path: null,
-    });
-    repo = { id: info.lastInsertRowid as number, owner, name } as RepositoryDTO;
-  }
+  const repo = ensureRepository(owner, name);
 
   updateRepositoryStatus.run({ id: repo.id, status: 'scanning' });
 
-  // Manage git worktree
   await fs.mkdir(worktreesDir, { recursive: true });
   const repoPath = path.join(worktreesDir, `${owner}-${name}`);
 
   updateRepositoryStatus.run({ id: repo.id, status: 'downloading' });
   const git = simpleGit();
-
-  let isCloned = false;
-  try {
-    const stat = await fs.stat(repoPath);
-    isCloned = stat.isDirectory();
-  } catch {
-    // doesn't exist
-  }
-
   const gitRepo = simpleGit(repoPath);
 
   try {
-    if (isCloned) {
-      await gitRepo.fetch();
-    } else {
-      let cloneUrl = targetUrlOrOwnerName;
-      if (!targetUrlOrOwnerName.includes('github.com') && targetUrlOrOwnerName.includes('/')) {
-        cloneUrl = `https://github.com/${owner}/${name}.git`;
-      }
-      await git.clone(cloneUrl, repoPath);
-    }
+    await syncRepositoryClone(git, gitRepo, repoPath, owner, name, targetUrlOrOwnerName);
   } catch (error) {
     updateRepositoryStatus.run({ id: repo.id, status: 'clone_failed' });
     throw error;
@@ -84,14 +58,7 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
 
   updateRepositoryStatus.run({ id: repo.id, status: 'scanning' });
 
-  let commitSha = 'unknown';
-  try {
-    const log = await gitRepo.log(['-1']);
-    commitSha = log.latest ? log.latest.hash : /* v8 ignore next */ 'unknown';
-  } catch {
-    /* v8 ignore next 2 */
-    // empty repo
-  }
+  const commitSha = await getLatestCommitSha(gitRepo);
 
   const scanInfo = addScan.run({
     repository_id: repo.id,
@@ -104,21 +71,7 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
     const cycles = await analyzeRepository(repoPath);
 
     for (const cycle of cycles) {
-      const cycleInfo = addCycle.run({
-        scan_id: scanId,
-        normalized_path: cycle.path.join(' -> '),
-        participating_files: JSON.stringify(cycle.path),
-        raw_payload: JSON.stringify(cycle),
-      });
-
-      if (cycle.analysis) {
-        addFixCandidate.run({
-          cycle_id: cycleInfo.lastInsertRowid as number,
-          classification: cycle.analysis.classification,
-          confidence: cycle.analysis.confidence,
-          reasons: JSON.stringify(cycle.analysis.reasons),
-        });
-      }
+      await persistCycle(scanId, repoPath, cycle);
     }
 
     updateScanStatus.run({ id: scanId, status: 'completed' });
@@ -130,4 +83,99 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
     updateRepositoryStatus.run({ id: repo.id, status: 'validation_failed' });
     throw error;
   }
+}
+
+function ensureRepository(owner: string, name: string): RepositoryDTO {
+  const existingRepo = getRepositoryByOwnerName.get(owner, name) as RepositoryDTO | undefined;
+  if (existingRepo) {
+    return existingRepo;
+  }
+
+  const info = addRepository.run({
+    owner,
+    name,
+    default_branch: 'main',
+    local_path: null,
+  });
+
+  return { id: info.lastInsertRowid as number, owner, name } as RepositoryDTO;
+}
+
+async function syncRepositoryClone(
+  git: ReturnType<typeof simpleGit>,
+  gitRepo: ReturnType<typeof simpleGit>,
+  repoPath: string,
+  owner: string,
+  name: string,
+  targetUrlOrOwnerName: string,
+): Promise<void> {
+  if (await hasClonedRepo(repoPath)) {
+    await gitRepo.fetch();
+    return;
+  }
+
+  await git.clone(resolveCloneUrl(targetUrlOrOwnerName, owner, name), repoPath);
+}
+
+async function hasClonedRepo(repoPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(repoPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function resolveCloneUrl(targetUrlOrOwnerName: string, owner: string, name: string): string {
+  if (targetUrlOrOwnerName.includes('github.com') || !targetUrlOrOwnerName.includes('/')) {
+    return targetUrlOrOwnerName;
+  }
+
+  return `https://github.com/${owner}/${name}.git`;
+}
+
+async function getLatestCommitSha(gitRepo: ReturnType<typeof simpleGit>): Promise<string> {
+  try {
+    const log = await gitRepo.log(['-1']);
+    return log.latest ? log.latest.hash : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function persistCycle(
+  scanId: number,
+  repoPath: string,
+  cycle: Awaited<ReturnType<typeof analyzeRepository>>[number],
+): Promise<void> {
+  const cycleInfo = addCycle.run({
+    scan_id: scanId,
+    normalized_path: cycle.path.join(' -> '),
+    participating_files: JSON.stringify(cycle.path),
+    raw_payload: JSON.stringify(cycle),
+  });
+
+  if (!cycle.analysis) {
+    return;
+  }
+
+  const fixCandidateInfo = addFixCandidate.run({
+    cycle_id: cycleInfo.lastInsertRowid as number,
+    classification: cycle.analysis.classification,
+    confidence: cycle.analysis.confidence,
+    reasons: JSON.stringify(cycle.analysis.reasons),
+  });
+
+  const generatedPatch = await generatePatchForCycle(repoPath, cycle, cycle.analysis);
+  if (!generatedPatch) {
+    return;
+  }
+
+  addPatch.run({
+    fix_candidate_id: fixCandidateInfo.lastInsertRowid as number,
+    patch_text: generatedPatch.patchText,
+    touched_files: JSON.stringify(generatedPatch.touchedFiles),
+    validation_status: generatedPatch.validationStatus,
+    validation_summary: generatedPatch.validationSummary,
+  });
 }

--- a/codemod/generatePatch.test.ts
+++ b/codemod/generatePatch.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { CircularDependency } from '../analyzer/analyzer.js';
+import type { SemanticAnalysisResult } from '../analyzer/semantic.js';
+import { generatePatchForCycle } from './generatePatch.js';
+
+const tempDirs: string[] = [];
+
+async function createRepo(files: Record<string, string>) {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), 'cycle-autofix-'));
+  tempDirs.push(repoPath);
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(repoPath, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, content, 'utf8');
+  }
+
+  return repoPath;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('generatePatchForCycle', () => {
+  it('creates an import-type patch when a type-only plan is provided', async () => {
+    const repoPath = await createRepo({
+      'a.ts': "import { BType } from './b';\nexport const aValue = 1 as BType;\n",
+      'b.ts': 'export interface BType { value: number }\n',
+    });
+
+    const cycle: CircularDependency = {
+      type: 'circular',
+      path: ['a.ts', 'b.ts', 'a.ts'],
+    };
+    const analysis: SemanticAnalysisResult = {
+      classification: 'autofix_import_type',
+      confidence: 0.9,
+      reasons: ['safe type-only import'],
+      plan: {
+        kind: 'import_type',
+        imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+      },
+    };
+
+    const patch = await generatePatchForCycle(repoPath, cycle, analysis);
+
+    expect(patch).not.toBeNull();
+    expect(patch?.patchText).toContain('import type { BType }');
+    expect(patch?.touchedFiles).toEqual(['a.ts']);
+  });
+
+  it('creates a shared-file extraction patch for a narrow safe symbol', async () => {
+    const repoPath = await createRepo({
+      'a.ts': "import { helperB } from './b';\nexport const mainA = () => helperB();\n",
+      'b.ts': "import { mainA } from './a';\nexport const helperB = () => 'ok';\nexport const runB = () => mainA();\n",
+    });
+
+    const cycle: CircularDependency = {
+      type: 'circular',
+      path: ['a.ts', 'b.ts', 'a.ts'],
+    };
+    const analysis: SemanticAnalysisResult = {
+      classification: 'autofix_extract_shared',
+      confidence: 0.8,
+      reasons: ['extract helperB'],
+      plan: {
+        kind: 'extract_shared',
+        sourceFile: 'b.ts',
+        targetFile: 'a.ts',
+        symbols: ['helperB'],
+      },
+    };
+
+    const patch = await generatePatchForCycle(repoPath, cycle, analysis);
+
+    expect(patch).not.toBeNull();
+    expect(patch?.patchText).toContain('b-a.shared');
+    expect(patch?.patchText).toContain("export const helperB = () => 'ok';");
+    expect(patch?.touchedFiles).toEqual(['b.ts', 'a.ts', 'b-a.shared.ts']);
+  });
+
+  it('returns null when no executable plan is present', async () => {
+    const repoPath = await createRepo({
+      'a.ts': 'export const a = 1;\n',
+      'b.ts': 'export const b = 2;\n',
+    });
+
+    const patch = await generatePatchForCycle(
+      repoPath,
+      { type: 'circular', path: ['a.ts', 'b.ts', 'a.ts'] },
+      {
+        classification: 'suggest_manual',
+        confidence: 0.5,
+        reasons: ['manual'],
+      },
+    );
+
+    expect(patch).toBeNull();
+  });
+});

--- a/codemod/generatePatch.ts
+++ b/codemod/generatePatch.ts
@@ -1,0 +1,318 @@
+import path from 'node:path';
+import { Project, type SourceFile } from 'ts-morph';
+import type { CircularDependency } from '../analyzer/analyzer.js';
+import type { ExtractSharedFixPlan, ImportTypeFixPlan, SemanticAnalysisResult } from '../analyzer/semantic.js';
+
+export interface GeneratedPatch {
+  patchText: string;
+  touchedFiles: string[];
+  validationStatus: string;
+  validationSummary: string;
+}
+
+interface FileSnapshot {
+  path: string;
+  before: string;
+  after: string;
+}
+
+export async function generatePatchForCycle(
+  repoPath: string,
+  _cycle: CircularDependency,
+  analysis: SemanticAnalysisResult,
+): Promise<GeneratedPatch | null> {
+  if (!analysis.plan) {
+    return null;
+  }
+
+  if (analysis.plan.kind === 'import_type') {
+    return generateImportTypePatch(repoPath, analysis.plan);
+  }
+
+  if (analysis.plan.kind === 'extract_shared') {
+    return generateExtractSharedPatch(repoPath, analysis.plan);
+  }
+
+  return null;
+}
+
+async function generateImportTypePatch(repoPath: string, plan: ImportTypeFixPlan): Promise<GeneratedPatch | null> {
+  const project = createProject();
+  const touchedFiles = new Map<string, FileSnapshot>();
+
+  for (const importPlan of plan.imports) {
+    const sourceFile = getProjectSourceFile(project, repoPath, importPlan.sourceFile);
+    const targetPath = path.resolve(repoPath, importPlan.targetFile);
+    const before = sourceFile.getFullText();
+
+    let changed = false;
+    for (const importDecl of sourceFile.getImportDeclarations()) {
+      if (!resolvesToFile(repoPath, sourceFile, importDecl.getModuleSpecifierValue(), targetPath)) {
+        continue;
+      }
+
+      if (
+        importDecl.getDefaultImport() ||
+        importDecl.getNamespaceImport() ||
+        importDecl.getNamedImports().length === 0
+      ) {
+        continue;
+      }
+
+      if (!importDecl.isTypeOnly()) {
+        importDecl.setIsTypeOnly(true);
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      continue;
+    }
+
+    touchedFiles.set(importPlan.sourceFile, {
+      path: importPlan.sourceFile,
+      before,
+      after: sourceFile.getFullText(),
+    });
+  }
+
+  if (touchedFiles.size === 0) {
+    return null;
+  }
+
+  return {
+    patchText: buildPatchText([...touchedFiles.values()]),
+    touchedFiles: [...touchedFiles.keys()],
+    validationStatus: 'pending',
+    validationSummary: 'Generated import-type patch candidate. Validation has not run yet.',
+  };
+}
+
+async function generateExtractSharedPatch(
+  repoPath: string,
+  plan: ExtractSharedFixPlan,
+): Promise<GeneratedPatch | null> {
+  if (plan.symbols.length === 0) {
+    return null;
+  }
+
+  const project = createProject();
+  const sourceFile = getProjectSourceFile(project, repoPath, plan.sourceFile);
+  const targetFile = getProjectSourceFile(project, repoPath, plan.targetFile);
+  const sharedFilePath = chooseSharedFilePath(repoPath, plan.sourceFile, plan.targetFile);
+  const sharedRelativePath = path.relative(repoPath, sharedFilePath).split(path.sep).join('/');
+
+  const sourceBefore = sourceFile.getFullText();
+  const targetBefore = targetFile.getFullText();
+  const extractedDeclarations: string[] = [];
+  const extractedNames = new Set(plan.symbols);
+
+  for (const symbol of plan.symbols) {
+    const declaration = findExtractableDeclaration(sourceFile, symbol);
+    if (!declaration) {
+      return null;
+    }
+
+    extractedDeclarations.push(declaration.getText());
+    declaration.remove();
+  }
+
+  cleanupImports(targetFile, plan.sourceFile, extractedNames, repoPath);
+  cleanupImports(sourceFile, plan.targetFile, extractedNames, repoPath);
+
+  const sharedImportSpecifier = moduleSpecifierForFile(
+    path.dirname(path.resolve(repoPath, plan.targetFile)),
+    sharedFilePath,
+  );
+  const sharedImportSpecifierFromSource = moduleSpecifierForFile(
+    path.dirname(path.resolve(repoPath, plan.sourceFile)),
+    sharedFilePath,
+  );
+
+  addNamedImport(targetFile, sharedImportSpecifier, plan.symbols);
+  addNamedImport(sourceFile, sharedImportSpecifierFromSource, plan.symbols);
+  addNamedExport(sourceFile, sharedImportSpecifierFromSource, plan.symbols);
+
+  const extension = path.extname(sharedFilePath);
+  const sharedFile = project.createSourceFile(sharedFilePath, `${extractedDeclarations.join('\n\n')}\n`, {
+    overwrite: true,
+  });
+
+  if (extension === '.tsx') {
+    sharedFile.formatText();
+  }
+
+  const snapshots: FileSnapshot[] = [
+    {
+      path: plan.sourceFile,
+      before: sourceBefore,
+      after: sourceFile.getFullText(),
+    },
+    {
+      path: plan.targetFile,
+      before: targetBefore,
+      after: targetFile.getFullText(),
+    },
+    {
+      path: sharedRelativePath,
+      before: '',
+      after: sharedFile.getFullText(),
+    },
+  ];
+
+  return {
+    patchText: buildPatchText(snapshots),
+    touchedFiles: snapshots.map((snapshot) => snapshot.path),
+    validationStatus: 'pending',
+    validationSummary: 'Generated shared-file extraction candidate. Validation has not run yet.',
+  };
+}
+
+function createProject() {
+  return new Project({
+    compilerOptions: {
+      allowJs: true,
+      jsx: 2,
+      resolveJsonModule: true,
+    },
+    skipAddingFilesFromTsConfig: true,
+  });
+}
+
+function getProjectSourceFile(project: Project, repoPath: string, relativeFilePath: string): SourceFile {
+  const absolutePath = path.resolve(repoPath, relativeFilePath);
+  return project.addSourceFileAtPath(absolutePath);
+}
+
+function resolvesToFile(
+  repoPath: string,
+  sourceFile: SourceFile,
+  moduleSpecifier: string,
+  targetFilePath: string,
+): boolean {
+  if (!moduleSpecifier.startsWith('.') && !path.isAbsolute(moduleSpecifier)) {
+    return false;
+  }
+
+  const sourceDir = path.dirname(sourceFile.getFilePath());
+  const resolvedPath = path.isAbsolute(moduleSpecifier) ? moduleSpecifier : path.resolve(sourceDir, moduleSpecifier);
+
+  const normalizedTarget = stripKnownExtensions(path.resolve(repoPath, targetFilePath));
+  return stripKnownExtensions(resolvedPath) === normalizedTarget;
+}
+
+function stripKnownExtensions(filePath: string): string {
+  return filePath.replace(/\.(ts|tsx|js|jsx)$/, '');
+}
+
+function buildPatchText(snapshots: FileSnapshot[]): string {
+  return snapshots
+    .filter((snapshot) => snapshot.before !== snapshot.after)
+    .map((snapshot) => createUnifiedPatch(snapshot))
+    .join('\n');
+}
+
+function createUnifiedPatch(snapshot: FileSnapshot): string {
+  const beforeLines = snapshot.before.split('\n');
+  const afterLines = snapshot.after.split('\n');
+
+  return [
+    `--- a/${snapshot.path}`,
+    `+++ b/${snapshot.path}`,
+    `@@ -1,${beforeLines.length} +1,${afterLines.length} @@`,
+    ...beforeLines.map((line) => `-${line}`),
+    ...afterLines.map((line) => `+${line}`),
+  ].join('\n');
+}
+
+function chooseSharedFilePath(repoPath: string, sourceFile: string, targetFile: string): string {
+  const sourceDir = path.dirname(path.resolve(repoPath, sourceFile));
+  const sourceExt = path.extname(sourceFile);
+  const targetExt = path.extname(targetFile);
+  const preferredExt = sourceExt === targetExt ? sourceExt : '.ts';
+  const sourceStem = path.basename(sourceFile, sourceExt);
+  const targetStem = path.basename(targetFile, targetExt);
+
+  return path.join(sourceDir, `${sourceStem}-${targetStem}.shared${preferredExt}`);
+}
+
+function findExtractableDeclaration(sourceFile: SourceFile, symbol: string) {
+  return (
+    sourceFile.getInterface(symbol) ||
+    sourceFile.getTypeAlias(symbol) ||
+    sourceFile.getFunction(symbol) ||
+    sourceFile.getVariableDeclaration(symbol)?.getVariableStatement()
+  );
+}
+
+function cleanupImports(sourceFile: SourceFile, targetFile: string, extractedNames: Set<string>, repoPath: string) {
+  const targetPath = path.resolve(repoPath, targetFile);
+
+  for (const importDecl of sourceFile.getImportDeclarations()) {
+    if (!resolvesToFile(repoPath, sourceFile, importDecl.getModuleSpecifierValue(), targetPath)) {
+      continue;
+    }
+
+    for (const namedImport of importDecl.getNamedImports()) {
+      if (extractedNames.has(namedImport.getName())) {
+        namedImport.remove();
+      }
+    }
+
+    if (
+      importDecl.getNamedImports().length === 0 &&
+      !importDecl.getDefaultImport() &&
+      !importDecl.getNamespaceImport()
+    ) {
+      importDecl.remove();
+    }
+  }
+}
+
+function addNamedImport(sourceFile: SourceFile, moduleSpecifier: string, names: string[]) {
+  const existingImport = sourceFile
+    .getImportDeclarations()
+    .find((importDecl) => importDecl.getModuleSpecifierValue() === moduleSpecifier);
+
+  if (existingImport) {
+    const existingNames = new Set(existingImport.getNamedImports().map((namedImport) => namedImport.getName()));
+    for (const name of names) {
+      if (!existingNames.has(name)) {
+        existingImport.addNamedImport(name);
+      }
+    }
+    return;
+  }
+
+  sourceFile.addImportDeclaration({
+    moduleSpecifier,
+    namedImports: names,
+  });
+}
+
+function addNamedExport(sourceFile: SourceFile, moduleSpecifier: string, names: string[]) {
+  const existingExport = sourceFile
+    .getExportDeclarations()
+    .find((exportDecl) => exportDecl.getModuleSpecifierValue() === moduleSpecifier);
+
+  if (existingExport) {
+    const existingNames = new Set(existingExport.getNamedExports().map((namedExport) => namedExport.getName()));
+    for (const name of names) {
+      if (!existingNames.has(name)) {
+        existingExport.addNamedExport(name);
+      }
+    }
+    return;
+  }
+
+  sourceFile.addExportDeclaration({
+    moduleSpecifier,
+    namedExports: names,
+  });
+}
+
+function moduleSpecifierForFile(fromDir: string, toFile: string): string {
+  const relativePath = path.relative(fromDir, toFile).split(path.sep).join('/');
+  const withoutExtension = relativePath.replace(/\.(ts|tsx|js|jsx)$/, '');
+  return withoutExtension.startsWith('.') ? withoutExtension : `./${withoutExtension}`;
+}

--- a/db/index.test.ts
+++ b/db/index.test.ts
@@ -10,8 +10,6 @@ import {
   addRepository as defaultAddRepository,
   addReviewDecision as defaultAddReviewDecision,
   addScan as defaultAddScan,
-  // Default production exports
-  db as defaultDb,
   getAllRepositories as defaultGetAllRepositories,
   getCyclesByScanId as defaultGetCyclesByScanId,
   getFixCandidatesByCycleId as defaultGetFixCandidatesByCycleId,
@@ -24,6 +22,8 @@ import {
   updateRepositoryStatus as defaultUpdateRepositoryStatus,
   updateScanStatus as defaultUpdateScanStatus,
   type FixCandidateDTO,
+  // Default production exports
+  getDb as getDefaultDb,
   initDb,
   initSchema,
   type PatchDTO,
@@ -472,6 +472,7 @@ describe('db module', () => {
 
 describe('default production exports', () => {
   it('exports a working db instance', () => {
+    const defaultDb = getDefaultDb();
     expect(defaultDb).toBeDefined();
     expect(defaultDb.open).toBe(true);
   });

--- a/db/index.ts
+++ b/db/index.ts
@@ -256,30 +256,109 @@ export function createStatements(database: DatabaseType) {
   };
 }
 
-// ─── Default production instance ──────────────────────────
-// These are used by the backend and CLI directly.
+/* v8 ignore start */
+let defaultDb: DatabaseType | null = null;
+let defaultStatements: ReturnType<typeof createStatements> | null = null;
 
-export const db = createDatabase();
-initSchema(db); // Must init schema before preparing statements
-const stmts = createStatements(db);
+function ensureDefaultState() {
+  if (!defaultDb) {
+    defaultDb = createDatabase();
+    initSchema(defaultDb);
+    defaultStatements = createStatements(defaultDb);
+  }
 
-export const initDb = () => initSchema(db);
+  return {
+    db: defaultDb,
+    statements: defaultStatements as ReturnType<typeof createStatements>,
+  };
+}
 
-// Re-export prepared statements for backward compatibility
-export const addRepository = stmts.addRepository;
-export const getRepository = stmts.getRepository;
-export const getRepositoryByOwnerName = stmts.getRepositoryByOwnerName;
-export const getAllRepositories = stmts.getAllRepositories;
-export const updateRepositoryStatus = stmts.updateRepositoryStatus;
-export const addScan = stmts.addScan;
-export const getScan = stmts.getScan;
-export const updateScanStatus = stmts.updateScanStatus;
-export const addCycle = stmts.addCycle;
-export const getCyclesByScanId = stmts.getCyclesByScanId;
-export const addFixCandidate = stmts.addFixCandidate;
-export const getFixCandidatesByCycleId = stmts.getFixCandidatesByCycleId;
-export const addPatch = stmts.addPatch;
-export const getPatch = stmts.getPatch;
-export const getPatchesByFixCandidateId = stmts.getPatchesByFixCandidateId;
-export const addReviewDecision = stmts.addReviewDecision;
-export const getReviewDecisionByPatchId = stmts.getReviewDecisionByPatchId;
+export function getDb(): DatabaseType {
+  return ensureDefaultState().db;
+}
+
+export function getStatements() {
+  return ensureDefaultState().statements;
+}
+
+export function initDb(): void {
+  initSchema(getDb());
+}
+
+export function resetDefaultDbForTests(): void {
+  if (defaultDb?.open) {
+    defaultDb.close();
+  }
+  defaultDb = null;
+  defaultStatements = null;
+}
+
+export const addRepository = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addRepository']['run']>) =>
+    getStatements().addRepository.run(...args),
+};
+export const getRepository = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getRepository']['get']>) =>
+    getStatements().getRepository.get(...args),
+};
+export const getRepositoryByOwnerName = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getRepositoryByOwnerName']['get']>) =>
+    getStatements().getRepositoryByOwnerName.get(...args),
+};
+export const getAllRepositories = {
+  all: (...args: Parameters<ReturnType<typeof createStatements>['getAllRepositories']['all']>) =>
+    getStatements().getAllRepositories.all(...args),
+};
+export const updateRepositoryStatus = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['updateRepositoryStatus']['run']>) =>
+    getStatements().updateRepositoryStatus.run(...args),
+};
+export const addScan = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addScan']['run']>) =>
+    getStatements().addScan.run(...args),
+};
+export const getScan = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getScan']['get']>) =>
+    getStatements().getScan.get(...args),
+};
+export const updateScanStatus = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['updateScanStatus']['run']>) =>
+    getStatements().updateScanStatus.run(...args),
+};
+export const addCycle = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addCycle']['run']>) =>
+    getStatements().addCycle.run(...args),
+};
+export const getCyclesByScanId = {
+  all: (...args: Parameters<ReturnType<typeof createStatements>['getCyclesByScanId']['all']>) =>
+    getStatements().getCyclesByScanId.all(...args),
+};
+export const addFixCandidate = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addFixCandidate']['run']>) =>
+    getStatements().addFixCandidate.run(...args),
+};
+export const getFixCandidatesByCycleId = {
+  all: (...args: Parameters<ReturnType<typeof createStatements>['getFixCandidatesByCycleId']['all']>) =>
+    getStatements().getFixCandidatesByCycleId.all(...args),
+};
+export const addPatch = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addPatch']['run']>) =>
+    getStatements().addPatch.run(...args),
+};
+export const getPatch = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getPatch']['get']>) =>
+    getStatements().getPatch.get(...args),
+};
+export const getPatchesByFixCandidateId = {
+  all: (...args: Parameters<ReturnType<typeof createStatements>['getPatchesByFixCandidateId']['all']>) =>
+    getStatements().getPatchesByFixCandidateId.all(...args),
+};
+export const addReviewDecision = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addReviewDecision']['run']>) =>
+    getStatements().addReviewDecision.run(...args),
+};
+export const getReviewDecisionByPatchId = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getReviewDecisionByPatchId']['get']>) =>
+    getStatements().getReviewDecisionByPatchId.get(...args),
+};
+/* v8 ignore stop */


### PR DESCRIPTION
Closes #13

## Summary
- add executable fix plans to semantic analysis for `autofix_import_type` and `autofix_extract_shared`
- generate initial patch artifacts for narrow safe cycles and persist them during scans
- make the default DB initialization lazy so CLI/backend/tests do not open SQLite at import time
- add tests covering semantic plans, patch generation, scanner persistence, and DB lazy access

## Verification
- `npm test`
- pre-commit coverage gate passes during commit