### PR TITLE
Add real-repo smoke harness

### DIFF
--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SemanticAnalyzer } from './semantic.js';
 
 vi.mock('node:fs', () => {
@@ -12,11 +15,39 @@ vi.mock('node:fs', () => {
 
 describe('SemanticAnalyzer', () => {
   let analyzer: SemanticAnalyzer;
+  const tempDirs: string[] = [];
 
   beforeEach(() => {
     vi.resetAllMocks();
     analyzer = new SemanticAnalyzer('/dummy/repo');
   });
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fsPromises.rm(dir, { recursive: true, force: true })));
+  });
+
+  async function createRepo(files: Record<string, string>): Promise<string> {
+    const repoPath = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'semantic-analyzer-'));
+    tempDirs.push(repoPath);
+
+    for (const [relativePath, content] of Object.entries(files)) {
+      const absolutePath = path.join(repoPath, relativePath);
+      await fsPromises.mkdir(path.dirname(absolutePath), { recursive: true });
+      await fsPromises.writeFile(absolutePath, content, 'utf8');
+    }
+
+    return repoPath;
+  }
+
+  function mockRepoExists(repoPath: string, files: string[]): void {
+    const existingPaths = new Set(files.map((file) => path.join(repoPath, file)));
+    vi.mocked(fs.existsSync).mockImplementation((input) => existingPaths.has(String(input)));
+  }
+
+  function mockExistingPaths(paths: string[]): void {
+    const existingPaths = new Set(paths);
+    vi.mocked(fs.existsSync).mockImplementation((input) => existingPaths.has(String(input)));
+  }
 
   it('rejects cycles with more than 2 unique files', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'c.ts', 'a.ts']);
@@ -125,6 +156,354 @@ describe('SemanticAnalyzer', () => {
         },
       ],
     });
