### PR TITLE
Persist scan provenance and patch snapshots for replay

### DIFF
--- a/backend/server.test.ts
+++ b/backend/server.test.ts
@@ -442,6 +442,90 @@ describe('backend API', () => {
       expect(detail.review_status).toBe('approved');
     });
 
+    it('GET /api/repositories/:id/cycles/:cycleId returns replay provenance when available', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'replay-detail',
+        name: 'repo',
+        default_branch: 'main',
+        local_path: '/tmp/replay-detail',
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'replay1',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'x->y',
+        participating_files: JSON.stringify(['x.ts', 'y.ts']),
+        raw_payload: JSON.stringify({ violations: [] }),
+      });
+      const fcInfo = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        classification: 'autofix_extract_shared',
+        confidence: 0.91,
+        reasons: JSON.stringify(['safe']),
+      });
+      const patchInfo = stmts.addPatch.run({
+        fix_candidate_id: fcInfo.lastInsertRowid,
+        patch_text: '--- a/x.ts\n+++ b/x.ts',
+        touched_files: '["x.ts"]',
+        validation_status: 'passed',
+        validation_summary: 'clean',
+      });
+      stmts.addPatchReplay.run({
+        patch_id: patchInfo.lastInsertRowid,
+        scan_id: scanInfo.lastInsertRowid,
+        source_target: '/tmp/replay-detail',
+        commit_sha: 'replay1',
+        replay_bundle: JSON.stringify({
+          scan_id: scanInfo.lastInsertRowid,
+          source_target: '/tmp/replay-detail',
+          commit_sha: 'replay1',
+          repository: {
+            owner: 'replay-detail',
+            name: 'repo',
+            default_branch: 'main',
+            local_path: '/tmp/replay-detail',
+          },
+          cycle: {
+            path: ['x.ts', 'y.ts'],
+            normalized_path: 'x -> y',
+            raw_payload: { violations: [] },
+          },
+          candidate: {
+            classification: 'autofix_extract_shared',
+            confidence: 0.91,
+            reasons: ['safe'],
+          },
+          validation: {
+            status: 'passed',
+            summary: 'clean',
+          },
+          file_snapshots: [
+            {
+              path: 'x.ts',
+              before: 'before',
+              after: 'after',
+            },
+          ],
+          patch_text: '--- a/x.ts\n+++ b/x.ts',
+        }),
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/repositories/${repoInfo.lastInsertRowid}/cycles/${cycleInfo.lastInsertRowid}`,
+      });
+      expect(response.statusCode).toBe(200);
+      const detail = response.json();
+      expect(detail.replay.source_target).toBe('/tmp/replay-detail');
+      expect(detail.replay.commit_sha).toBe('replay1');
+      expect(detail.replay.validation.summary).toBe('clean');
+      expect(detail.replay.file_snapshots).toHaveLength(1);
+    });
+
     it('GET /api/repositories/:id/cycles/:cycleId returns 404 for non-existent cycle', async () => {
       const response = await app.inject({
         method: 'GET',

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -7,6 +7,7 @@ import {
   type FixCandidateDTO,
   getDb,
   initSchema,
+  type PatchReplayDTO,
   type PatchDTO,
   type RepositoryDTO,
   type RepositoryStatus,
@@ -68,6 +69,14 @@ function parseJsonValue<T>(value: string | null, fallback: T): T {
     return JSON.parse(value) as T;
   } catch {
     return fallback;
+  }
+}
+
+function parseReplayBundle(value: string): Record<string, unknown> {
+  try {
+    return JSON.parse(value) as Record<string, unknown>;
+  } catch {
+    return {};
   }
 }
 
@@ -410,6 +419,7 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
       | undefined;
 
     let patch: PatchDTO | undefined;
+    let patchReplay: PatchReplayDTO | undefined;
     let reviewDecision: ReviewDecisionDTO | undefined;
 
     if (fixCandidate) {
@@ -418,9 +428,14 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
         | undefined;
 
       if (patch) {
+        patchReplay = db.prepare('SELECT * FROM patch_replays WHERE patch_id = ? LIMIT 1').get(patch.id) as
+          | PatchReplayDTO
+          | undefined;
         reviewDecision = stmts.getReviewDecisionByPatchId.get(patch.id) as ReviewDecisionDTO | undefined;
       }
     }
+
+    const replay = patchReplay ? parseReplayBundle(patchReplay.replay_bundle) : null;
 
     return {
       ...cycle,
@@ -433,6 +448,15 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
       patch: patch?.patch_text ?? null,
       validation_status: patch?.validation_status ?? null,
       validation_summary: patch?.validation_summary ?? null,
+      replay: replay
+        ? {
+            patch_id: patchReplay?.patch_id ?? null,
+            scan_id: patchReplay?.scan_id ?? null,
+            source_target: patchReplay?.source_target ?? null,
+            commit_sha: patchReplay?.commit_sha ?? null,
+            ...replay,
+          }
+        : null,
       review_status: reviewDecision?.decision ?? 'pending',
       review_notes: reviewDecision?.notes ?? null,
     };

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -41,6 +41,8 @@ vi.mock('../db/index.js', async () => {
     getFixCandidatesByCycleId: stmts.getFixCandidatesByCycleId,
     addPatch: stmts.addPatch,
     getPatchesByFixCandidateId: stmts.getPatchesByFixCandidateId,
+    addPatchReplay: stmts.addPatchReplay,
+    getPatchReplayByPatchId: stmts.getPatchReplayByPatchId,
   };
 });
 
@@ -65,6 +67,7 @@ describe('Scanner Worker', () => {
       summary: 'Validation passed.',
     });
 
+    dbModule.getDb().prepare('DELETE FROM patch_replays').run();
     dbModule.getDb().prepare('DELETE FROM patches').run();
     dbModule.getDb().prepare('DELETE FROM fix_candidates').run();
     dbModule.getDb().prepare('DELETE FROM cycles').run();
@@ -276,10 +279,18 @@ describe('Scanner Worker', () => {
     const result = await scanRepository('org/patch');
     const cycles = dbModule.getCyclesByScanId.all(result.scanId) as Array<{ id: number }>;
     const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as Array<{ id: number }>;
-    const patches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id) as Array<{ patch_text: string }>;
+    const patches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id) as Array<{ id: number; patch_text: string }>;
+    const replay = dbModule.getPatchReplayByPatchId.get(patches[0].id) as {
+      source_target: string;
+      commit_sha: string;
+      replay_bundle: string;
+    };
 
     expect(patches).toHaveLength(1);
     expect(patches[0].patch_text).toContain('--- a/a.ts');
+    expect(replay.source_target).toBe('org/patch');
+    expect(replay.commit_sha).toBe('mock-sha');
+    expect(JSON.parse(replay.replay_bundle).file_snapshots).toHaveLength(1);
   });
 
   it('persists failed validation summaries when a generated patch does not validate', async () => {
@@ -321,12 +332,17 @@ describe('Scanner Worker', () => {
     const cycles = dbModule.getCyclesByScanId.all(result.scanId) as Array<{ id: number }>;
     const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as Array<{ id: number }>;
     const patches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id) as Array<{
+      id: number;
       validation_status: string;
       validation_summary: string;
     }>;
+    const replay = dbModule.getPatchReplayByPatchId.get(patches[0].id) as { validation_bundle?: string } & {
+      replay_bundle: string;
+    };
 
     expect(patches).toHaveLength(1);
     expect(patches[0].validation_status).toBe('failed');
     expect(patches[0].validation_summary).toContain('original cycle is still present');
+    expect(JSON.parse(replay.replay_bundle).validation.summary).toContain('original cycle is still present');
   });
 });

--- a/cli/scanner.ts
+++ b/cli/scanner.ts
@@ -2,20 +2,25 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import simpleGit from 'simple-git';
 import { analyzeRepository } from '../analyzer/analyzer.js';
+import type { GeneratedPatch } from '../codemod/generatePatch.js';
 import { generatePatchForCycle } from '../codemod/generatePatch.js';
-import { validateGeneratedPatch } from './validation.js';
+import { validateGeneratedPatch, type ValidationResult } from './validation.js';
 import type { RepositoryDTO } from '../db/index.js';
 import {
   addCycle,
   addFixCandidate,
   addPatch,
+  addPatchReplay,
   addRepository,
   addScan,
+  getDb,
   getRepositoryByOwnerName,
   updateRepositoryLocalPath,
   updateRepositoryStatus,
   updateScanStatus,
 } from '../db/index.js';
+
+type ScannedCycle = Awaited<ReturnType<typeof analyzeRepository>>[number];
 
 function parseTargetUrl(targetUrlOrOwnerName: string) {
   let owner = 'unknown';
@@ -81,7 +86,7 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
     const cycles = await analyzeRepository(resolvedTarget.repoPath);
 
     for (const cycle of cycles) {
-      await persistCycle(scanId, resolvedTarget.repoPath, cycle);
+      await persistCycle(scanId, resolvedTarget.repoPath, targetUrlOrOwnerName, commitSha, repo, cycle);
     }
 
     updateScanStatus.run({ id: scanId, status: 'completed' });
@@ -112,6 +117,11 @@ function ensureRepository(owner: string, name: string, localPath: string | null)
     default_branch: 'main',
     local_path: localPath,
   });
+
+  const createdRepo = getRepositoryByOwnerName.get(owner, name) as RepositoryDTO | undefined;
+  if (createdRepo) {
+    return createdRepo;
+  }
 
   return { id: info.lastInsertRowid as number, owner, name } as RepositoryDTO;
 }
@@ -248,7 +258,10 @@ async function getLatestCommitSha(gitRepo: ReturnType<typeof simpleGit>): Promis
 async function persistCycle(
   scanId: number,
   repoPath: string,
-  cycle: Awaited<ReturnType<typeof analyzeRepository>>[number],
+  sourceTarget: string,
+  commitSha: string,
+  repository: RepositoryDTO,
+  cycle: ScannedCycle,
 ): Promise<void> {
   const cycleInfo = addCycle.run({
     scan_id: scanId,
@@ -274,11 +287,92 @@ async function persistCycle(
   }
 
   const validation = await validateGeneratedPatch(repoPath, cycle, generatedPatch);
-  addPatch.run({
+  const patchPayload = {
     fix_candidate_id: fixCandidateInfo.lastInsertRowid as number,
     patch_text: generatedPatch.patchText,
     touched_files: JSON.stringify(generatedPatch.touchedFiles),
     validation_status: validation.status,
     validation_summary: validation.summary,
+  };
+  const replayBundle = buildPatchReplayBundle({
+    scanId,
+    sourceTarget,
+    commitSha,
+    repository,
+    cycle,
+    generatedPatch,
+    validation,
   });
+
+  getDb()
+    .transaction((patchRow: typeof patchPayload, replayBundleJson: string) => {
+      const patchInfo = addPatch.run(patchRow);
+      addPatchReplay.run({
+        patch_id: patchInfo.lastInsertRowid as number,
+        scan_id: scanId,
+        source_target: sourceTarget,
+        commit_sha: commitSha,
+        replay_bundle: replayBundleJson,
+      });
+    })(patchPayload, JSON.stringify(replayBundle));
+}
+
+interface PatchReplayBundle {
+  scan_id: number;
+  source_target: string;
+  commit_sha: string;
+  repository: {
+    owner: string;
+    name: string;
+    default_branch: string | null;
+    local_path: string | null;
+  };
+  cycle: {
+    path: string[];
+    normalized_path: string;
+    raw_payload: ScannedCycle;
+  };
+  candidate: {
+    classification: string;
+    confidence: number;
+    reasons: string[] | null;
+  };
+  validation: ValidationResult;
+  file_snapshots: GeneratedPatch['fileSnapshots'];
+  patch_text: string;
+}
+
+function buildPatchReplayBundle(args: {
+  scanId: number;
+  sourceTarget: string;
+  commitSha: string;
+  repository: RepositoryDTO;
+  cycle: ScannedCycle;
+  generatedPatch: GeneratedPatch;
+  validation: ValidationResult;
+}): PatchReplayBundle {
+  return {
+    scan_id: args.scanId,
+    source_target: args.sourceTarget,
+    commit_sha: args.commitSha,
+    repository: {
+      owner: args.repository.owner,
+      name: args.repository.name,
+      default_branch: args.repository.default_branch ?? null,
+      local_path: args.repository.local_path ?? null,
+    },
+    cycle: {
+      path: args.cycle.path,
+      normalized_path: args.cycle.path.join(' -> '),
+      raw_payload: args.cycle,
+    },
+    candidate: {
+      classification: args.cycle.analysis?.classification ?? 'unsupported',
+      confidence: args.cycle.analysis?.confidence ?? 0,
+      reasons: args.cycle.analysis?.reasons ?? null,
+    },
+    validation: args.validation,
+    file_snapshots: args.generatedPatch.fileSnapshots,
+    patch_text: args.generatedPatch.patchText,
+  };
 }

--- a/db/index.test.ts
+++ b/db/index.test.ts
@@ -7,6 +7,7 @@ import {
   addCycle as defaultAddCycle,
   addFixCandidate as defaultAddFixCandidate,
   addPatch as defaultAddPatch,
+  addPatchReplay as defaultAddPatchReplay,
   addRepository as defaultAddRepository,
   addReviewDecision as defaultAddReviewDecision,
   addScan as defaultAddScan,
@@ -14,6 +15,7 @@ import {
   getCyclesByScanId as defaultGetCyclesByScanId,
   getFixCandidatesByCycleId as defaultGetFixCandidatesByCycleId,
   getPatch as defaultGetPatch,
+  getPatchReplayByPatchId as defaultGetPatchReplayByPatchId,
   getPatchesByFixCandidateId as defaultGetPatchesByFixCandidateId,
   getRepository as defaultGetRepository,
   getRepositoryByOwnerName as defaultGetRepositoryByOwnerName,
@@ -27,6 +29,7 @@ import {
   initDb,
   initSchema,
   type PatchDTO,
+  type PatchReplayDTO,
   type RepositoryDTO,
   type ReviewDecisionDTO,
   type ScanDTO,
@@ -67,6 +70,7 @@ describe('db module', () => {
       expect(tableNames).toContain('cycles');
       expect(tableNames).toContain('fix_candidates');
       expect(tableNames).toContain('patches');
+      expect(tableNames).toContain('patch_replays');
       expect(tableNames).toContain('review_decisions');
     });
 
@@ -84,6 +88,8 @@ describe('db module', () => {
       expect(indexNames).toContain('idx_fix_candidates_classification');
       expect(indexNames).toContain('idx_fix_candidates_confidence');
       expect(indexNames).toContain('idx_patches_fix_candidate_id');
+      expect(indexNames).toContain('idx_patch_replays_patch_id');
+      expect(indexNames).toContain('idx_patch_replays_scan_id');
       expect(indexNames).toContain('idx_review_decisions_patch_id');
       expect(indexNames).toContain('idx_review_decisions_decision');
     });
@@ -402,6 +408,93 @@ describe('db module', () => {
     });
   });
 
+  describe('patch_replays', () => {
+    let patchId: number | bigint;
+    let scanId: number | bigint;
+
+    beforeEach(() => {
+      const repoInfo = stmts.addRepository.run({
+        owner: 'replay-test',
+        name: 'repo',
+        default_branch: 'main',
+        local_path: '/tmp/replay-test',
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'replay123',
+        status: 'completed',
+      });
+      scanId = scanInfo.lastInsertRowid;
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'r.ts -> s.ts',
+        participating_files: JSON.stringify(['r.ts', 's.ts']),
+        raw_payload: JSON.stringify({ type: 'circular', path: ['r.ts', 's.ts'] }),
+      });
+      const fcInfo = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        classification: 'autofix_extract_shared',
+        confidence: 0.88,
+        reasons: JSON.stringify(['safe to extract shared symbol']),
+      });
+      const patchInfo = stmts.addPatch.run({
+        fix_candidate_id: fcInfo.lastInsertRowid,
+        patch_text: '--- a/r.ts\n+++ b/r.ts',
+        touched_files: JSON.stringify(['r.ts', 's.ts']),
+        validation_status: 'passed',
+        validation_summary: 'validation ok',
+      });
+      patchId = patchInfo.lastInsertRowid;
+    });
+
+    it('stores a replay bundle for a patch', () => {
+      const info = stmts.addPatchReplay.run({
+        patch_id: patchId,
+        scan_id: scanId,
+        source_target: 'https://github.com/example/replay.git',
+        commit_sha: 'replay123',
+        replay_bundle: JSON.stringify({
+          scan_id: scanId,
+          source_target: 'https://github.com/example/replay.git',
+          commit_sha: 'replay123',
+          repository: {
+            owner: 'replay-test',
+            name: 'repo',
+            default_branch: 'main',
+            local_path: '/tmp/replay-test',
+          },
+          cycle: {
+            path: ['r.ts', 's.ts'],
+            normalized_path: 'r.ts -> s.ts',
+            raw_payload: { type: 'circular', path: ['r.ts', 's.ts'] },
+          },
+          candidate: {
+            classification: 'autofix_extract_shared',
+            confidence: 0.88,
+            reasons: ['safe to extract shared symbol'],
+          },
+          validation: {
+            status: 'passed',
+            summary: 'validation ok',
+          },
+          file_snapshots: [
+            {
+              path: 'r.ts',
+              before: 'before',
+              after: 'after',
+            },
+          ],
+          patch_text: '--- a/r.ts\n+++ b/r.ts',
+        }),
+      });
+
+      const replay = stmts.getPatchReplayByPatchId.get(info.lastInsertRowid) as PatchReplayDTO;
+      expect(replay.patch_id).toBe(patchId);
+      expect(replay.commit_sha).toBe('replay123');
+      expect(JSON.parse(replay.replay_bundle).source_target).toBe('https://github.com/example/replay.git');
+    });
+  });
+
   describe('review_decisions', () => {
     let patchId: number | bigint;
 
@@ -521,6 +614,8 @@ describe('default production exports', () => {
     expect(defaultAddPatch).toBeDefined();
     expect(defaultGetPatch).toBeDefined();
     expect(defaultGetPatchesByFixCandidateId).toBeDefined();
+    expect(defaultAddPatchReplay).toBeDefined();
+    expect(defaultGetPatchReplayByPatchId).toBeDefined();
     expect(defaultAddReviewDecision).toBeDefined();
     expect(defaultGetReviewDecisionByPatchId).toBeDefined();
   });

--- a/db/index.ts
+++ b/db/index.ts
@@ -54,6 +54,16 @@ export interface PatchDTO {
   created_at: string;
 }
 
+export interface PatchReplayDTO {
+  id: number;
+  patch_id: number;
+  scan_id: number;
+  source_target: string;
+  commit_sha: string;
+  replay_bundle: string;
+  created_at: string;
+}
+
 export interface ReviewDecisionDTO {
   id: number;
   patch_id: number;
@@ -136,6 +146,18 @@ const SCHEMA_SQL = `
     FOREIGN KEY (fix_candidate_id) REFERENCES fix_candidates(id)
   );
 
+  CREATE TABLE IF NOT EXISTS patch_replays (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    patch_id INTEGER NOT NULL UNIQUE,
+    scan_id INTEGER NOT NULL,
+    source_target TEXT NOT NULL,
+    commit_sha TEXT NOT NULL,
+    replay_bundle TEXT NOT NULL, -- JSON string
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (patch_id) REFERENCES patches(id),
+    FOREIGN KEY (scan_id) REFERENCES scans(id)
+  );
+
   CREATE TABLE IF NOT EXISTS review_decisions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     patch_id INTEGER NOT NULL,
@@ -155,6 +177,8 @@ const SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_fix_candidates_classification ON fix_candidates(classification);
   CREATE INDEX IF NOT EXISTS idx_fix_candidates_confidence ON fix_candidates(confidence);
   CREATE INDEX IF NOT EXISTS idx_patches_fix_candidate_id ON patches(fix_candidate_id);
+  CREATE INDEX IF NOT EXISTS idx_patch_replays_patch_id ON patch_replays(patch_id);
+  CREATE INDEX IF NOT EXISTS idx_patch_replays_scan_id ON patch_replays(scan_id);
   CREATE INDEX IF NOT EXISTS idx_review_decisions_patch_id ON review_decisions(patch_id);
   CREATE INDEX IF NOT EXISTS idx_review_decisions_decision ON review_decisions(decision);
 `;
@@ -249,6 +273,15 @@ export function createStatements(database: DatabaseType) {
     `),
     getPatchesByFixCandidateId: database.prepare(`
       SELECT * FROM patches WHERE fix_candidate_id = ?
+    `),
+
+    // Patch Replays
+    addPatchReplay: database.prepare(`
+      INSERT INTO patch_replays (patch_id, scan_id, source_target, commit_sha, replay_bundle)
+      VALUES (@patch_id, @scan_id, @source_target, @commit_sha, @replay_bundle)
+    `),
+    getPatchReplayByPatchId: database.prepare(`
+      SELECT * FROM patch_replays WHERE patch_id = ?
     `),
 
     // Review Decisions
