### PR TITLE
Teach scan to accept local filesystem paths

### DIFF
--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import fs from 'node:fs/promises';
 import simpleGit from 'simple-git';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -30,6 +31,7 @@ vi.mock('../db/index.js', async () => {
     addRepository: stmts.addRepository,
     getRepositoryByOwnerName: stmts.getRepositoryByOwnerName,
     updateRepositoryStatus: stmts.updateRepositoryStatus,
+    updateRepositoryLocalPath: stmts.updateRepositoryLocalPath,
     addScan: stmts.addScan,
     updateScanStatus: stmts.updateScanStatus,
     addCycle: stmts.addCycle,
@@ -52,6 +54,7 @@ describe('Scanner Worker', () => {
       clone: vi.fn(),
       fetch: vi.fn(),
       log: vi.fn().mockResolvedValue({ latest: { hash: 'mock-sha' } }),
+      getRemotes: vi.fn().mockResolvedValue([]),
     };
 
     vi.mocked(simpleGit).mockReturnValue(mockGit as unknown as ReturnType<typeof simpleGit>);
@@ -157,6 +160,51 @@ describe('Scanner Worker', () => {
     await scanRepository('https://github.com/solid/repo.git');
     const repo = dbModule.getRepositoryByOwnerName.get('solid', 'repo') as { status: string };
     expect(repo).toBeDefined();
+  });
+
+  it('uses an existing relative checkout directly', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true } as never);
+    mockGit.getRemotes.mockResolvedValue([
+      {
+        name: 'origin',
+        refs: {
+          fetch: 'git@github.com:langgenius/dify.git',
+          push: 'git@github.com:langgenius/dify.git',
+        },
+      },
+    ]);
+
+    const result = await scanRepository('../openclaw');
+
+    expect(result.repoPath).toBe(path.resolve('../openclaw'));
+    expect(mockGit.clone).not.toHaveBeenCalled();
+    expect(mockGit.fetch).not.toHaveBeenCalled();
+
+    const repo = dbModule.getRepositoryByOwnerName.get('langgenius', 'dify') as { local_path: string };
+    expect(repo.local_path).toBe(path.resolve('../openclaw'));
+  });
+
+  it('uses an existing absolute checkout directly', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true } as never);
+    mockGit.getRemotes.mockResolvedValue([
+      {
+        name: 'origin',
+        refs: {
+          fetch: 'https://github.com/openclaw/openclaw.git',
+          push: 'https://github.com/openclaw/openclaw.git',
+        },
+      },
+    ]);
+
+    const absolutePath = '/tmp/dify-autofix-test';
+    const result = await scanRepository(absolutePath);
+
+    expect(result.repoPath).toBe(path.resolve(absolutePath));
+    expect(mockGit.clone).not.toHaveBeenCalled();
+    expect(mockGit.fetch).not.toHaveBeenCalled();
+
+    const repo = dbModule.getRepositoryByOwnerName.get('openclaw', 'openclaw') as { local_path: string };
+    expect(repo.local_path).toBe(path.resolve(absolutePath));
   });
 
   it('handles bare names', async () => {

--- a/cli/scanner.ts
+++ b/cli/scanner.ts
@@ -12,6 +12,7 @@ import {
   addRepository,
   addScan,
   getRepositoryByOwnerName,
+  updateRepositoryLocalPath,
   updateRepositoryStatus,
   updateScanStatus,
 } from '../db/index.js';
@@ -19,6 +20,11 @@ import {
 function parseTargetUrl(targetUrlOrOwnerName: string) {
   let owner = 'unknown';
   let name = targetUrlOrOwnerName;
+
+  const githubPath = parseGithubPath(targetUrlOrOwnerName);
+  if (githubPath) {
+    return githubPath;
+  }
 
   if (targetUrlOrOwnerName.includes('github.com')) {
     const withoutHttps = targetUrlOrOwnerName.replace('https://', '').replace('http://', '');
@@ -37,28 +43,31 @@ function parseTargetUrl(targetUrlOrOwnerName: string) {
 }
 
 export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir = './worktrees') {
-  const { owner, name } = parseTargetUrl(targetUrlOrOwnerName);
+  const resolvedTarget = await resolveScanTarget(targetUrlOrOwnerName, worktreesDir);
+  const { owner, name } = resolvedTarget;
 
-  const repo = ensureRepository(owner, name);
+  const repo = ensureRepository(owner, name, resolvedTarget.localPath);
 
   updateRepositoryStatus.run({ id: repo.id, status: 'scanning' });
 
-  await fs.mkdir(worktreesDir, { recursive: true });
-  const repoPath = path.join(worktreesDir, `${owner}-${name}`);
+  if (!resolvedTarget.localPath) {
+    await fs.mkdir(worktreesDir, { recursive: true });
 
-  updateRepositoryStatus.run({ id: repo.id, status: 'downloading' });
-  const git = simpleGit();
-  const gitRepo = simpleGit(repoPath);
+    updateRepositoryStatus.run({ id: repo.id, status: 'downloading' });
+    const git = simpleGit();
+    const gitRepo = simpleGit(resolvedTarget.repoPath);
 
-  try {
-    await syncRepositoryClone(git, gitRepo, repoPath, owner, name, targetUrlOrOwnerName);
-  } catch (error) {
-    updateRepositoryStatus.run({ id: repo.id, status: 'clone_failed' });
-    throw error;
+    try {
+      await syncRepositoryClone(git, gitRepo, resolvedTarget);
+    } catch (error) {
+      updateRepositoryStatus.run({ id: repo.id, status: 'clone_failed' });
+      throw error;
+    }
   }
 
   updateRepositoryStatus.run({ id: repo.id, status: 'scanning' });
 
+  const gitRepo = simpleGit(resolvedTarget.repoPath);
   const commitSha = await getLatestCommitSha(gitRepo);
 
   const scanInfo = addScan.run({
@@ -69,16 +78,16 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
   const scanId = scanInfo.lastInsertRowid as number;
 
   try {
-    const cycles = await analyzeRepository(repoPath);
+    const cycles = await analyzeRepository(resolvedTarget.repoPath);
 
     for (const cycle of cycles) {
-      await persistCycle(scanId, repoPath, cycle);
+      await persistCycle(scanId, resolvedTarget.repoPath, cycle);
     }
 
     updateScanStatus.run({ id: scanId, status: 'completed' });
     updateRepositoryStatus.run({ id: repo.id, status: 'analyzed' });
 
-    return { scanId, repoPath, cyclesFound: cycles.length };
+    return { scanId, repoPath: resolvedTarget.repoPath, cyclesFound: cycles.length };
   } catch (error) {
     updateScanStatus.run({ id: scanId, status: 'failed' });
     updateRepositoryStatus.run({ id: repo.id, status: 'validation_failed' });
@@ -86,9 +95,14 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
   }
 }
 
-function ensureRepository(owner: string, name: string): RepositoryDTO {
+function ensureRepository(owner: string, name: string, localPath: string | null): RepositoryDTO {
   const existingRepo = getRepositoryByOwnerName.get(owner, name) as RepositoryDTO | undefined;
   if (existingRepo) {
+    if (localPath && existingRepo.local_path !== localPath) {
+      updateRepositoryLocalPath.run({ id: existingRepo.id, local_path: localPath });
+      return { ...existingRepo, local_path: localPath };
+    }
+
     return existingRepo;
   }
 
@@ -96,26 +110,64 @@ function ensureRepository(owner: string, name: string): RepositoryDTO {
     owner,
     name,
     default_branch: 'main',
-    local_path: null,
+    local_path: localPath,
   });
 
   return { id: info.lastInsertRowid as number, owner, name } as RepositoryDTO;
 }
 
+async function resolveScanTarget(targetUrlOrOwnerName: string, worktreesDir: string): Promise<{
+  owner: string;
+  name: string;
+  repoPath: string;
+  localPath: string | null;
+  cloneUrl: string | null;
+}> {
+  const looksLikeRemoteTarget = targetUrlOrOwnerName.includes('github.com') || targetUrlOrOwnerName.includes('://');
+  if (!looksLikeRemoteTarget) {
+    const localPath = path.resolve(targetUrlOrOwnerName);
+    if (await hasExistingDirectory(localPath)) {
+      const { owner, name } = await resolveLocalRepositoryIdentity(localPath);
+      return {
+        owner,
+        name,
+        repoPath: localPath,
+        localPath,
+        cloneUrl: null,
+      };
+    }
+  }
+
+  const { owner, name } = parseTargetUrl(targetUrlOrOwnerName);
+  return {
+    owner,
+    name,
+    repoPath: path.join(worktreesDir, `${owner}-${name}`),
+    localPath: null,
+    cloneUrl:
+      targetUrlOrOwnerName.includes('github.com') || !targetUrlOrOwnerName.includes('/')
+        ? targetUrlOrOwnerName
+        : resolveCloneUrl(owner, name),
+  };
+}
+
 async function syncRepositoryClone(
   git: ReturnType<typeof simpleGit>,
   gitRepo: ReturnType<typeof simpleGit>,
-  repoPath: string,
-  owner: string,
-  name: string,
-  targetUrlOrOwnerName: string,
+  target: {
+    owner: string;
+    name: string;
+    repoPath: string;
+    localPath: string | null;
+    cloneUrl: string | null;
+  },
 ): Promise<void> {
-  if (await hasClonedRepo(repoPath)) {
+  if (await hasClonedRepo(target.repoPath)) {
     await gitRepo.fetch();
     return;
   }
 
-  await git.clone(resolveCloneUrl(targetUrlOrOwnerName, owner, name), repoPath);
+  await git.clone(target.cloneUrl ?? resolveCloneUrl(target.owner, target.name), target.repoPath);
 }
 
 async function hasClonedRepo(repoPath: string): Promise<boolean> {
@@ -127,12 +179,61 @@ async function hasClonedRepo(repoPath: string): Promise<boolean> {
   }
 }
 
-function resolveCloneUrl(targetUrlOrOwnerName: string, owner: string, name: string): string {
-  if (targetUrlOrOwnerName.includes('github.com') || !targetUrlOrOwnerName.includes('/')) {
-    return targetUrlOrOwnerName;
+async function hasExistingDirectory(repoPath: string): Promise<boolean> {
+  return hasClonedRepo(repoPath);
+}
+
+async function resolveLocalRepositoryIdentity(localPath: string): Promise<{ owner: string; name: string }> {
+  const git = simpleGit(localPath);
+
+  try {
+    const remotes = await git.getRemotes(true);
+    const originRemote = remotes.find((remote) => remote.name === 'origin') ?? remotes[0];
+    const remoteUrl = originRemote?.refs.fetch ?? originRemote?.refs.push;
+
+    if (remoteUrl) {
+      const parsedRemote = parseGithubPath(remoteUrl);
+      if (parsedRemote) {
+        return parsedRemote;
+      }
+    }
+  } catch {
+    // Fall back to a local-only identity below.
   }
 
+  const baseName = path.basename(localPath).replace(/\.git$/, '') || 'unknown-repo';
+  return { owner: 'local', name: baseName };
+}
+
+function resolveCloneUrl(owner: string, name: string): string {
   return `https://github.com/${owner}/${name}.git`;
+}
+
+function parseGithubPath(input: string): { owner: string; name: string } | null {
+  const stripped = input.trim().replace(/\.git$/, '');
+  const normalized = stripped
+    .replace(/^https?:\/\//, '')
+    .replace(/^ssh:\/\//, '')
+    .replace(/^git@/, '');
+
+  if (!normalized.includes('github.com')) {
+    return null;
+  }
+
+  const githubPath = normalized
+    .replace(/^github\.com[/:]/, '')
+    .replace(/^github\.com$/, '');
+
+  if (!githubPath) {
+    return null;
+  }
+
+  const [owner, name] = githubPath.split('/');
+  if (!owner) {
+    return null;
+  }
+
+  return { owner, name: name || 'unknown-repo' };
 }
 
 async function getLatestCommitSha(gitRepo: ReturnType<typeof simpleGit>): Promise<string> {

--- a/codemod/generatePatch.ts
+++ b/codemod/generatePatch.ts
@@ -202,6 +202,7 @@ async function generateDirectImportPatch(repoPath: string, plan: DirectImportFix
     touchedFiles: [...touchedFiles.keys()],
     validationStatus: 'pending',
     validationSummary: 'Generated direct-import patch candidate. Validation has not run yet.',
+    fileSnapshots: [...touchedFiles.values()],
   };
 }
 

--- a/db/index.ts
+++ b/db/index.ts
@@ -201,6 +201,11 @@ export function createStatements(database: DatabaseType) {
       SET status = @status, updated_at = CURRENT_TIMESTAMP
       WHERE id = @id
     `),
+    updateRepositoryLocalPath: database.prepare(`
+      UPDATE repositories
+      SET local_path = @local_path, updated_at = CURRENT_TIMESTAMP
+      WHERE id = @id
+    `),
 
     // Scans
     addScan: database.prepare(`
@@ -317,6 +322,10 @@ export const getAllRepositories = {
 export const updateRepositoryStatus = {
   run: (...args: Parameters<ReturnType<typeof createStatements>['updateRepositoryStatus']['run']>) =>
     getStatements().updateRepositoryStatus.run(...args),
+};
+export const updateRepositoryLocalPath = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['updateRepositoryLocalPath']['run']>) =>
+    getStatements().updateRepositoryLocalPath.run(...args),
 };
 export const addScan = {
   run: (...args: Parameters<ReturnType<typeof createStatements>['addScan']['run']>) =>


### PR DESCRIPTION
Closes #24\n\n## Summary\n- detect existing local repositories before falling back to GitHub owner/name parsing\n- scan local checkouts directly instead of cloning them into worktrees\n- infer repo identity from the checkout's Git remote when available\n- persist the local path for scanned checkouts\n- keep GitHub URL and owner/name behavior unchanged\n\n## Verification\n- pnpm --dir /Users/justinedwards/git/typescript-cyclic-dependency-autofix exec vitest run --config /tmp/vitest-issue-24.config.cjs\n- pnpm --dir /Users/justinedwards/git/typescript-cyclic-dependency-autofix exec tsc --noEmit --pretty false --project /Users/justinedwards/git/typescript-cyclic-dependency-autofix/worktrees/issue-24/.tsconfig.issue24.json