+  });
+
+  it('loads cycle files from disk when they are not already in the project', async () => {
+    const repoPath = await createRepo({
+      'a.ts': `
+        import type { BType } from './b';
+        export interface AType { b: BType; }
+      `,
+      'b.ts': `
+        import type { AType } from './a';
+        export interface BType { a: AType; }
+      `,
+    });
+
+    mockRepoExists(repoPath, ['a.ts', 'b.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
+
+    expect(result.classification).toBe('autofix_import_type');
+    expect(result.plan).toEqual({
+      kind: 'import_type',
+      imports: [
+        { sourceFile: 'a.ts', targetFile: 'b.ts' },
+        { sourceFile: 'b.ts', targetFile: 'a.ts' },
+      ],
+    });
+  });
+
+  it('falls back to manual review for side-effectful barrel modules', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        import './setup';
+        export { Foo } from './foo';
+      `,
+      'foo.ts': 'export const Foo = 1;',
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+      'setup.ts': 'export const setup = true;',
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'foo.ts', 'bar.ts', 'setup.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+    expect(result.reasons[0]).toMatch(/direct-import rewrite is not safe/);
+  });
+
+  it('falls back to manual review when barrel re-exports resolve ambiguously', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo, Bar } from './index';
+        export const appValue = Foo + Bar + 1;
+      `,
+      'index.ts': `
+        export { Foo } from './foo';
+        export { Bar } from './qux';
+      `,
+      'foo.ts': 'export const Foo = 1;',
+      'qux.ts': 'export const Bar = 2;',
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'foo.ts', 'qux.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects extract_shared when a candidate depends on another cycle file', async () => {
+    const repoPath = await createRepo({
+      'a.ts': `
+        import { helperB } from './b';
+        export const mainA = () => helperB();
+      `,
+      'b.ts': `
+        import { mainA } from './a';
+        export const helperB = () => mainA();
+      `,
+    });
+
+    mockRepoExists(repoPath, ['a.ts', 'b.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects direct import rewrites that point at external modules', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from 'external-package';
+      `,
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects direct import rewrites for default imports from a barrel', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import Foo from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from './foo';
+      `,
+      'foo.ts': 'export const Foo = 1;',
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'foo.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects direct import rewrites when the target resolves outside the repo', async () => {
+    const externalRepoPath = await createRepo({
+      'foo.ts': 'export const Foo = 1;',
+    });
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from '${path.join(externalRepoPath, 'foo')}';
+      `,
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockExistingPaths([
+      path.join(repoPath, 'app.ts'),
+      path.join(repoPath, 'index.ts'),
+      path.join(repoPath, 'bar.ts'),
+      path.join(externalRepoPath, 'foo.ts'),
+    ]);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects direct import rewrites when the target is the source file', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from './app';
+      `,
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects direct import rewrites when the target file still depends on the cycle', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from './foo';
+      `,
+      'foo.ts': `
+        import { appValue } from './app';
+        export const Foo = appValue + 1;
+      `,
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'foo.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects re-export loops while resolving barrel targets', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from './mid';
+      `,
+      'mid.ts': `
+        export { Foo } from './index';
+      `,
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'mid.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects barrel exports that resolve the same symbol to multiple targets', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from './foo';
+        export { Foo } from './bar';
+      `,
+      'foo.ts': 'export const Foo = 1;',
+      'bar.ts': 'export const Foo = 2;',
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'foo.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects namespace export barrels', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export * as all from './foo';
+      `,
+      'foo.ts': 'export const Foo = 1;',
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'foo.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects non-pure barrel modules with local statements', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        const sideEffect = 1;
+        export { Foo } from './foo';
+      `,
+      'foo.ts': 'export const Foo = 1;',
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'foo.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
+  });
+
+  it('rejects direct import rewrites when the target export is missing', async () => {
+    const repoPath = await createRepo({
+      'app.ts': `
+        import { Foo } from './index';
+        export const appValue = Foo + 1;
+      `,
+      'index.ts': `
+        export { Foo } from './missing';
+      `,
+      'bar.ts': `
+        import { appValue } from './app';
+        export const Bar = appValue + 1;
+      `,
+    });
+
+    mockRepoExists(repoPath, ['app.ts', 'index.ts', 'bar.ts']);
+
+    const diskAnalyzer = new SemanticAnalyzer(repoPath);
+    const result = diskAnalyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('suggest_manual');
   });
 
   it('identifies suggest_manual for non-type cycles with unsupported declarations', () => {

--- a/backend/server.test.ts
+++ b/backend/server.test.ts
@@ -246,6 +246,128 @@ describe('backend API', () => {
       expect(findings[0].cycle_path).toEqual(['a.ts', 'b.ts']);
     });
 
+    it('GET /api/repositories/:id/findings falls back cleanly for malformed stored JSON', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'broken',
+        name: 'json',
+        default_branch: null,
+        local_path: null,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'broken-json',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        participating_files: JSON.stringify({ a: 'b' }),
+        raw_payload: JSON.stringify({ ok: true }),
+      });
+      const candidateInfo = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        classification: 'autofix_extract_shared',
+        confidence: 0.9,
+        reasons: JSON.stringify(['safe']),
+      });
+      const patchInfo = stmts.addPatch.run({
+        fix_candidate_id: candidateInfo.lastInsertRowid,
+        patch_text: 'diff',
+        touched_files: JSON.stringify(['a.ts']),
+        validation_status: 'passed',
+        validation_summary: 'Validation passed.',
+      });
+
+      testDb.prepare('UPDATE cycles SET participating_files = ?, raw_payload = ? WHERE id = ?').run(
+        'not-json',
+        'also-not-json',
+        cycleInfo.lastInsertRowid,
+      );
+      testDb.prepare('UPDATE fix_candidates SET reasons = ? WHERE id = ?').run('still-not-json', candidateInfo.lastInsertRowid);
+      testDb
+        .prepare('UPDATE patches SET validation_status = NULL, validation_summary = NULL WHERE id = ?')
+        .run(patchInfo.lastInsertRowid);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/repositories/${repoInfo.lastInsertRowid}/findings`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const findings = response.json();
+      expect(findings[0].cycle_path).toEqual([]);
+      expect(findings[0].raw_payload).toBeNull();
+      expect(findings[0].reasons).toBeNull();
+      expect(findings[0].validation_status).toBe('pending');
+      expect(findings[0].review_status).toBe('pending');
+    });
+
+    it('GET /api/findings supports unclassified and pending filter modes', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'queue',
+        name: 'filters',
+        default_branch: null,
+        local_path: null,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'queue-filters',
+        status: 'completed',
+      });
+      stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'queued.ts -> queued.ts',
+        participating_files: JSON.stringify(['queued.ts', 'queued.ts']),
+        raw_payload: null,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/findings?repository_id=${repoInfo.lastInsertRowid}&classification=unclassified&validation_status=pending&review_status=pending`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const findings = response.json();
+      expect(findings).toHaveLength(1);
+      expect(findings[0].classification).toBeNull();
+      expect(findings[0].validation_status).toBe('pending');
+      expect(findings[0].review_status).toBe('pending');
+    });
+
+    it('GET /api/findings returns all findings when repository_id is not numeric', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'global',
+        name: 'queue',
+        default_branch: null,
+        local_path: null,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'global-1',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'global.ts -> global.ts',
+        participating_files: JSON.stringify(['global.ts', 'global.ts']),
+        raw_payload: null,
+      });
+      stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        classification: 'autofix_import_type',
+        confidence: 0.88,
+        reasons: null,
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/findings?repository_id=not-a-number' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toHaveLength(1);
+    });
+
     it('GET /api/findings filters by repository, classification, validation, review, cycle size, and search', async () => {
       const stmts = createStatements(testDb);
       const repoInfo = stmts.addRepository.run({

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { exportApprovedPatches } from './exportPatches.js';
 import { createProgram } from './index.js';
 import { scanRepository } from './scanner.js';
+import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
 
 const exportedDir = path.join(os.tmpdir(), 'patches');
 
@@ -17,6 +18,28 @@ vi.mock('./exportPatches.js', () => ({
     exportedCount: 2,
     files: [path.join(os.tmpdir(), 'patches', 'a.patch'), path.join(os.tmpdir(), 'patches', 'b.patch')],
   }),
+}));
+
+vi.mock('./smoke.js', () => ({
+  loadSmokeFixtures: vi.fn().mockResolvedValue([{ name: 'fixture', target: '/tmp/repo' }]),
+  runSmokeSuite: vi.fn().mockResolvedValue({
+    passed: 1,
+    failed: 0,
+    results: [
+      {
+        name: 'fixture',
+        target: '/tmp/repo',
+        status: 'passed',
+        cyclesFound: 1,
+        candidateCount: 1,
+        patchCount: 1,
+        classifications: {
+          unsupported: 1,
+        },
+      },
+    ],
+  }),
+  formatSmokeSuiteResult: vi.fn().mockReturnValue('Smoke suite complete: 1 passed, 0 failed.'),
 }));
 
 describe('CLI', () => {
@@ -91,12 +114,77 @@ describe('CLI', () => {
     consoleSpy.mockRestore();
   });
 
-  it('has all four subcommands registered', () => {
+  it('smoke command loads fixtures and runs the suite', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'smoke', './smoke.fixtures.json']);
+
+    expect(consoleSpy).toHaveBeenCalledWith('Running smoke suite from ./smoke.fixtures.json');
+    expect(vi.mocked(loadSmokeFixtures)).toHaveBeenCalledWith('./smoke.fixtures.json');
+    expect(vi.mocked(runSmokeSuite)).toHaveBeenCalledWith([{ name: 'fixture', target: '/tmp/repo' }]);
+    expect(vi.mocked(formatSmokeSuiteResult)).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('smoke command exits when the suite reports failures', async () => {
+    vi.mocked(runSmokeSuite).mockResolvedValueOnce({
+      passed: 0,
+      failed: 1,
+      results: [
+        {
+          name: 'fixture',
+          target: '/tmp/repo',
+          status: 'failed',
+          stage: 'scan',
+          message: 'Scan failed',
+        },
+      ],
+    });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'smoke']);
+
+    expect(consoleSpy).toHaveBeenCalledWith('Running smoke suite from ./smoke.fixtures.json');
+    expect(vi.mocked(formatSmokeSuiteResult)).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('smoke command reports fixture loading errors and exits', async () => {
+    vi.mocked(loadSmokeFixtures).mockRejectedValueOnce(new Error('Fixture file is invalid'));
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'smoke']);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to run smoke suite from ./smoke.fixtures.json:',
+      expect.any(Error),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('has all five subcommands registered', () => {
     const program = createProgram();
     const commandNames = program.commands.map((cmd) => cmd.name());
     expect(commandNames).toContain('scan');
     expect(commandNames).toContain('scan:all');
     expect(commandNames).toContain('retry:failed');
     expect(commandNames).toContain('export:patches');
+    expect(commandNames).toContain('smoke');
   });
 });

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { exportApprovedPatches } from './exportPatches.js';
 import { scanRepository } from './scanner.js';
+import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -42,6 +43,25 @@ export function createProgram(): Command {
     .action(async (outputDir?: string) => {
       const result = await exportApprovedPatches(outputDir);
       console.log(`Exported ${result.exportedCount} patch file(s) to ${result.outputDir}`);
+    });
+
+  program
+    .command('smoke [fixturesFile]')
+    .description('Run the smoke suite against a fixture list of real repositories')
+    .action(async (fixturesFile = './smoke.fixtures.json') => {
+      console.log(`Running smoke suite from ${fixturesFile}`);
+      try {
+        const fixtures = await loadSmokeFixtures(fixturesFile);
+        const result = await runSmokeSuite(fixtures);
+        console.log(formatSmokeSuiteResult(result));
+
+        if (result.failed > 0) {
+          process.exit(1);
+        }
+      } catch (error) {
+        console.error(`Failed to run smoke suite from ${fixturesFile}:`, error);
+        process.exit(1);
+      }
     });
 
   return program;

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -125,6 +125,20 @@ describe('Scanner Worker', () => {
     expect(repo).toBeDefined();
   });
 
+  it('handles github.com urls without an owner segment', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    await scanRepository('https://github.com//repo');
+    const repo = dbModule.getRepositoryByOwnerName.get('', 'repo') as { status: string };
+    expect(repo).toBeDefined();
+  });
+
+  it('falls back to unknown-repo when a github URL omits the repository name', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    await scanRepository('https://github.com/org/');
+    const repo = dbModule.getRepositoryByOwnerName.get('org', 'unknown-repo') as { status: string };
+    expect(repo).toBeDefined();
+  });
+
   it('handles bare github.com url', async () => {
     vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
     await scanRepository('github.com');
@@ -205,6 +219,66 @@ describe('Scanner Worker', () => {
 
     const repo = dbModule.getRepositoryByOwnerName.get('openclaw', 'openclaw') as { local_path: string };
     expect(repo.local_path).toBe(path.resolve(absolutePath));
+  });
+
+  it('falls back to a local-only identity when the checkout has no remotes', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true } as never);
+    mockGit.getRemotes.mockResolvedValue([]);
+
+    const result = await scanRepository('../plain-local-repo');
+
+    expect(result.repoPath).toBe(path.resolve('../plain-local-repo'));
+    const repo = dbModule.getRepositoryByOwnerName.get('local', 'plain-local-repo') as { local_path: string };
+    expect(repo.local_path).toBe(path.resolve('../plain-local-repo'));
+  });
+
+  it('falls back to a local-only identity when remotes cannot be read', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true } as never);
+    mockGit.getRemotes.mockRejectedValue(new Error('No remotes configured'));
+
+    const result = await scanRepository('../plain-local-repo-error');
+
+    expect(result.repoPath).toBe(path.resolve('../plain-local-repo-error'));
+    const repo = dbModule.getRepositoryByOwnerName.get('local', 'plain-local-repo-error') as { local_path: string };
+    expect(repo.local_path).toBe(path.resolve('../plain-local-repo-error'));
+  });
+
+  it('updates an existing repository record with a newly discovered local path', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true } as never);
+    mockGit.getRemotes.mockResolvedValue([
+      {
+        name: 'origin',
+        refs: {
+          fetch: 'git@github.com:langgenius/dify.git',
+          push: 'git@github.com:langgenius/dify.git',
+        },
+      },
+    ]);
+
+    dbModule.addRepository.run({
+      owner: 'langgenius',
+      name: 'dify',
+      default_branch: 'main',
+      local_path: null,
+    });
+
+    const result = await scanRepository('../openclaw');
+
+    expect(result.repoPath).toBe(path.resolve('../openclaw'));
+    const repo = dbModule.getRepositoryByOwnerName.get('langgenius', 'dify') as { local_path: string };
+    expect(repo.local_path).toBe(path.resolve('../openclaw'));
+  });
+
+  it('falls back to an unknown commit SHA when git log fails', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    mockGit.clone.mockResolvedValue(undefined);
+    mockGit.log.mockResolvedValue({ latest: null } as never);
+
+    const result = await scanRepository('justin/repo');
+
+    expect(result.cyclesFound).toBe(1);
+    const scan = dbModule.getScan.get(result.scanId) as { commit_sha: string };
+    expect(scan.commit_sha).toBe('unknown');
   });
 
   it('handles bare names', async () => {

--- a/cli/smoke.test.ts
+++ b/cli/smoke.test.ts
@@ -1,0 +1,407 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as dbModule from '../db/index.js';
+import { scanRepository } from './scanner.js';
+import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
+
+vi.mock('./scanner.js', () => ({
+  scanRepository: vi.fn(),
+}));
+
+vi.mock('../db/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../db/index.js')>('../db/index.js');
+  return {
+    ...actual,
+    getCyclesByScanId: {
+      all: vi.fn(),
+    },
+    getFixCandidatesByCycleId: {
+      all: vi.fn(),
+    },
+    getPatchesByFixCandidateId: {
+      all: vi.fn(),
+    },
+  };
+});
+
+describe('smoke suite', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function mockMetrics(
+    cycles: Array<{ id: number }>,
+    candidatesByCycle: Record<number, Array<{ id: number; classification: string }>>,
+    patchesByCandidate: Record<number, Array<{ id: number }>>,
+  ): void {
+    vi.mocked(dbModule.getCyclesByScanId.all).mockImplementation((scanId: number) => (scanId === 1 ? cycles : []));
+    vi.mocked(dbModule.getFixCandidatesByCycleId.all).mockImplementation((cycleId: number) => candidatesByCycle[cycleId] ?? []);
+    vi.mocked(dbModule.getPatchesByFixCandidateId.all).mockImplementation((candidateId: number) => patchesByCandidate[candidateId] ?? []);
+  }
+
+  it('loads smoke fixtures from JSON', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+    const fixturePath = path.join(tmpDir, 'fixtures.json');
+    await fs.writeFile(
+      fixturePath,
+      JSON.stringify([
+        {
+          name: 'openclaw',
+          target: '../openclaw',
+          expectations: {
+            minCycles: 1,
+          },
+        },
+      ]),
+      'utf8',
+    );
+
+    const fixtures = await loadSmokeFixtures(fixturePath);
+    expect(fixtures).toHaveLength(1);
+    expect(fixtures[0]).toMatchObject({
+      name: 'openclaw',
+      target: '../openclaw',
+      expectations: {
+        minCycles: 1,
+      },
+    });
+  });
+
+  it('loads smoke fixtures without expectations', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+    const fixturePath = path.join(tmpDir, 'fixtures.json');
+    await fs.writeFile(
+      fixturePath,
+      JSON.stringify([
+        {
+          name: 'jan',
+          target: 'https://github.com/janhq/jan.git',
+        },
+      ]),
+      'utf8',
+    );
+
+    const fixtures = await loadSmokeFixtures(fixturePath);
+    expect(fixtures[0]).toMatchObject({
+      name: 'jan',
+      target: 'https://github.com/janhq/jan.git',
+    });
+    expect(fixtures[0].expectations).toBeUndefined();
+  });
+
+  it('rejects fixture files that are not arrays', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+    const fixturePath = path.join(tmpDir, 'fixtures.json');
+    await fs.writeFile(fixturePath, JSON.stringify({ name: 'invalid' }), 'utf8');
+
+    await expect(loadSmokeFixtures(fixturePath)).rejects.toThrow('must contain an array');
+  });
+
+  it('rejects fixture entries that are not objects', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+    const fixturePath = path.join(tmpDir, 'fixtures.json');
+    await fs.writeFile(fixturePath, JSON.stringify([null]), 'utf8');
+
+    await expect(loadSmokeFixtures(fixturePath)).rejects.toThrow('must be an object');
+  });
+
+  it('rejects fixture entries without name and target fields', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+    const fixturePath = path.join(tmpDir, 'fixtures.json');
+    await fs.writeFile(fixturePath, JSON.stringify([{ name: 'missing-target' }]), 'utf8');
+
+    await expect(loadSmokeFixtures(fixturePath)).rejects.toThrow('must include string name and target fields');
+  });
+
+  it('rejects invalid expectation blocks', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+    const fixturePath = path.join(tmpDir, 'fixtures.json');
+    await fs.writeFile(
+      fixturePath,
+      JSON.stringify([
+        {
+          name: 'broken',
+          target: '../broken',
+          expectations: 42,
+        },
+      ]),
+      'utf8',
+    );
+
+    await expect(loadSmokeFixtures(fixturePath)).rejects.toThrow('invalid expectations block');
+  });
+
+  it('rejects invalid minClassifications blocks', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+    const fixturePath = path.join(tmpDir, 'fixtures.json');
+    await fs.writeFile(
+      fixturePath,
+      JSON.stringify([
+        {
+          name: 'broken',
+          target: '../broken',
+          expectations: {
+            minClassifications: 42,
+          },
+        },
+      ]),
+      'utf8',
+    );
+
+    await expect(loadSmokeFixtures(fixturePath)).rejects.toThrow('invalid minClassifications');
+  });
+
+  it('reports pass and expectation failure results', async () => {
+    vi.mocked(scanRepository).mockResolvedValueOnce({
+      scanId: 1,
+      repoPath: '/tmp/repo-one',
+      cyclesFound: 2,
+    });
+    vi.mocked(scanRepository).mockRejectedValueOnce(new Error('Validation failed: the original cycle is still present.'));
+
+    mockMetrics(
+      [{ id: 11 }, { id: 12 }],
+      {
+        11: [
+          { id: 111, classification: 'autofix_extract_shared' },
+          { id: 112, classification: 'unsupported' },
+        ],
+        12: [{ id: 121, classification: 'autofix_extract_shared' }],
+      },
+      {
+        111: [{ id: 1 }],
+      },
+    );
+
+    const report = await runSmokeSuite(
+      [
+        {
+          name: 'repo-one',
+          target: '../repo-one',
+          expectations: {
+            minCycles: 2,
+            minClassifications: {
+              autofix_extract_shared: 2,
+            },
+            minPatches: 1,
+          },
+        },
+        {
+          name: 'repo-two',
+          target: 'https://github.com/org/repo-two.git',
+        },
+      ],
+      './worktrees/smoke',
+    );
+
+    expect(report.passed).toBe(1);
+    expect(report.failed).toBe(1);
+    expect(report.results[0]).toMatchObject({
+      name: 'repo-one',
+      status: 'passed',
+      cyclesFound: 2,
+      candidateCount: 3,
+      patchCount: 1,
+    });
+    expect(report.results[1]).toMatchObject({
+      name: 'repo-two',
+      status: 'failed',
+      stage: 'validation',
+      message: 'Validation failed: the original cycle is still present.',
+    });
+    expect(formatSmokeSuiteResult(report)).toContain('PASS repo-one');
+  });
+
+  it('passes fixtures without explicit expectations', async () => {
+    vi.mocked(scanRepository).mockResolvedValueOnce({
+      scanId: 1,
+      repoPath: '/tmp/repo-three',
+      cyclesFound: 1,
+    });
+    mockMetrics([{ id: 11 }], { 11: [{ id: 111, classification: 'unsupported' }] }, { 111: [] });
+
+    const report = await runSmokeSuite([
+      {
+        name: 'repo-three',
+        target: '../repo-three',
+      },
+    ]);
+
+    expect(report.results[0]).toMatchObject({
+      status: 'passed',
+      scanId: 1,
+      cyclesFound: 1,
+      candidateCount: 1,
+      patchCount: 0,
+    });
+  });
+
+  it.each([
+    {
+      name: 'exact cycle expectations',
+      expectations: { exactCycles: 2 },
+      cycles: [{ id: 11 }],
+      candidatesByCycle: { 11: [] },
+      patchesByCandidate: {},
+      messageFragment: 'Expected exactly 2 cycles',
+    },
+    {
+      name: 'minimum cycle expectations',
+      expectations: { minCycles: 1 },
+      cycles: [],
+      candidatesByCycle: {},
+      patchesByCandidate: {},
+      messageFragment: 'Expected at least 1 cycles',
+    },
+    {
+      name: 'maximum cycle expectations',
+      expectations: { maxCycles: 1 },
+      cycles: [{ id: 11 }, { id: 12 }],
+      candidatesByCycle: { 11: [], 12: [] },
+      patchesByCandidate: {},
+      messageFragment: 'Expected at most 1 cycles',
+    },
+    {
+      name: 'classification expectations',
+      expectations: { minClassifications: { autofix_extract_shared: 1 } },
+      cycles: [{ id: 11 }],
+      candidatesByCycle: { 11: [{ id: 111, classification: 'unsupported' }] },
+      patchesByCandidate: { 111: [] },
+      messageFragment: 'Expected at least 1 autofix_extract_shared candidates',
+    },
+    {
+      name: 'patch expectations',
+      expectations: { minPatches: 1 },
+      cycles: [{ id: 11 }],
+      candidatesByCycle: { 11: [{ id: 111, classification: 'autofix_extract_shared' }] },
+      patchesByCandidate: { 111: [] },
+      messageFragment: 'Expected at least 1 generated patches',
+    },
+  ])('reports $name', async ({ expectations, cycles, candidatesByCycle, patchesByCandidate, messageFragment }) => {
+    vi.mocked(scanRepository).mockResolvedValueOnce({
+      scanId: 1,
+      repoPath: '/tmp/repo-four',
+      cyclesFound: cycles.length,
+    });
+    mockMetrics(cycles, candidatesByCycle, patchesByCandidate);
+
+    const report = await runSmokeSuite([
+      {
+        name: 'repo-four',
+        target: '../repo-four',
+        expectations,
+      },
+    ]);
+
+    expect(report.results[0]).toMatchObject({
+      status: 'failed',
+      stage: 'expectation',
+    });
+    expect(report.results[0].message).toContain(messageFragment);
+  });
+
+  it('classifies clone failures as clone stage failures', async () => {
+    vi.mocked(scanRepository).mockRejectedValueOnce(new Error('Clone error'));
+
+    const report = await runSmokeSuite([
+      {
+        name: 'dify',
+        target: 'https://github.com/langgenius/dify.git',
+      },
+    ]);
+
+    expect(report.results[0]).toMatchObject({
+      status: 'failed',
+      stage: 'clone',
+      message: 'Clone error',
+    });
+  });
+
+  it('classifies generic failures as scan-stage failures', async () => {
+    vi.mocked(scanRepository).mockRejectedValueOnce(new Error('Something broke during scan'));
+
+    const report = await runSmokeSuite([
+      {
+        name: 'repo-five',
+        target: '../repo-five',
+      },
+    ]);
+
+    expect(report.results[0]).toMatchObject({
+      status: 'failed',
+      stage: 'scan',
+    });
+    expect(report.results[0].message).toContain('Something broke during scan');
+  });
+
+  it('treats non-error scan failures as unknown smoke suite failures', async () => {
+    vi.mocked(scanRepository).mockRejectedValueOnce({ code: 1 });
+
+    const report = await runSmokeSuite([
+      {
+        name: 'repo-six',
+        target: '../repo-six',
+      },
+    ]);
+
+    expect(report.results[0]).toMatchObject({
+      status: 'failed',
+      stage: 'scan',
+      message: 'Unknown smoke suite failure',
+    });
+  });
+
+  it('formats passed results without classification counts', () => {
+    const output = formatSmokeSuiteResult({
+      passed: 1,
+      failed: 0,
+      results: [
+        {
+          name: 'repo-six',
+          target: '../repo-six',
+          status: 'passed',
+          cyclesFound: 0,
+          candidateCount: 0,
+          patchCount: 0,
+        },
+      ],
+    });
+
+    expect(output).toContain('PASS repo-six: 0 cycles, 0 candidates, 0 patches');
+    expect(output).not.toContain('(');
+  });
+
+  it('formats passed results with omitted counts as zero', () => {
+    const output = formatSmokeSuiteResult({
+      passed: 1,
+      failed: 0,
+      results: [
+        {
+          name: 'repo-seven',
+          target: '../repo-seven',
+          status: 'passed',
+        } as SmokeFixtureResult,
+      ],
+    });
+
+    expect(output).toContain('PASS repo-seven: 0 cycles, 0 candidates, 0 patches');
+  });
+
+  it('formats failed results without a stage as scan failures', () => {
+    const output = formatSmokeSuiteResult({
+      passed: 0,
+      failed: 1,
+      results: [
+        {
+          name: 'repo-eight',
+          target: '../repo-eight',
+          status: 'failed',
+        } as SmokeFixtureResult,
+      ],
+    });
+
+    expect(output).toContain('FAIL repo-eight [scan]: Unknown failure');
+  });
+});

--- a/cli/smoke.ts
+++ b/cli/smoke.ts
@@ -1,0 +1,272 @@
+import fs from 'node:fs/promises';
+import { scanRepository } from './scanner.js';
+import {
+  getCyclesByScanId,
+  getFixCandidatesByCycleId,
+  getPatchesByFixCandidateId,
+} from '../db/index.js';
+
+export interface SmokeFixtureExpectations {
+  exactCycles?: number;
+  minCycles?: number;
+  maxCycles?: number;
+  minClassifications?: Record<string, number>;
+  minPatches?: number;
+}
+
+export interface SmokeFixture {
+  name: string;
+  target: string;
+  expectations?: SmokeFixtureExpectations;
+}
+
+export type SmokeStage = 'clone' | 'scan' | 'validation' | 'expectation';
+
+export interface SmokeFixtureResult {
+  name: string;
+  target: string;
+  status: 'passed' | 'failed';
+  stage?: SmokeStage;
+  message?: string;
+  scanId?: number;
+  cyclesFound?: number;
+  candidateCount?: number;
+  patchCount?: number;
+  classifications?: Record<string, number>;
+}
+
+export interface SmokeSuiteResult {
+  results: SmokeFixtureResult[];
+  passed: number;
+  failed: number;
+}
+
+interface SmokeMetrics {
+  cyclesFound: number;
+  candidateCount: number;
+  patchCount: number;
+  classifications: Record<string, number>;
+}
+
+export async function loadSmokeFixtures(fixturesPath: string): Promise<SmokeFixture[]> {
+  const contents = await fs.readFile(fixturesPath, 'utf8');
+  const parsed = JSON.parse(contents) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Smoke fixture file must contain an array: ${fixturesPath}`);
+  }
+
+  return parsed.map((item, index) => normalizeSmokeFixture(item, fixturesPath, index));
+}
+
+export async function runSmokeSuite(fixtures: SmokeFixture[], worktreesDir = './worktrees/smoke'): Promise<SmokeSuiteResult> {
+  const results: SmokeFixtureResult[] = [];
+
+  for (const fixture of fixtures) {
+    results.push(await runSmokeFixture(fixture, worktreesDir));
+  }
+
+  return {
+    results,
+    passed: results.filter((result) => result.status === 'passed').length,
+    failed: results.filter((result) => result.status === 'failed').length,
+  };
+}
+
+export function formatSmokeSuiteResult(result: SmokeSuiteResult): string {
+  const lines = result.results.map((fixtureResult) => {
+    if (fixtureResult.status === 'passed') {
+      const summary = [
+        `${fixtureResult.cyclesFound ?? 0} cycles`,
+        `${fixtureResult.candidateCount ?? 0} candidates`,
+        `${fixtureResult.patchCount ?? 0} patches`,
+      ].join(', ');
+      const classifications = formatClassificationCounts(fixtureResult.classifications);
+      return `PASS ${fixtureResult.name}: ${summary}${classifications ? ` (${classifications})` : ''}`;
+    }
+
+    return `FAIL ${fixtureResult.name} [${fixtureResult.stage ?? 'scan'}]: ${fixtureResult.message ?? 'Unknown failure'}`;
+  });
+
+  lines.push(`Smoke suite complete: ${result.passed} passed, ${result.failed} failed.`);
+  return lines.join('\n');
+}
+
+async function runSmokeFixture(fixture: SmokeFixture, worktreesDir: string): Promise<SmokeFixtureResult> {
+  try {
+    const scanResult = await scanRepository(fixture.target, worktreesDir);
+    const metrics = collectSmokeMetrics(scanResult.scanId);
+    const failureMessage = evaluateSmokeExpectations(fixture.expectations, metrics);
+
+    if (failureMessage) {
+      return {
+        name: fixture.name,
+        target: fixture.target,
+        status: 'failed',
+        stage: 'expectation',
+        message: failureMessage,
+        scanId: scanResult.scanId,
+        ...metrics,
+      };
+    }
+
+    return {
+      name: fixture.name,
+      target: fixture.target,
+      status: 'passed',
+      scanId: scanResult.scanId,
+      ...metrics,
+    };
+  } catch (error) {
+    return {
+      name: fixture.name,
+      target: fixture.target,
+      status: 'failed',
+      stage: inferFailureStage(error),
+      message: getErrorMessage(error),
+    };
+  }
+}
+
+function collectSmokeMetrics(scanId: number): SmokeMetrics {
+  const cycles = getCyclesByScanId.all(scanId) as Array<{ id: number }>;
+  const classifications: Record<string, number> = {};
+  let candidateCount = 0;
+  let patchCount = 0;
+
+  for (const cycle of cycles) {
+    const candidates = getFixCandidatesByCycleId.all(cycle.id) as Array<{ id: number; classification: string }>;
+    candidateCount += candidates.length;
+
+    for (const candidate of candidates) {
+      classifications[candidate.classification] = (classifications[candidate.classification] ?? 0) + 1;
+      const patches = getPatchesByFixCandidateId.all(candidate.id) as Array<unknown>;
+      patchCount += patches.length;
+    }
+  }
+
+  return {
+    cyclesFound: cycles.length,
+    candidateCount,
+    patchCount,
+    classifications,
+  };
+}
+
+function evaluateSmokeExpectations(
+  expectations: SmokeFixtureExpectations | undefined,
+  metrics: SmokeMetrics,
+): string | null {
+  if (!expectations) {
+    return null;
+  }
+
+  if (typeof expectations.exactCycles === 'number' && metrics.cyclesFound !== expectations.exactCycles) {
+    return `Expected exactly ${expectations.exactCycles} cycles, found ${metrics.cyclesFound}.`;
+  }
+
+  if (typeof expectations.minCycles === 'number' && metrics.cyclesFound < expectations.minCycles) {
+    return `Expected at least ${expectations.minCycles} cycles, found ${metrics.cyclesFound}.`;
+  }
+
+  if (typeof expectations.maxCycles === 'number' && metrics.cyclesFound > expectations.maxCycles) {
+    return `Expected at most ${expectations.maxCycles} cycles, found ${metrics.cyclesFound}.`;
+  }
+
+  if (expectations.minClassifications) {
+    for (const [classification, minimum] of Object.entries(expectations.minClassifications)) {
+      const found = metrics.classifications[classification] ?? 0;
+      if (found < minimum) {
+        return `Expected at least ${minimum} ${classification} candidates, found ${found}.`;
+      }
+    }
+  }
+
+  if (typeof expectations.minPatches === 'number' && metrics.patchCount < expectations.minPatches) {
+    return `Expected at least ${expectations.minPatches} generated patches, found ${metrics.patchCount}.`;
+  }
+
+  return null;
+}
+
+function inferFailureStage(error: unknown): SmokeStage {
+  const message = getErrorMessage(error).toLowerCase();
+
+  if (message.includes('validation') || message.includes('typescript') || message.includes('tsc')) {
+    return 'validation';
+  }
+
+  if (message.includes('clone') || message.includes('fetch') || message.includes('download')) {
+    return 'clone';
+  }
+
+  return 'scan';
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return typeof error === 'string' ? error : 'Unknown smoke suite failure';
+}
+
+function normalizeSmokeFixture(item: unknown, fixturesPath: string, index: number): SmokeFixture {
+  if (!item || typeof item !== 'object') {
+    throw new Error(`Smoke fixture ${index + 1} in ${fixturesPath} must be an object.`);
+  }
+
+  const fixture = item as Record<string, unknown>;
+  if (typeof fixture.name !== 'string' || typeof fixture.target !== 'string') {
+    throw new Error(`Smoke fixture ${index + 1} in ${fixturesPath} must include string name and target fields.`);
+  }
+
+  return {
+    name: fixture.name,
+    target: fixture.target,
+    expectations: normalizeExpectations(fixture.expectations, fixturesPath, index),
+  };
+}
+
+function normalizeExpectations(
+  value: unknown,
+  fixturesPath: string,
+  index: number,
+): SmokeFixtureExpectations | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== 'object') {
+    throw new Error(`Smoke fixture ${index + 1} in ${fixturesPath} has an invalid expectations block.`);
+  }
+
+  const expectations = value as Record<string, unknown>;
+  const minClassifications = expectations.minClassifications;
+  if (minClassifications !== undefined && (!minClassifications || typeof minClassifications !== 'object')) {
+    throw new Error(`Smoke fixture ${index + 1} in ${fixturesPath} has invalid minClassifications.`);
+  }
+
+  return {
+    exactCycles: asOptionalNumber(expectations.exactCycles),
+    minCycles: asOptionalNumber(expectations.minCycles),
+    maxCycles: asOptionalNumber(expectations.maxCycles),
+    minClassifications: minClassifications as Record<string, number> | undefined,
+    minPatches: asOptionalNumber(expectations.minPatches),
+  };
+}
+
+function asOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function formatClassificationCounts(classifications: Record<string, number> | undefined): string {
+  if (!classifications || Object.keys(classifications).length === 0) {
+    return '';
+  }
+
+  return Object.entries(classifications)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([classification, count]) => `${classification}=${count}`)
+    .join(', ');
+}

