### PR TITLE
Add findings queue filters and patch export

### DIFF
--- a/backend/server.test.ts
+++ b/backend/server.test.ts
@@ -246,6 +246,90 @@ describe('backend API', () => {
       expect(findings[0].cycle_path).toEqual(['a.ts', 'b.ts']);
     });
 
+    it('GET /api/findings filters by repository, classification, validation, review, cycle size, and search', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'acme',
+        name: 'widget',
+        default_branch: null,
+        local_path: null,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'queue1',
+        status: 'completed',
+      });
+      const matchingCycle = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        participating_files: JSON.stringify(['a.ts', 'b.ts']),
+        raw_payload: null,
+      });
+      const matchingCandidate = stmts.addFixCandidate.run({
+        cycle_id: matchingCycle.lastInsertRowid,
+        classification: 'autofix_extract_shared',
+        confidence: 0.98,
+        reasons: JSON.stringify(['safe top-level function']),
+      });
+      const matchingPatch = stmts.addPatch.run({
+        fix_candidate_id: matchingCandidate.lastInsertRowid,
+        patch_text: '--- a.ts\n+++ b.ts',
+        touched_files: JSON.stringify(['a.ts', 'b.ts']),
+        validation_status: 'passed',
+        validation_summary: 'Validation passed.',
+      });
+      stmts.addReviewDecision.run({
+        patch_id: matchingPatch.lastInsertRowid,
+        decision: 'approved',
+        notes: 'Ship it',
+      });
+
+      stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'x.ts -> y.ts -> x.ts',
+        participating_files: JSON.stringify(['x.ts', 'y.ts', 'x.ts']),
+        raw_payload: null,
+      });
+      const otherCycle = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'm.ts -> n.ts -> m.ts',
+        participating_files: JSON.stringify(['m.ts', 'n.ts', 'm.ts']),
+        raw_payload: null,
+      });
+      const otherCandidate = stmts.addFixCandidate.run({
+        cycle_id: otherCycle.lastInsertRowid,
+        classification: 'autofix_import_type',
+        confidence: 0.74,
+        reasons: null,
+      });
+      const otherPatch = stmts.addPatch.run({
+        fix_candidate_id: otherCandidate.lastInsertRowid,
+        patch_text: 'other diff',
+        touched_files: JSON.stringify(['m.ts', 'n.ts']),
+        validation_status: 'failed',
+        validation_summary: 'TypeScript check failed.',
+      });
+      stmts.addReviewDecision.run({
+        patch_id: otherPatch.lastInsertRowid,
+        decision: 'pr_candidate',
+        notes: null,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/findings?repository_id=${repoInfo.lastInsertRowid}&classification=autofix_extract_shared&validation_status=passed&review_status=approved&cycle_size=2&search=acme/widget`,
+      });
+      expect(response.statusCode).toBe(200);
+      const findings = response.json();
+      expect(findings).toHaveLength(1);
+      expect(findings[0].repository_id).toBe(repoInfo.lastInsertRowid);
+      expect(findings[0].classification).toBe('autofix_extract_shared');
+      expect(findings[0].validation_status).toBe('passed');
+      expect(findings[0].review_status).toBe('approved');
+      expect(findings[0].cycle_size).toBe(2);
+      expect(findings[0].cycle_path).toEqual(['a.ts', 'b.ts']);
+    });
+
     it('GET /api/repositories/:id/findings filters by status', async () => {
       const stmts = createStatements(testDb);
       const repoInfo = stmts.addRepository.run({
@@ -354,6 +438,7 @@ describe('backend API', () => {
       expect(detail.confidence).toBe(0.85);
       expect(detail.reasons).toEqual(['type-only import']);
       expect(detail.patch).toContain('--- a/p.ts');
+      expect(detail.patch_id).toBeDefined();
       expect(detail.review_status).toBe('approved');
     });
 
@@ -544,6 +629,61 @@ describe('backend API', () => {
       });
       expect(response.statusCode).toBe(201);
       expect(response.json().decision).toBe('rejected');
+    });
+
+    it('POST /api/patches/:patchId/review updates the latest review decision', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'rev-update',
+        name: 'repo',
+        default_branch: null,
+        local_path: null,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'rev3',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'u->v',
+        participating_files: '[]',
+        raw_payload: null,
+      });
+      const fcInfo = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        classification: 'autofix_extract_shared',
+        confidence: 0.9,
+        reasons: null,
+      });
+      const patchInfo = stmts.addPatch.run({
+        fix_candidate_id: fcInfo.lastInsertRowid,
+        patch_text: 'diff',
+        touched_files: '[]',
+        validation_status: 'passed',
+        validation_summary: null,
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: `/api/patches/${patchInfo.lastInsertRowid}/review`,
+        payload: { decision: 'approved' },
+      });
+
+      const updateResponse = await app.inject({
+        method: 'POST',
+        url: `/api/patches/${patchInfo.lastInsertRowid}/review`,
+        payload: { decision: 'rejected', notes: 'Needs more work' },
+      });
+      expect(updateResponse.statusCode).toBe(201);
+
+      const detailResponse = await app.inject({
+        method: 'GET',
+        url: `/api/repositories/${repoInfo.lastInsertRowid}/cycles/${cycleInfo.lastInsertRowid}`,
+      });
+      expect(detailResponse.statusCode).toBe(200);
+      expect(detailResponse.json().review_status).toBe('rejected');
+      expect(detailResponse.json().review_notes).toBe('Needs more work');
     });
   });
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -14,6 +14,225 @@ import {
   type ReviewDecisionDTO,
 } from '../db/index.js';
 
+interface FindingsFilters {
+  repositoryId?: number;
+  classification?: string;
+  validationStatus?: string;
+  reviewStatus?: string;
+  cycleSize?: number;
+  search?: string;
+}
+
+interface FindingsQueryRow {
+  cycle_id: number;
+  scan_id: number;
+  normalized_path: string;
+  participating_files: string;
+  raw_payload: string | null;
+  fix_candidate_id: number | null;
+  classification: string | null;
+  confidence: number | null;
+  reasons: string | null;
+  patch_id: number | null;
+  patch_text: string | null;
+  validation_status: string | null;
+  validation_summary: string | null;
+  review_status: string | null;
+  review_notes: string | null;
+  repository_id: number;
+  owner: string;
+  name: string;
+  commit_sha: string;
+  cycle_size: number;
+}
+
+function parseJsonArray(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseJsonValue<T>(value: string | null, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function toOptionalNumber(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function buildFindingsQuery(filters: FindingsFilters): { query: string; params: unknown[] } {
+  const queryParts = [
+    `
+    SELECT
+      c.id AS cycle_id,
+      c.scan_id,
+      c.normalized_path,
+      c.participating_files,
+      c.raw_payload,
+      fc.id AS fix_candidate_id,
+      fc.classification,
+      fc.confidence,
+      fc.reasons,
+      p.id AS patch_id,
+      p.patch_text,
+      p.validation_status,
+      p.validation_summary,
+      rd.decision AS review_status,
+      rd.notes AS review_notes,
+      r.id AS repository_id,
+      r.owner,
+      r.name,
+      s.commit_sha,
+      CASE
+        WHEN json_valid(c.participating_files) THEN json_array_length(c.participating_files)
+        ELSE 0
+      END AS cycle_size
+    FROM cycles c
+    INNER JOIN scans s ON s.id = c.scan_id
+    INNER JOIN repositories r ON r.id = s.repository_id
+    LEFT JOIN fix_candidates fc ON fc.cycle_id = c.id
+    LEFT JOIN patches p ON p.fix_candidate_id = fc.id
+    LEFT JOIN review_decisions rd ON rd.id = (
+      SELECT id
+      FROM review_decisions
+      WHERE patch_id = p.id
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    )
+    WHERE 1 = 1
+      AND c.scan_id = (
+        SELECT id
+        FROM scans
+        WHERE repository_id = r.id
+        ORDER BY started_at DESC, id DESC
+        LIMIT 1
+      )
+  `,
+  ];
+
+  const params: unknown[] = [];
+
+  appendRepositoryFilter(queryParts, params, filters.repositoryId);
+  appendSearchFilter(queryParts, params, filters.search);
+  appendClassificationFilter(queryParts, params, filters.classification);
+  appendValidationStatusFilter(queryParts, params, filters.validationStatus);
+  appendReviewStatusFilter(queryParts, params, filters.reviewStatus);
+  appendCycleSizeFilter(queryParts, params, filters.cycleSize);
+
+  queryParts.push(`
+    ORDER BY COALESCE(fc.confidence, 0) DESC, r.owner ASC, r.name ASC, c.id ASC
+  `);
+
+  return { query: queryParts.join(''), params };
+}
+
+function appendRepositoryFilter(query: string[], params: unknown[], repositoryId?: number): void {
+  if (repositoryId === undefined) {
+    return;
+  }
+
+  query.push(' AND r.id = ?');
+  params.push(repositoryId);
+}
+
+function appendSearchFilter(query: string[], params: unknown[], search?: string): void {
+  const trimmedSearch = search?.trim();
+  if (!trimmedSearch) {
+    return;
+  }
+
+  query.push(" AND LOWER(r.owner || '/' || r.name || ' ' || c.normalized_path) LIKE ?");
+  params.push(`%${trimmedSearch.toLowerCase()}%`);
+}
+
+function appendClassificationFilter(query: string[], params: unknown[], classification?: string): void {
+  if (!classification || classification === 'all') {
+    return;
+  }
+
+  if (classification === 'unclassified') {
+    query.push(' AND fc.id IS NULL');
+    return;
+  }
+
+  query.push(' AND fc.classification = ?');
+  params.push(classification);
+}
+
+function appendValidationStatusFilter(query: string[], params: unknown[], validationStatus?: string): void {
+  if (!validationStatus || validationStatus === 'all') {
+    return;
+  }
+
+  if (validationStatus === 'pending') {
+    query.push(' AND p.validation_status IS NULL');
+    return;
+  }
+
+  query.push(' AND p.validation_status = ?');
+  params.push(validationStatus);
+}
+
+function appendReviewStatusFilter(query: string[], params: unknown[], reviewStatus?: string): void {
+  if (!reviewStatus || reviewStatus === 'all') {
+    return;
+  }
+
+  if (reviewStatus === 'pending') {
+    query.push(' AND rd.decision IS NULL');
+    return;
+  }
+
+  query.push(' AND rd.decision = ?');
+  params.push(reviewStatus);
+}
+
+function appendCycleSizeFilter(query: string[], params: unknown[], cycleSize?: number): void {
+  if (cycleSize === undefined) {
+    return;
+  }
+
+  query.push(`
+    AND CASE
+      WHEN json_valid(c.participating_files) THEN json_array_length(c.participating_files)
+      ELSE 0
+    END = ?
+  `);
+  params.push(cycleSize);
+}
+
+function mapFindingRows(rows: FindingsQueryRow[]) {
+  return rows.map((row) => ({
+    ...row,
+    cycle_path: parseJsonArray(row.participating_files),
+    raw_payload: parseJsonValue(row.raw_payload, null),
+    reasons: parseJsonValue(row.reasons, null),
+    validation_status: row.validation_status ?? 'pending',
+    review_status: row.review_status ?? 'pending',
+    status: row.review_status ?? 'pending',
+  }));
+}
+
 /**
  * Build and configure the Fastify app.
  * Accepts an optional database instance for testing (defaults to the production DB).
@@ -127,51 +346,51 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
     return stmts.getCyclesByScanId.all(Number(request.params.scanId));
   });
 
+  fastify.get<{
+    Querystring: {
+      repository_id?: string;
+      search?: string;
+      classification?: string;
+      validation_status?: string;
+      review_status?: string;
+      cycle_size?: string;
+    };
+  }>('/api/findings', async (request) => {
+    const { query, params } = buildFindingsQuery({
+      repositoryId: toOptionalNumber(request.query.repository_id),
+      search: request.query.search,
+      classification: request.query.classification,
+      validationStatus: request.query.validation_status,
+      reviewStatus: request.query.review_status,
+      cycleSize: toOptionalNumber(request.query.cycle_size),
+    });
+
+    const rows = db.prepare(query).all(...params) as FindingsQueryRow[];
+    return mapFindingRows(rows);
+  });
+
   // Combined findings view: cycles + fix candidates for a repository
   fastify.get<{
     Params: { id: string };
-    Querystring: { status?: string };
+    Querystring: {
+      search?: string;
+      classification?: string;
+      validation_status?: string;
+      review_status?: string;
+      cycle_size?: string;
+    };
   }>('/api/repositories/:id/findings', async (request) => {
-    const repoId = Number(request.params.id);
-    const statusFilter = request.query.status;
+    const { query, params } = buildFindingsQuery({
+      repositoryId: toOptionalNumber(request.params.id),
+      search: request.query.search,
+      classification: request.query.classification,
+      validationStatus: request.query.validation_status,
+      reviewStatus: request.query.review_status,
+      cycleSize: toOptionalNumber(request.query.cycle_size),
+    });
 
-    // Get the latest scan for this repo
-    const latestScan = db
-      .prepare('SELECT * FROM scans WHERE repository_id = ? ORDER BY started_at DESC LIMIT 1')
-      .get(repoId) as { id: number } | undefined;
-
-    if (!latestScan) return [];
-
-    let query = `
-      SELECT
-        c.id,
-        c.normalized_path,
-        c.participating_files,
-        fc.classification,
-        fc.confidence,
-        rd.decision as status
-      FROM cycles c
-      LEFT JOIN fix_candidates fc ON fc.cycle_id = c.id
-      LEFT JOIN patches p ON p.fix_candidate_id = fc.id
-      LEFT JOIN review_decisions rd ON rd.patch_id = p.id
-      WHERE c.scan_id = ?
-    `;
-
-    const params: unknown[] = [latestScan.id];
-
-    if (statusFilter && statusFilter !== 'all') {
-      query += " AND (rd.decision = ? OR (rd.decision IS NULL AND ? = 'pending'))";
-      params.push(statusFilter, statusFilter);
-    }
-
-    query += ' ORDER BY fc.confidence DESC';
-
-    const rows = db.prepare(query).all(...params) as Record<string, unknown>[];
-
-    return rows.map((row) => ({
-      ...row,
-      cycle_path: row.participating_files ? JSON.parse(row.participating_files as string) : [],
-    }));
+    const rows = db.prepare(query).all(...params) as FindingsQueryRow[];
+    return mapFindingRows(rows);
   });
 
   // Cycle detail with patch
@@ -205,15 +424,17 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
 
     return {
       ...cycle,
-      cycle_path: cycle.participating_files ? JSON.parse(cycle.participating_files) : /* v8 ignore next */ [],
-      raw_payload: cycle.raw_payload ? JSON.parse(cycle.raw_payload) : /* v8 ignore next */ null,
+      patch_id: patch?.id ?? null,
+      cycle_path: parseJsonArray(cycle.participating_files),
+      raw_payload: parseJsonValue(cycle.raw_payload, null),
       classification: fixCandidate?.classification ?? null,
       confidence: fixCandidate?.confidence ?? null,
-      reasons: fixCandidate?.reasons ? JSON.parse(fixCandidate.reasons) : null,
+      reasons: parseJsonValue(fixCandidate?.reasons ?? null, null),
       patch: patch?.patch_text ?? null,
       validation_status: patch?.validation_status ?? null,
       validation_summary: patch?.validation_summary ?? null,
       review_status: reviewDecision?.decision ?? 'pending',
+      review_notes: reviewDecision?.notes ?? null,
     };
   });
 

--- a/cli/exportPatches.test.ts
+++ b/cli/exportPatches.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDatabase, createStatements, initSchema } from '../db/index.js';
+import { exportApprovedPatches } from './exportPatches.js';
+
+describe('exportApprovedPatches', () => {
+  let db: ReturnType<typeof createDatabase>;
+  let statements: ReturnType<typeof createStatements>;
+  let outputDir: string;
+
+  beforeEach(async () => {
+    db = createDatabase(':memory:');
+    initSchema(db);
+    statements = createStatements(db);
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'patch-export-'));
+  });
+
+  afterEach(async () => {
+    db.close();
+    await fs.rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('exports validated approved and pr-candidate patches to deterministic paths', async () => {
+    const repoInfo = statements.addRepository.run({
+      owner: 'acme',
+      name: 'widget',
+      default_branch: null,
+      local_path: null,
+    });
+    const scanInfo = statements.addScan.run({
+      repository_id: repoInfo.lastInsertRowid,
+      commit_sha: 'abc123',
+      status: 'completed',
+    });
+    const cycleInfo = statements.addCycle.run({
+      scan_id: scanInfo.lastInsertRowid,
+      normalized_path: 'a.ts -> b.ts -> a.ts',
+      participating_files: JSON.stringify(['a.ts', 'b.ts']),
+      raw_payload: null,
+    });
+
+    const approvedCandidate = statements.addFixCandidate.run({
+      cycle_id: cycleInfo.lastInsertRowid,
+      classification: 'autofix_extract_shared',
+      confidence: 0.98,
+      reasons: JSON.stringify(['safe shared function']),
+    });
+    const approvedPatch = statements.addPatch.run({
+      fix_candidate_id: approvedCandidate.lastInsertRowid,
+      patch_text: '--- a.ts\n+++ b.ts\n',
+      touched_files: JSON.stringify(['a.ts', 'b.ts']),
+      validation_status: 'passed',
+      validation_summary: 'Validation passed.',
+    });
+    statements.addReviewDecision.run({
+      patch_id: approvedPatch.lastInsertRowid,
+      decision: 'approved',
+      notes: 'Ship it',
+    });
+
+    const prCandidate = statements.addFixCandidate.run({
+      cycle_id: cycleInfo.lastInsertRowid,
+      classification: 'autofix_import_type',
+      confidence: 0.86,
+      reasons: JSON.stringify(['type-only dependency']),
+    });
+    const prCandidatePatch = statements.addPatch.run({
+      fix_candidate_id: prCandidate.lastInsertRowid,
+      patch_text: '--- c.ts\n+++ c.ts\n',
+      touched_files: JSON.stringify(['c.ts']),
+      validation_status: 'passed',
+      validation_summary: 'Validation passed.',
+    });
+    statements.addReviewDecision.run({
+      patch_id: prCandidatePatch.lastInsertRowid,
+      decision: 'pr_candidate',
+      notes: null,
+    });
+
+    const rejectedCandidate = statements.addFixCandidate.run({
+      cycle_id: cycleInfo.lastInsertRowid,
+      classification: 'suggest_manual',
+      confidence: 0.4,
+      reasons: null,
+    });
+    const rejectedPatch = statements.addPatch.run({
+      fix_candidate_id: rejectedCandidate.lastInsertRowid,
+      patch_text: '--- rejected.ts\n+++ rejected.ts\n',
+      touched_files: JSON.stringify(['rejected.ts']),
+      validation_status: 'passed',
+      validation_summary: 'Validation passed.',
+    });
+    statements.addReviewDecision.run({
+      patch_id: rejectedPatch.lastInsertRowid,
+      decision: 'rejected',
+      notes: 'Needs more work',
+    });
+
+    const result = await exportApprovedPatches(outputDir, db);
+
+    expect(result.exportedCount).toBe(2);
+    expect(result.files).toHaveLength(2);
+
+    const approvedPath = path.join(
+      outputDir,
+      'acme-widget',
+      `scan-${scanInfo.lastInsertRowid}`,
+      `cycle-${cycleInfo.lastInsertRowid}`,
+      `fix-${approvedCandidate.lastInsertRowid}-patch-${approvedPatch.lastInsertRowid}-approved.patch`,
+    );
+    const prCandidatePath = path.join(
+      outputDir,
+      'acme-widget',
+      `scan-${scanInfo.lastInsertRowid}`,
+      `cycle-${cycleInfo.lastInsertRowid}`,
+      `fix-${prCandidate.lastInsertRowid}-patch-${prCandidatePatch.lastInsertRowid}-pr_candidate.patch`,
+    );
+    const rejectedPath = path.join(
+      outputDir,
+      'acme-widget',
+      `scan-${scanInfo.lastInsertRowid}`,
+      `cycle-${cycleInfo.lastInsertRowid}`,
+      `fix-${rejectedCandidate.lastInsertRowid}-patch-${rejectedPatch.lastInsertRowid}-rejected.patch`,
+    );
+
+    await expect(fs.readFile(approvedPath, 'utf8')).resolves.toBe('--- a.ts\n+++ b.ts\n');
+    await expect(fs.readFile(prCandidatePath, 'utf8')).resolves.toBe('--- c.ts\n+++ c.ts\n');
+    expect(result.files).not.toContain(rejectedPath);
+  });
+});

--- a/cli/exportPatches.ts
+++ b/cli/exportPatches.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import { getDb } from '../db/index.js';
+
+const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), 'exports', 'patches');
+
+interface ExportablePatchRow {
+  patch_id: number;
+  fix_candidate_id: number;
+  cycle_id: number;
+  scan_id: number;
+  owner: string;
+  name: string;
+  patch_text: string;
+  review_status: string;
+  validation_status: string | null;
+}
+
+export interface ExportResult {
+  outputDir: string;
+  exportedCount: number;
+  files: string[];
+}
+
+export async function exportApprovedPatches(
+  outputDir = DEFAULT_OUTPUT_DIR,
+  database: DatabaseType = getDb(),
+): Promise<ExportResult> {
+  const rows = database
+    .prepare(`
+    SELECT
+      p.id AS patch_id,
+      fc.id AS fix_candidate_id,
+      c.id AS cycle_id,
+      s.id AS scan_id,
+      r.owner,
+      r.name,
+      p.patch_text,
+      COALESCE(rd.decision, 'pending') AS review_status,
+      p.validation_status
+    FROM patches p
+    INNER JOIN fix_candidates fc ON fc.id = p.fix_candidate_id
+    INNER JOIN cycles c ON c.id = fc.cycle_id
+    INNER JOIN scans s ON s.id = c.scan_id
+    INNER JOIN repositories r ON r.id = s.repository_id
+    LEFT JOIN review_decisions rd ON rd.id = (
+      SELECT id
+      FROM review_decisions
+      WHERE patch_id = p.id
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    )
+    WHERE rd.decision IN ('approved', 'pr_candidate')
+      AND p.validation_status = 'passed'
+    ORDER BY r.owner ASC, r.name ASC, s.id ASC, fc.id ASC, p.id ASC
+  `)
+    .all() as ExportablePatchRow[];
+
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const exportedFiles: string[] = [];
+  for (const row of rows) {
+    const filePath = buildExportPath(outputDir, row);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, row.patch_text, 'utf8');
+    exportedFiles.push(filePath);
+  }
+
+  return {
+    outputDir,
+    exportedCount: exportedFiles.length,
+    files: exportedFiles,
+  };
+}
+
+function buildExportPath(outputDir: string, row: ExportablePatchRow): string {
+  const repoSegment = `${sanitizeSegment(row.owner)}-${sanitizeSegment(row.name)}`;
+  const scanSegment = `scan-${row.scan_id}`;
+  const cycleSegment = `cycle-${row.cycle_id}`;
+  const fileSegment = `fix-${row.fix_candidate_id}-patch-${row.patch_id}-${row.review_status}.patch`;
+
+  return path.join(outputDir, repoSegment, scanSegment, cycleSegment, fileSegment);
+}
+
+function sanitizeSegment(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9._-]+/g, '-');
+}

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -1,9 +1,22 @@
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { exportApprovedPatches } from './exportPatches.js';
 import { createProgram } from './index.js';
 import { scanRepository } from './scanner.js';
 
+const exportedDir = path.join(os.tmpdir(), 'patches');
+
 vi.mock('./scanner.js', () => ({
   scanRepository: vi.fn().mockResolvedValue({ scanId: 999, cyclesFound: 2 }),
+}));
+
+vi.mock('./exportPatches.js', () => ({
+  exportApprovedPatches: vi.fn().mockResolvedValue({
+    outputDir: path.join(os.tmpdir(), 'patches'),
+    exportedCount: 2,
+    files: [path.join(os.tmpdir(), 'patches', 'a.patch'), path.join(os.tmpdir(), 'patches', 'b.patch')],
+  }),
 }));
 
 describe('CLI', () => {
@@ -27,7 +40,7 @@ describe('CLI', () => {
 
   it('scan command catches errors and exits', async () => {
     const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
 
     // override mock to throw
     vi.mocked(scanRepository).mockRejectedValueOnce(new Error('Scanner error'));
@@ -66,14 +79,15 @@ describe('CLI', () => {
     consoleSpy.mockRestore();
   });
 
-  it('export:patches command logs export message', () => {
+  it('export:patches command logs export message', async () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const program = createProgram();
     program.exitOverride();
 
-    program.parse(['export:patches'], { from: 'user' });
+    await program.parseAsync(['node', 'test', 'export:patches']);
 
-    expect(consoleSpy).toHaveBeenCalledWith('Exporting approved patch files...');
+    expect(consoleSpy).toHaveBeenCalledWith(`Exported 2 patch file(s) to ${exportedDir}`);
+    expect(vi.mocked(exportApprovedPatches)).toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { exportApprovedPatches } from './exportPatches.js';
 import { scanRepository } from './scanner.js';
 
 export function createProgram(): Command {
@@ -36,9 +37,11 @@ export function createProgram(): Command {
 
   program
     .command('export:patches')
-    .description('Export approved patch files for PR generation')
-    .action(() => {
-      console.log('Exporting approved patch files...');
+    .argument('[outputDir]', 'Directory to write exported patch files to')
+    .description('Export approved or PR-candidate patch files for PR generation')
+    .action(async (outputDir?: string) => {
+      const result = await exportApprovedPatches(outputDir);
+      console.log(`Exported ${result.exportedCount} patch file(s) to ${result.outputDir}`);
     });
 
   return program;
@@ -48,6 +51,6 @@ export function createProgram(): Command {
 /* v8 ignore start */
 const isMainModule = process.argv[1]?.endsWith('index.ts') || process.argv[1]?.endsWith('index.js');
 if (isMainModule) {
-  createProgram().parse(process.argv);
+  await createProgram().parseAsync(process.argv);
 }
 /* v8 ignore stop */

--- a/db/index.test.ts
+++ b/db/index.test.ts
@@ -451,6 +451,28 @@ describe('db module', () => {
       expect(decision.notes).toBe('Looks good to me');
     });
 
+    it('updates the existing review decision for a patch', () => {
+      stmts.addReviewDecision.run({
+        patch_id: patchId,
+        decision: 'approved',
+        notes: 'Looks good to me',
+      });
+      stmts.addReviewDecision.run({
+        patch_id: patchId,
+        decision: 'rejected',
+        notes: 'Needs more work',
+      });
+
+      const decisions = db
+        .prepare('SELECT * FROM review_decisions WHERE patch_id = ?')
+        .all(patchId) as ReviewDecisionDTO[];
+      expect(decisions).toHaveLength(1);
+
+      const decision = stmts.getReviewDecisionByPatchId.get(patchId) as ReviewDecisionDTO;
+      expect(decision.decision).toBe('rejected');
+      expect(decision.notes).toBe('Needs more work');
+    });
+
     it('handles null notes', () => {
       stmts.addReviewDecision.run({
         patch_id: patchId,

--- a/db/index.ts
+++ b/db/index.ts
@@ -142,7 +142,8 @@ const SCHEMA_SQL = `
     decision TEXT NOT NULL, -- approved, rejected, ignored, pr_candidate
     notes TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (patch_id) REFERENCES patches(id)
+    FOREIGN KEY (patch_id) REFERENCES patches(id),
+    UNIQUE(patch_id)
   );
 
   -- Indexes
@@ -249,6 +250,10 @@ export function createStatements(database: DatabaseType) {
     addReviewDecision: database.prepare(`
       INSERT INTO review_decisions (patch_id, decision, notes)
       VALUES (@patch_id, @decision, @notes)
+      ON CONFLICT(patch_id) DO UPDATE SET
+        decision = excluded.decision,
+        notes = excluded.notes,
+        created_at = CURRENT_TIMESTAMP
     `),
     getReviewDecisionByPatchId: database.prepare(`
       SELECT * FROM review_decisions WHERE patch_id = ?

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,6 +39,9 @@ export default function Header() {
           <Link to="/" className="nav-link" activeProps={{ className: 'nav-link is-active' }}>
             Repositories
           </Link>
+          <Link to="/findings" className="nav-link" activeProps={{ className: 'nav-link is-active' }}>
+            Review Queue
+          </Link>
           <Link to="/about" className="nav-link" activeProps={{ className: 'nav-link is-active' }}>
             About
           </Link>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,57 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api'
 
 const NETWORK_ERROR = 'Network response was not ok';
 
+export type ReviewDecision = 'approved' | 'rejected' | 'ignored' | 'pr_candidate';
+
+export interface FindingsFilters {
+  repository_id?: string | number;
+  search?: string;
+  classification?: string;
+  validation_status?: string;
+  review_status?: string;
+  cycle_size?: string | number;
+}
+
+export interface FindingRecord {
+  cycle_id: number;
+  scan_id: number;
+  normalized_path: string;
+  participating_files: string;
+  raw_payload: unknown;
+  fix_candidate_id: number | null;
+  classification: string | null;
+  confidence: number | null;
+  reasons: unknown;
+  patch_id: number | null;
+  patch_text: string | null;
+  validation_status: string;
+  validation_summary: string | null;
+  review_status: string;
+  review_notes: string | null;
+  repository_id: number;
+  owner: string;
+  name: string;
+  commit_sha: string;
+  cycle_size: number;
+  cycle_path: string[];
+  status?: string;
+}
+
+function toSearchParams(filters?: FindingsFilters) {
+  const searchParams = new URLSearchParams();
+
+  if (filters) {
+    for (const [key, value] of Object.entries(filters)) {
+      if (value === undefined || value === null || value === '' || value === 'all') {
+        continue;
+      }
+      searchParams.append(key, String(value));
+    }
+  }
+
+  return searchParams;
+}
+
 export async function fetchRepositories() {
   const response = await fetch(`${API_BASE_URL}/repositories`);
   if (!response.ok) {
@@ -18,24 +69,43 @@ export async function fetchRepository(id: string) {
   return response.json();
 }
 
-export async function fetchRepositoryFindings(id: string, filters?: Record<string, unknown>) {
-  const url = new URL(`${API_BASE_URL}/repositories/${id}/findings`);
-  if (filters) {
-    for (const key of Object.keys(filters)) {
-      if (filters[key] !== undefined && filters[key] !== null) {
-        url.searchParams.append(key, String(filters[key]));
-      }
-    }
-  }
-  const response = await fetch(url.toString());
+export async function fetchFindings(filters?: FindingsFilters): Promise<FindingRecord[]> {
+  const searchParams = toSearchParams(filters);
+  const queryString = searchParams.toString();
+  const url = queryString ? `${API_BASE_URL}/findings?${queryString}` : `${API_BASE_URL}/findings`;
+  const response = await fetch(url);
   if (!response.ok) {
     throw new Error(NETWORK_ERROR);
   }
   return response.json();
 }
 
+export async function fetchRepositoryFindings(
+  id: string,
+  filters?: Omit<FindingsFilters, 'repository_id'>,
+): Promise<FindingRecord[]> {
+  return fetchFindings({
+    repository_id: id,
+    ...filters,
+  });
+}
+
 export async function fetchCycleDetail(repoId: string, cycleId: string) {
   const response = await fetch(`${API_BASE_URL}/repositories/${repoId}/cycles/${cycleId}`);
+  if (!response.ok) {
+    throw new Error(NETWORK_ERROR);
+  }
+  return response.json();
+}
+
+export async function submitReviewDecision(patchId: string, decision: ReviewDecision, notes?: string) {
+  const response = await fetch(`${API_BASE_URL}/patches/${patchId}/review`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ decision, notes }),
+  });
   if (!response.ok) {
     throw new Error(NETWORK_ERROR);
   }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,113 +8,150 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as AboutRouteImport } from './routes/about';
-import { Route as IndexRouteImport } from './routes/index';
-import { Route as RepositoriesIdCyclesCycleIdRouteImport } from './routes/repositories.$id.cycles.$cycleId';
-import { Route as RepositoriesIdIndexRouteImport } from './routes/repositories.$id.index';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as FindingsRouteImport } from './routes/findings'
+import { Route as AboutRouteImport } from './routes/about'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as RepositoriesIdIndexRouteImport } from './routes/repositories.$id.index'
+import { Route as RepositoriesIdCyclesCycleIdRouteImport } from './routes/repositories.$id.cycles.$cycleId'
 
+const FindingsRoute = FindingsRouteImport.update({
+  id: '/findings',
+  path: '/findings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const RepositoriesIdIndexRoute = RepositoriesIdIndexRouteImport.update({
   id: '/repositories/$id/',
   path: '/repositories/$id/',
   getParentRoute: () => rootRouteImport,
-} as any);
-const RepositoriesIdCyclesCycleIdRoute = RepositoriesIdCyclesCycleIdRouteImport.update({
-  id: '/repositories/$id/cycles/$cycleId',
-  path: '/repositories/$id/cycles/$cycleId',
-  getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const RepositoriesIdCyclesCycleIdRoute =
+  RepositoriesIdCyclesCycleIdRouteImport.update({
+    id: '/repositories/$id/cycles/$cycleId',
+    path: '/repositories/$id/cycles/$cycleId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute;
-  '/about': typeof AboutRoute;
-  '/repositories/$id/': typeof RepositoriesIdIndexRoute;
-  '/repositories/$id/cycles/$cycleId': typeof RepositoriesIdCyclesCycleIdRoute;
+  '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/findings': typeof FindingsRoute
+  '/repositories/$id/': typeof RepositoriesIdIndexRoute
+  '/repositories/$id/cycles/$cycleId': typeof RepositoriesIdCyclesCycleIdRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute;
-  '/about': typeof AboutRoute;
-  '/repositories/$id': typeof RepositoriesIdIndexRoute;
-  '/repositories/$id/cycles/$cycleId': typeof RepositoriesIdCyclesCycleIdRoute;
+  '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/findings': typeof FindingsRoute
+  '/repositories/$id': typeof RepositoriesIdIndexRoute
+  '/repositories/$id/cycles/$cycleId': typeof RepositoriesIdCyclesCycleIdRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  '/': typeof IndexRoute;
-  '/about': typeof AboutRoute;
-  '/repositories/$id/': typeof RepositoriesIdIndexRoute;
-  '/repositories/$id/cycles/$cycleId': typeof RepositoriesIdCyclesCycleIdRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/findings': typeof FindingsRoute
+  '/repositories/$id/': typeof RepositoriesIdIndexRoute
+  '/repositories/$id/cycles/$cycleId': typeof RepositoriesIdCyclesCycleIdRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: '/' | '/about' | '/repositories/$id/' | '/repositories/$id/cycles/$cycleId';
-  fileRoutesByTo: FileRoutesByTo;
-  to: '/' | '/about' | '/repositories/$id' | '/repositories/$id/cycles/$cycleId';
-  id: '__root__' | '/' | '/about' | '/repositories/$id/' | '/repositories/$id/cycles/$cycleId';
-  fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/about'
+    | '/findings'
+    | '/repositories/$id/'
+    | '/repositories/$id/cycles/$cycleId'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/about'
+    | '/findings'
+    | '/repositories/$id'
+    | '/repositories/$id/cycles/$cycleId'
+  id:
+    | '__root__'
+    | '/'
+    | '/about'
+    | '/findings'
+    | '/repositories/$id/'
+    | '/repositories/$id/cycles/$cycleId'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  AboutRoute: typeof AboutRoute;
-  RepositoriesIdIndexRoute: typeof RepositoriesIdIndexRoute;
-  RepositoriesIdCyclesCycleIdRoute: typeof RepositoriesIdCyclesCycleIdRoute;
+  IndexRoute: typeof IndexRoute
+  AboutRoute: typeof AboutRoute
+  FindingsRoute: typeof FindingsRoute
+  RepositoriesIdIndexRoute: typeof RepositoriesIdIndexRoute
+  RepositoriesIdCyclesCycleIdRoute: typeof RepositoriesIdCyclesCycleIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/findings': {
+      id: '/findings'
+      path: '/findings'
+      fullPath: '/findings'
+      preLoaderRoute: typeof FindingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/about': {
-      id: '/about';
-      path: '/about';
-      fullPath: '/about';
-      preLoaderRoute: typeof AboutRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/repositories/$id/': {
-      id: '/repositories/$id/';
-      path: '/repositories/$id';
-      fullPath: '/repositories/$id/';
-      preLoaderRoute: typeof RepositoriesIdIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/repositories/$id/'
+      path: '/repositories/$id'
+      fullPath: '/repositories/$id/'
+      preLoaderRoute: typeof RepositoriesIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/repositories/$id/cycles/$cycleId': {
-      id: '/repositories/$id/cycles/$cycleId';
-      path: '/repositories/$id/cycles/$cycleId';
-      fullPath: '/repositories/$id/cycles/$cycleId';
-      preLoaderRoute: typeof RepositoriesIdCyclesCycleIdRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/repositories/$id/cycles/$cycleId'
+      path: '/repositories/$id/cycles/$cycleId'
+      fullPath: '/repositories/$id/cycles/$cycleId'
+      preLoaderRoute: typeof RepositoriesIdCyclesCycleIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  FindingsRoute: FindingsRoute,
   RepositoriesIdIndexRoute: RepositoriesIdIndexRoute,
   RepositoriesIdCyclesCycleIdRoute: RepositoriesIdCyclesCycleIdRoute,
-};
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>();
+}
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from './router.tsx';
-
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/src/routes/findings.tsx
+++ b/src/routes/findings.tsx
@@ -1,0 +1,336 @@
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { useState } from 'react';
+import { type FindingRecord, type FindingsFilters, fetchFindings, fetchRepositories } from '../lib/api';
+
+type QueueFilters = {
+  repository_id: string;
+  search: string;
+  classification: string;
+  validation_status: string;
+  review_status: string;
+  cycle_size: string;
+};
+
+const INITIAL_FILTERS: QueueFilters = {
+  repository_id: 'all',
+  search: '',
+  classification: 'all',
+  validation_status: 'all',
+  review_status: 'all',
+  cycle_size: 'all',
+};
+
+const CLASSIFICATION_OPTIONS = [
+  ['all', 'All classifications'],
+  ['autofix_extract_shared', 'Extract shared'],
+  ['autofix_direct_import', 'Direct import'],
+  ['autofix_import_type', 'Import type'],
+  ['suggest_manual', 'Suggest manual'],
+  ['unsupported', 'Unsupported'],
+  ['unclassified', 'Unclassified'],
+] as const;
+
+const VALIDATION_OPTIONS = [
+  ['all', 'All validation states'],
+  ['pending', 'Pending'],
+  ['passed', 'Passed'],
+  ['failed', 'Failed'],
+] as const;
+
+const REVIEW_OPTIONS = [
+  ['all', 'All review states'],
+  ['pending', 'Pending'],
+  ['approved', 'Approved'],
+  ['pr_candidate', 'PR candidate'],
+  ['ignored', 'Ignored'],
+  ['rejected', 'Rejected'],
+] as const;
+
+const CYCLE_SIZE_OPTIONS = [
+  ['all', 'Any size'],
+  ['2', '2 files'],
+  ['3', '3 files'],
+  ['4', '4 files'],
+  ['5', '5 files'],
+] as const;
+
+export const Route = createFileRoute('/findings')({
+  component: FindingsQueue,
+});
+
+function FindingsQueue() {
+  const [filters, setFilters] = useState<QueueFilters>(INITIAL_FILTERS);
+
+  const { data: repositories = [] } = useQuery({
+    queryKey: ['repositories'],
+    queryFn: fetchRepositories,
+  });
+
+  const {
+    data: findings = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['findings', filters],
+    queryFn: () => fetchFindings(buildApiFilters(filters)),
+  });
+
+  const activeFilterCount = Object.entries(filters).filter(([key, value]) => {
+    if (key === 'search') {
+      return value.trim().length > 0;
+    }
+    return value !== 'all';
+  }).length;
+
+  return (
+    <div className="page-wrap px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8 flex flex-col gap-4 border-b border-[var(--line)] pb-6 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-[var(--sea-ink-soft)]">Review Queue</p>
+          <h1 className="text-3xl font-semibold tracking-tight text-[var(--sea-ink)] sm:text-4xl">Findings queue</h1>
+          <p className="max-w-3xl text-sm leading-6 text-[var(--sea-ink-soft)] sm:text-base">
+            Narrow the latest findings by repository, classification, validation state, cycle size, and review status
+            before opening a cycle for manual review.
+          </p>
+        </div>
+
+        <Link
+          to="/"
+          className="inline-flex items-center justify-center rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-4 py-2 text-sm font-semibold text-[var(--sea-ink)] no-underline transition hover:translate-y-[-1px] hover:shadow-[0_12px_24px_rgba(30,90,72,0.12)]"
+        >
+          Repositories
+        </Link>
+      </div>
+
+      <div className="mb-6 rounded-3xl border border-[var(--line)] bg-[var(--panel-bg)] p-4 shadow-[0_16px_50px_rgba(27,67,54,0.08)] sm:p-5">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+          <label className="space-y-2 text-sm font-medium text-[var(--sea-ink-soft)]">
+            <span>Search</span>
+            <input
+              value={filters.search}
+              onChange={(event) => setFilters((current) => ({ ...current, search: event.target.value }))}
+              placeholder="Repo or cycle path"
+              className="w-full rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-2.5 text-sm text-[var(--sea-ink)] outline-none transition placeholder:text-[var(--sea-ink-soft)] focus:border-[var(--lagoon)]"
+            />
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-[var(--sea-ink-soft)]">
+            <span>Repository</span>
+            <select
+              value={filters.repository_id}
+              onChange={(event) => setFilters((current) => ({ ...current, repository_id: event.target.value }))}
+              className="w-full rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-2.5 text-sm text-[var(--sea-ink)] outline-none transition focus:border-[var(--lagoon)]"
+            >
+              <option value="all">All repositories</option>
+              {repositories.map((repository: { id: number; owner: string; name: string }) => (
+                <option key={repository.id} value={repository.id}>
+                  {repository.owner}/{repository.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-[var(--sea-ink-soft)]">
+            <span>Classification</span>
+            <select
+              value={filters.classification}
+              onChange={(event) => setFilters((current) => ({ ...current, classification: event.target.value }))}
+              className="w-full rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-2.5 text-sm text-[var(--sea-ink)] outline-none transition focus:border-[var(--lagoon)]"
+            >
+              {CLASSIFICATION_OPTIONS.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-[var(--sea-ink-soft)]">
+            <span>Validation</span>
+            <select
+              value={filters.validation_status}
+              onChange={(event) => setFilters((current) => ({ ...current, validation_status: event.target.value }))}
+              className="w-full rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-2.5 text-sm text-[var(--sea-ink)] outline-none transition focus:border-[var(--lagoon)]"
+            >
+              {VALIDATION_OPTIONS.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-[var(--sea-ink-soft)]">
+            <span>Review</span>
+            <select
+              value={filters.review_status}
+              onChange={(event) => setFilters((current) => ({ ...current, review_status: event.target.value }))}
+              className="w-full rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-2.5 text-sm text-[var(--sea-ink)] outline-none transition focus:border-[var(--lagoon)]"
+            >
+              {REVIEW_OPTIONS.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-[var(--sea-ink-soft)]">
+            <span>Cycle size</span>
+            <select
+              value={filters.cycle_size}
+              onChange={(event) => setFilters((current) => ({ ...current, cycle_size: event.target.value }))}
+              className="w-full rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-2.5 text-sm text-[var(--sea-ink)] outline-none transition focus:border-[var(--lagoon)]"
+            >
+              {CYCLE_SIZE_OPTIONS.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-[var(--sea-ink-soft)]">{getActiveFilterMessage(activeFilterCount)}</p>
+          <button
+            type="button"
+            onClick={() => setFilters(INITIAL_FILTERS)}
+            className="rounded-full border border-[var(--line)] bg-[var(--surface)] px-4 py-2 text-sm font-medium text-[var(--sea-ink)] transition hover:border-[var(--lagoon)]"
+          >
+            Reset filters
+          </button>
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="rounded-3xl border border-[var(--line)] bg-[var(--panel-bg)] p-8 text-[var(--sea-ink-soft)]">
+          Loading findings...
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-3xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+          Error loading findings queue.
+        </div>
+      )}
+
+      {!isLoading && !error && findings.length === 0 && (
+        <div className="rounded-3xl border border-[var(--line)] bg-[var(--panel-bg)] p-8 text-[var(--sea-ink-soft)]">
+          No findings match the current filters.
+        </div>
+      )}
+
+      {!isLoading && !error && findings.length > 0 && (
+        <div className="overflow-hidden rounded-3xl border border-[var(--line)] bg-[var(--panel-bg)] shadow-[0_16px_50px_rgba(27,67,54,0.08)]">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-[var(--line)]">
+              <thead className="bg-[var(--surface)]/90">
+                <tr className="text-left text-xs font-semibold uppercase tracking-[0.2em] text-[var(--sea-ink-soft)]">
+                  <th className="px-5 py-4">Repository</th>
+                  <th className="px-5 py-4">Cycle</th>
+                  <th className="px-5 py-4">Classification</th>
+                  <th className="px-5 py-4">Validation</th>
+                  <th className="px-5 py-4">Review</th>
+                  <th className="px-5 py-4">Confidence</th>
+                  <th className="px-5 py-4 text-right">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--line)]">
+                {findings.map((finding: FindingRecord) => (
+                  <tr
+                    key={`${finding.repository_id}-${finding.cycle_id}`}
+                    className="align-top transition hover:bg-[var(--surface)]/70"
+                  >
+                    <td className="px-5 py-4 text-sm">
+                      <div className="font-semibold text-[var(--sea-ink)]">
+                        {finding.owner}/{finding.name}
+                      </div>
+                      <div className="text-xs text-[var(--sea-ink-soft)]">Scan {finding.scan_id}</div>
+                    </td>
+                    <td className="px-5 py-4 text-sm text-[var(--sea-ink)]">
+                      <div className="font-mono text-xs leading-5 text-[var(--sea-ink)]">
+                        {finding.cycle_path.length > 0 ? finding.cycle_path.join(' → ') : 'Unknown'}
+                      </div>
+                      <div className="mt-2 text-xs text-[var(--sea-ink-soft)]">Size {finding.cycle_size}</div>
+                    </td>
+                    <td className="px-5 py-4 text-sm">
+                      <span className="inline-flex rounded-full bg-[var(--chip-bg)] px-3 py-1 text-xs font-semibold text-[var(--sea-ink)]">
+                        {finding.classification || 'unclassified'}
+                      </span>
+                    </td>
+                    <td className="px-5 py-4 text-sm">
+                      <div className={statusBadgeClass(finding.validation_status)}>{finding.validation_status}</div>
+                      {finding.validation_summary && (
+                        <p className="mt-2 max-w-sm text-xs leading-5 text-[var(--sea-ink-soft)]">
+                          {finding.validation_summary}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-sm">
+                      <div className={statusBadgeClass(finding.review_status)}>{finding.review_status}</div>
+                      {finding.review_notes && (
+                        <p className="mt-2 max-w-sm text-xs leading-5 text-[var(--sea-ink-soft)]">
+                          {finding.review_notes}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-sm text-[var(--sea-ink)]">
+                      {finding.confidence === null ? 'N/A' : `${Math.round(finding.confidence * 100)}%`}
+                    </td>
+                    <td className="px-5 py-4 text-right text-sm font-medium">
+                      <Link
+                        to="/repositories/$id/cycles/$cycleId"
+                        params={{ id: String(finding.repository_id), cycleId: String(finding.cycle_id) }}
+                        className="inline-flex rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--sea-ink)] no-underline transition hover:border-[var(--lagoon)] hover:text-[var(--lagoon)]"
+                      >
+                        Review
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildApiFilters(filters: QueueFilters): FindingsFilters {
+  return {
+    repository_id: filters.repository_id,
+    search: filters.search,
+    classification: filters.classification,
+    validation_status: filters.validation_status,
+    review_status: filters.review_status,
+    cycle_size: filters.cycle_size,
+  };
+}
+
+function getActiveFilterMessage(activeFilterCount: number): string {
+  if (activeFilterCount === 0) {
+    return 'Showing the latest findings for all repositories.';
+  }
+
+  const suffix = activeFilterCount === 1 ? '' : 's';
+  return `Showing ${activeFilterCount} active filter${suffix}.`;
+}
+
+function statusBadgeClass(status: string) {
+  if (status === 'passed' || status === 'approved') {
+    return 'inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-emerald-800';
+  }
+
+  if (status === 'failed' || status === 'rejected') {
+    return 'inline-flex rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-rose-800';
+  }
+
+  if (status === 'pr_candidate' || status === 'pending') {
+    return 'inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-amber-800';
+  }
+
+  return 'inline-flex rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-slate-700';
+}

--- a/src/routes/repositories.$id.cycles.$cycleId.tsx
+++ b/src/routes/repositories.$id.cycles.$cycleId.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { fetchCycleDetail } from '../lib/api';
+import { fetchCycleDetail, type ReviewDecision, submitReviewDecision } from '../lib/api';
 
 export const Route = createFileRoute('/repositories/$id/cycles/$cycleId')({
   component: CycleDetail,
@@ -8,6 +8,7 @@ export const Route = createFileRoute('/repositories/$id/cycles/$cycleId')({
 
 function CycleDetail() {
   const { id, cycleId } = Route.useParams();
+  const queryClient = useQueryClient();
 
   const {
     data: cycle,
@@ -18,12 +19,30 @@ function CycleDetail() {
     queryFn: () => fetchCycleDetail(id, cycleId),
   });
 
+  const reviewMutation = useMutation({
+    mutationFn: (decision: ReviewDecision) => {
+      if (!cycle?.patch_id) {
+        throw new Error('No patch is available for this cycle.');
+      }
+
+      return submitReviewDecision(String(cycle.patch_id), decision);
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['cycle', id, cycleId] }),
+        queryClient.invalidateQueries({ queryKey: ['findings'] }),
+      ]);
+    },
+  });
+
   if (isLoading) return <div className="p-8">Loading cycle details...</div>;
   if (error) return <div className="p-8 text-red-600">Error loading cycle details</div>;
 
   let statusColor = 'text-gray-800';
   if (cycle?.validation_status === 'passed') statusColor = 'text-green-600';
   if (cycle?.validation_status === 'failed') statusColor = 'text-red-600';
+
+  const canReview = Boolean(cycle?.patch_id);
 
   return (
     <div className="p-8 max-w-6xl mx-auto">
@@ -50,6 +69,13 @@ function CycleDetail() {
                 <span className="font-medium">
                   {cycle.confidence ? `${(Number(cycle.confidence) * 100).toFixed(0)}%` : 'N/A'}
                 </span>
+              </div>
+              <div>
+                <span className="text-gray-500 block text-sm">Review Status</span>
+                <span className="font-medium bg-gray-100 px-2 py-1 rounded-md mt-1 inline-block">
+                  {String(cycle.review_status || 'pending')}
+                </span>
+                {cycle.review_notes && <p className="mt-2 text-sm text-gray-500">{cycle.review_notes}</p>}
               </div>
               <div className="col-span-2">
                 <span className="text-gray-500 block text-sm">Cycle Path</span>
@@ -104,17 +130,43 @@ function CycleDetail() {
           <div className="flex gap-4 justify-end">
             <button
               type="button"
-              className="px-6 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors"
+              disabled={!canReview || reviewMutation.isPending}
+              onClick={() => reviewMutation.mutate('rejected')}
+              className="px-6 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors disabled:cursor-not-allowed disabled:bg-red-300"
             >
               Reject
             </button>
             <button
               type="button"
-              className="px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors"
+              disabled={!canReview || reviewMutation.isPending}
+              onClick={() => reviewMutation.mutate('ignored')}
+              className="px-6 py-2 bg-slate-700 text-white rounded-md hover:bg-slate-800 transition-colors disabled:cursor-not-allowed disabled:bg-slate-300"
+            >
+              Ignore
+            </button>
+            <button
+              type="button"
+              disabled={!canReview || reviewMutation.isPending}
+              onClick={() => reviewMutation.mutate('pr_candidate')}
+              className="px-6 py-2 bg-amber-600 text-white rounded-md hover:bg-amber-700 transition-colors disabled:cursor-not-allowed disabled:bg-amber-300"
+            >
+              PR Candidate
+            </button>
+            <button
+              type="button"
+              disabled={!canReview || reviewMutation.isPending}
+              onClick={() => reviewMutation.mutate('approved')}
+              className="px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors disabled:cursor-not-allowed disabled:bg-green-300"
             >
               Approve
             </button>
           </div>
+          {!canReview && (
+            <p className="text-right text-sm text-gray-500">
+              A patch must exist before a review decision can be recorded.
+            </p>
+          )}
+          {reviewMutation.isPending && <p className="text-right text-sm text-gray-500">Saving review decision...</p>}
         </div>
       )}
     </div>

--- a/src/routes/repositories.$id.index.tsx
+++ b/src/routes/repositories.$id.index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useState } from 'react';
-import { fetchRepository, fetchRepositoryFindings } from '../lib/api';
+import { type FindingRecord, fetchRepository, fetchRepositoryFindings } from '../lib/api';
 
 export const Route = createFileRoute('/repositories/$id/')({
   component: RepositoryFindings,
@@ -22,7 +22,7 @@ function RepositoryFindings() {
     error,
   } = useQuery({
     queryKey: ['findings', id, filter],
-    queryFn: () => fetchRepositoryFindings(id, filter === 'all' ? undefined : { status: filter }),
+    queryFn: () => fetchRepositoryFindings(id, filter === 'all' ? undefined : { review_status: filter }),
   });
 
   if (repoLoading || findingsLoading) return <div className="p-8">Loading...</div>;
@@ -50,8 +50,9 @@ function RepositoryFindings() {
         >
           <option value="all">All</option>
           <option value="pending">Pending</option>
-          <option value="reviewed">Reviewed</option>
           <option value="approved">Approved</option>
+          <option value="pr_candidate">PR Candidate</option>
+          <option value="ignored">Ignored</option>
           <option value="rejected">Rejected</option>
         </select>
       </div>
@@ -83,10 +84,10 @@ function RepositoryFindings() {
                 </td>
               </tr>
             )}
-            {findings?.map((finding: Record<string, unknown>) => (
-              <tr key={String(finding.id)} className="hover:bg-gray-50">
+            {findings?.map((finding: FindingRecord) => (
+              <tr key={String(finding.cycle_id)} className="hover:bg-gray-50">
                 <td className="px-6 py-4 text-sm text-gray-900 break-words max-w-md">
-                  {finding.cycle_path ? (finding.cycle_path as string[]).join(' → ') : 'Unknown'}
+                  {finding.cycle_path.length > 0 ? finding.cycle_path.join(' → ') : 'Unknown'}
                 </td>
                 <td className="px-6 py-4 text-sm text-gray-500">
                   <span className="px-2 py-1 bg-gray-100 rounded-full text-xs font-medium">
@@ -99,18 +100,18 @@ function RepositoryFindings() {
                 <td className="px-6 py-4 text-sm text-gray-500">
                   <span
                     className={`px-2 py-1 rounded-full text-xs font-medium ${(() => {
-                      if (finding.status === 'approved') return 'bg-green-100 text-green-800';
-                      if (finding.status === 'rejected') return 'bg-red-100 text-red-800';
+                      if (finding.review_status === 'approved') return 'bg-green-100 text-green-800';
+                      if (finding.review_status === 'rejected') return 'bg-red-100 text-red-800';
                       return 'bg-yellow-100 text-yellow-800';
                     })()}`}
                   >
-                    {String(finding.status || 'pending')}
+                    {String(finding.review_status || 'pending')}
                   </span>
                 </td>
                 <td className="px-6 py-4 text-right text-sm font-medium">
                   <Link
                     to="/repositories/$id/cycles/$cycleId"
-                    params={{ id, cycleId: String(finding.id) }}
+                    params={{ id, cycleId: String(finding.cycle_id) }}
                     className="text-blue-600 hover:text-blue-900"
                   >
                     View


### PR DESCRIPTION
Closes #15

## Summary
- add a global findings queue with API-backed filters for repository, search, classification, validation status, cycle size, and review status
- wire review decisions through the cycle detail view so approve/reject/ignore/PR-candidate persist and refresh the queue
- implement `pnpm run export:patches` to write deterministic patch artifacts for approved and PR-candidate fixes
- add tests for queue filtering, review decision updates, and export output

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm build`