@@ -366,6 +399,14 @@ export const getPatch = {
 export const getPatchesByFixCandidateId = {
   all: (...args: Parameters<ReturnType<typeof createStatements>['getPatchesByFixCandidateId']['all']>) =>
     getStatements().getPatchesByFixCandidateId.all(...args),
+};
+export const addPatchReplay = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addPatchReplay']['run']>) =>
+    getStatements().addPatchReplay.run(...args),
+};
+export const getPatchReplayByPatchId = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getPatchReplayByPatchId']['get']>) =>
+    getStatements().getPatchReplayByPatchId.get(...args),
 };
 export const addReviewDecision = {
   run: (...args: Parameters<ReturnType<typeof createStatements>['addReviewDecision']['run']>) =>

--- a/src/routes/repositories.$id.cycles.$cycleId.tsx
+++ b/src/routes/repositories.$id.cycles.$cycleId.tsx
@@ -2,6 +2,30 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { fetchCycleDetail, type ReviewDecision, submitReviewDecision } from '../lib/api';
 
+type ReplayBundle = {
+  source_target?: string | null;
+  commit_sha?: string | null;
+  repository?: {
+    owner?: string;
+    name?: string;
+    local_path?: string | null;
+  };
+  candidate?: {
+    classification?: string;
+    confidence?: number;
+    reasons?: string[] | null;
+  };
+  validation?: {
+    status?: string;
+    summary?: string;
+  };
+  file_snapshots?: Array<{
+    path: string;
+    before: string;
+    after: string;
+  }>;
+};
+
 export const Route = createFileRoute('/repositories/$id/cycles/$cycleId')({
   component: CycleDetail,
 });
@@ -41,6 +65,7 @@ function CycleDetail() {
   let statusColor = 'text-gray-800';
   if (cycle?.validation_status === 'passed') statusColor = 'text-green-600';
   if (cycle?.validation_status === 'failed') statusColor = 'text-red-600';
+  const replay = cycle?.replay as ReplayBundle | null | undefined;
 
   const canReview = Boolean(cycle?.patch_id);
 
@@ -114,6 +139,72 @@ function CycleDetail() {
                 )}
               </div>
             </div>
+          </div>
+
+          <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
+            <h2 className="text-xl font-semibold mb-4">Replay Provenance</h2>
+            {replay ? (
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <span className="text-gray-500 block text-sm">Source Target</span>
+                    <span className="font-medium break-all">{replay.source_target || 'N/A'}</span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block text-sm">Commit SHA</span>
+                    <span className="font-medium font-mono break-all">{replay.commit_sha || 'N/A'}</span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block text-sm">Repository</span>
+                    <span className="font-medium">
+                      {replay.repository?.owner && replay.repository?.name
+                        ? `${replay.repository.owner}/${replay.repository.name}`
+                        : 'N/A'}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block text-sm">Repository Path</span>
+                    <span className="font-medium break-all">{replay.repository?.local_path || 'N/A'}</span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block text-sm">Classification</span>
+                    <span className="font-medium">
+                      {replay.candidate?.classification || String(cycle.classification || 'Unknown')}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block text-sm">Validation</span>
+                    <span className={`font-medium ${statusColor}`}>
+                      {replay.validation?.status || cycle.validation_status || 'Pending / N/A'}
+                    </span>
+                  </div>
+                </div>
+
+                <div>
+                  <span className="text-gray-500 block text-sm mb-2">
+                    File Snapshots ({replay.file_snapshots?.length || 0})
+                  </span>
+                  {replay.file_snapshots?.length ? (
+                    <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 max-h-72 overflow-y-auto">
+                      <code>{JSON.stringify(replay.file_snapshots, null, 2)}</code>
+                    </pre>
+                  ) : (
+                    <p className="text-gray-500 italic text-sm">No file snapshots available.</p>
+                  )}
+                </div>
+
+                {replay.validation?.summary ? (
+                  <div>
+                    <span className="text-gray-500 block text-sm mb-2">Validation Summary</span>
+                    <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 max-h-56 overflow-y-auto">
+                      <code>{replay.validation.summary}</code>
+                    </pre>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-gray-500 italic text-sm">No replay bundle stored for this patch yet.</p>
+            )}
           </div>
 
           <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">


### PR DESCRIPTION
Closes #21\n\nAdds a persisted patch replay bundle so executable patches can be reconstructed later from stored provenance instead of temporary validation worktrees. The backend now surfaces the replay bundle in cycle detail responses, and the cycle detail UI renders the source target, commit SHA, repository info, validation summary, and file snapshots.\n\nVerification:\n- ../../node_modules/.bin/vitest run --config vitest.config.ts db/index.test.ts cli/scanner.test.ts backend/server.test.ts\n- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json