--- a/cli/validation.test.ts
+++ b/cli/validation.test.ts
@@ -95,4 +95,121 @@ describe('validateGeneratedPatch', () => {
     expect(result.status).toBe('failed');
     expect(result.summary).toContain('original cycle is still present');
   });
+
+  it('passes when the rewrite removes the cycle and TypeScript validates cleanly', async () => {
+    const repoPath = await createRepo({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          target: 'es2022',
+          module: 'esnext',
+          noEmit: true,
+        },
+        include: ['*.ts'],
+      }),
+      'a.ts': "export const value = 1;\n",
+    });
+
+    vi.spyOn(analyzerModule, 'analyzeRepository').mockResolvedValue([]);
+
+    const generatedPatch: GeneratedPatch = {
+      patchText: 'diff',
+      touchedFiles: ['a.ts'],
+      validationStatus: 'pending',
+      validationSummary: 'pending',
+      fileSnapshots: [],
+    };
+
+    const result = await validateGeneratedPatch(
+      repoPath,
+      { type: 'circular', path: ['a.ts', 'b.ts', 'a.ts'] },
+      generatedPatch,
+    );
+
+    expect(result.status).toBe('passed');
+    expect(result.summary).toContain('Remaining cycles detected: 0');
+  });
+
+  it('fails when TypeScript validation rejects the rewritten snapshot', async () => {
+    const repoPath = await createRepo({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          target: 'es2022',
+          module: 'esnext',
+          noEmit: true,
+        },
+        include: ['*.ts'],
+      }),
+      'a.ts': "export const value: string = 'ok';\n",
+    });
+
+    vi.spyOn(analyzerModule, 'analyzeRepository').mockResolvedValue([]);
+
+    const generatedPatch: GeneratedPatch = {
+      patchText: 'diff',
+      touchedFiles: ['a.ts'],
+      validationStatus: 'pending',
+      validationSummary: 'pending',
+      fileSnapshots: [
+        {
+          path: 'a.ts',
+          before: "export const value: string = 'ok';\n",
+          after: 'export const value: string = 123;\n',
+        },
+      ],
+    };
+
+    const result = await validateGeneratedPatch(
+      repoPath,
+      { type: 'circular', path: ['a.ts', 'b.ts', 'a.ts'] },
+      generatedPatch,
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.summary).toContain('TypeScript check did not pass');
+  });
+
+  it('falls back to the spawned process error when the compiler entrypoint cannot be resolved', async () => {
+    vi.resetModules();
+    vi.doMock('../analyzer/analyzer.js', () => ({
+      analyzeRepository: vi.fn().mockResolvedValue([]),
+    }));
+    vi.doMock('node:module', () => ({
+      createRequire: () => ({
+        resolve: () => path.join(os.tmpdir(), 'missing-typescript-tsc.js'),
+      }),
+    }));
+
+    const { validateGeneratedPatch: isolatedValidateGeneratedPatch } = await import('./validation.js');
+    const repoPath = await createRepo({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          target: 'es2022',
+          module: 'esnext',
+          noEmit: true,
+        },
+        include: ['*.ts'],
+      }),
+      'a.ts': "export const value = 1;\n",
+    });
+
+    const generatedPatch: GeneratedPatch = {
+      patchText: 'diff',
+      touchedFiles: ['a.ts'],
+      validationStatus: 'pending',
+      validationSummary: 'pending',
+      fileSnapshots: [],
+    };
+
+    const result = await isolatedValidateGeneratedPatch(
+      repoPath,
+      { type: 'circular', path: ['a.ts', 'b.ts', 'a.ts'] },
+      generatedPatch,
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.summary).toContain('TypeScript check did not pass');
+  });
 });

--- a/cli/validation.ts
+++ b/cli/validation.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
@@ -78,7 +79,8 @@ async function runTypecheckIfPresent(repoPath: string): Promise<{ ok: true } | {
     return { ok: true };
   }
 
-  const tscEntrypoint = path.join(process.cwd(), 'node_modules', 'typescript', 'bin', 'tsc');
+  const require = createRequire(import.meta.url);
+  const tscEntrypoint = require.resolve('typescript/bin/tsc');
 
   try {
     await execFileAsync(process.execPath, [tscEntrypoint, '--noEmit', '--project', tsconfigPath], {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "scan:all": "tsx cli/index.ts scan:all",
     "retry:failed": "tsx cli/index.ts retry:failed",
     "export:patches": "tsx cli/index.ts export:patches",
+    "smoke": "tsx cli/index.ts smoke",
     "prepare": "husky"
   },
   "dependencies": {

--- a/smoke.fixtures.json
+++ b/smoke.fixtures.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "openclaw",
+    "target": "../openclaw",
+    "expectations": {
+      "minCycles": 1,
+      "minClassifications": {
+        "unsupported": 1
+      }
+    }
+  },
+  {
+    "name": "dify",
+    "target": "https://github.com/langgenius/dify.git",
+    "expectations": {
+      "minCycles": 1,
+      "minClassifications": {
+        "autofix_extract_shared": 1
+      },
+      "minPatches": 1
+    }
+  },
+  {
+    "name": "jan",
+    "target": "https://github.com/janhq/jan.git",
+    "expectations": {
+      "maxCycles": 0
+    }
+  }
+]


### PR DESCRIPTION
Closes #22\n\nAdds a real-repo smoke harness for analyzer and codemod validation, with fixture loading, CLI wiring, sample fixtures, and tests. Coverage is green with the repo thresholds.