### PR TITLE
Automate PR creation from validated patch artifacts

### DIFF
--- a/cli/createPullRequest.test.ts
+++ b/cli/createPullRequest.test.ts
@@ -1,0 +1,225 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import simpleGit from 'simple-git';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDatabase, createStatements, initSchema } from '../db/index.js';
+import { createPullRequestForPatch } from './createPullRequest.js';
+
+vi.mock('simple-git');
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+describe('createPullRequestForPatch', () => {
+  let db: ReturnType<typeof createDatabase>;
+  let statements: ReturnType<typeof createStatements>;
+  let repoPath: string;
+  let checkoutRoot: string;
+  let originalRepoPath: string;
+  let rootGit: Record<string, ReturnType<typeof vi.fn>>;
+  let repoGit: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    db = createDatabase(':memory:');
+    initSchema(db);
+    statements = createStatements(db);
+    repoPath = await fs.mkdtemp(path.join(os.tmpdir(), 'target-repo-'));
+    checkoutRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pr-checkouts-'));
+    originalRepoPath = path.join(process.cwd(), '.test-fixtures', 'original-widget');
+
+    rootGit = {
+      clone: vi.fn(async (_remoteUrl: string, targetPath: string) => {
+        await fs.mkdir(path.join(targetPath, 'src'), { recursive: true });
+        await fs.writeFile(path.join(targetPath, 'src', 'a.ts'), 'before', 'utf8');
+      }),
+    };
+
+    repoGit = {
+      status: vi.fn(),
+      raw: vi.fn().mockResolvedValue(''),
+      commit: vi.fn().mockResolvedValue({ commit: 'new-commit' }),
+      push: vi.fn(async () => {}),
+    };
+
+    vi.mocked(simpleGit).mockImplementation(((workingPath?: string) =>
+      workingPath ? repoGit : rootGit) as unknown as typeof simpleGit);
+    vi.mocked(execFile).mockImplementation(((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      callback(null, 'https://github.com/acme/widget/pull/123\n', '');
+      return {} as never;
+    }) as unknown as typeof execFile);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await fs.rm(repoPath, { recursive: true, force: true });
+    await fs.rm(checkoutRoot, { recursive: true, force: true });
+  });
+
+  it('creates a pull request from a reviewed validated patch using an explicit checkout', async () => {
+    const patchId = insertPatchCandidate({
+      reviewDecision: 'approved',
+      validationStatus: 'passed',
+      remoteUrl: 'git@github.com:acme/widget.git',
+    });
+    await fs.mkdir(path.join(repoPath, 'src'), { recursive: true });
+    await fs.writeFile(path.join(repoPath, 'src', 'a.ts'), 'before', 'utf8');
+
+    repoGit.status.mockResolvedValueOnce({ files: [] }).mockResolvedValueOnce({ files: [{ path: 'src/a.ts' }] });
+
+    const result = await createPullRequestForPatch(patchId, {
+      linkedIssueNumber: 42,
+      repoPath,
+      database: db,
+    });
+
+    expect(await fs.readFile(path.join(repoPath, 'src', 'a.ts'), 'utf8')).toBe('after');
+    expect(repoGit.raw).toHaveBeenNthCalledWith(1, ['fetch', '--all', '--prune']);
+    expect(repoGit.raw).toHaveBeenNthCalledWith(2, ['checkout', '-B', 'codex/issue-42-patch-1', 'abc123']);
+    expect(repoGit.raw).toHaveBeenNthCalledWith(3, ['add', '--all']);
+    expect(repoGit.commit).toHaveBeenCalledWith('Break circular dependency between a.ts and b.ts');
+    expect(repoGit.push).toHaveBeenCalledWith(['-u', 'origin', 'codex/issue-42-patch-1']);
+    expect(result.prUrl).toBe('https://github.com/acme/widget/pull/123');
+
+    const ghArgs = vi.mocked(execFile).mock.calls[0]?.[1] as string[];
+    expect(ghArgs).toContain('--repo');
+    expect(ghArgs).toContain('acme/widget');
+    expect(ghArgs).toContain('--base');
+    expect(ghArgs).toContain('main');
+    expect(ghArgs).toContain('--head');
+    expect(ghArgs).toContain('codex/issue-42-patch-1');
+    expect(ghArgs).toContain('--body');
+    expect(ghArgs.at(-1)).toContain('Validation passed: original cycle removed.');
+    expect(ghArgs.at(-1)).toContain('Closes #42');
+  });
+
+  it('clones a scratch checkout using the stored remote URL when repoPath is omitted', async () => {
+    const patchId = insertPatchCandidate({
+      reviewDecision: 'pr_candidate',
+      validationStatus: 'passed',
+      remoteUrl: 'git@github.com:acme/widget.git',
+    });
+
+    repoGit.status.mockResolvedValueOnce({ files: [{ path: 'src/a.ts' }] });
+
+    const result = await createPullRequestForPatch(patchId, {
+      linkedIssueNumber: 7,
+      checkoutRoot,
+      database: db,
+    });
+
+    expect(rootGit.clone).toHaveBeenCalledWith(
+      'git@github.com:acme/widget.git',
+      expect.stringContaining(path.join(checkoutRoot, 'acme-widget-patch-1-')),
+    );
+    expect(result.repoPath).toContain(path.join(checkoutRoot, 'acme-widget-patch-1-'));
+    expect(repoGit.raw).toHaveBeenCalledWith(['checkout', '-B', 'codex/issue-7-patch-1', 'abc123']);
+  });
+
+  it('rejects PR creation when the patch is not in an approved publishable state', async () => {
+    const patchId = insertPatchCandidate({
+      reviewDecision: 'pending',
+      validationStatus: 'passed',
+      remoteUrl: 'git@github.com:acme/widget.git',
+    });
+
+    await expect(
+      createPullRequestForPatch(patchId, {
+        linkedIssueNumber: 99,
+        repoPath,
+        database: db,
+      }),
+    ).rejects.toThrow('must be marked approved or pr_candidate');
+  });
+
+  function insertPatchCandidate(args: {
+    reviewDecision: 'approved' | 'pr_candidate' | 'pending';
+    validationStatus: 'passed' | 'failed';
+    remoteUrl: string | null;
+  }): number {
+    const repositoryInfo = statements.addRepository.run({
+      owner: 'acme',
+      name: 'widget',
+      default_branch: 'main',
+      local_path: originalRepoPath,
+    });
+    const scanInfo = statements.addScan.run({
+      repository_id: repositoryInfo.lastInsertRowid,
+      commit_sha: 'abc123',
+      status: 'completed',
+    });
+    const cycleInfo = statements.addCycle.run({
+      scan_id: scanInfo.lastInsertRowid,
+      normalized_path: 'src/a.ts -> src/b.ts -> src/a.ts',
+      participating_files: JSON.stringify(['src/a.ts', 'src/b.ts']),
+      raw_payload: JSON.stringify({ type: 'circular' }),
+    });
+    const fixCandidateInfo = statements.addFixCandidate.run({
+      cycle_id: cycleInfo.lastInsertRowid,
+      classification: 'autofix_extract_shared',
+      confidence: 0.91,
+      reasons: JSON.stringify(['safe shared symbol']),
+    });
+    const patchInfo = statements.addPatch.run({
+      fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+      patch_text: '--- a/src/a.ts\n+++ b/src/a.ts\n',
+      touched_files: JSON.stringify(['src/a.ts', 'src/b.ts', 'src/a-b.shared.ts']),
+      validation_status: args.validationStatus,
+      validation_summary: 'Validation passed: original cycle removed.',
+    });
+    statements.addPatchReplay.run({
+      patch_id: patchInfo.lastInsertRowid,
+      scan_id: scanInfo.lastInsertRowid,
+      source_target: 'https://github.com/acme/widget.git',
+      commit_sha: 'abc123',
+      replay_bundle: JSON.stringify({
+        source_target: 'https://github.com/acme/widget.git',
+        commit_sha: 'abc123',
+        repository: {
+          owner: 'acme',
+          name: 'widget',
+          default_branch: 'main',
+          local_path: originalRepoPath,
+          remote_url: args.remoteUrl,
+        },
+        cycle: {
+          path: ['src/a.ts', 'src/b.ts'],
+          normalized_path: 'src/a.ts -> src/b.ts -> src/a.ts',
+        },
+        candidate: {
+          classification: 'autofix_extract_shared',
+          confidence: 0.91,
+          reasons: ['safe shared symbol'],
+        },
+        validation: {
+          status: args.validationStatus,
+          summary: 'Validation passed: original cycle removed.',
+        },
+        file_snapshots: [
+          {
+            path: 'src/a.ts',
+            before: 'before',
+            after: 'after',
+          },
+        ],
+        patch_text: '--- a/src/a.ts\n+++ b/src/a.ts\n',
+      }),
+    });
+
+    if (args.reviewDecision !== 'pending') {
+      statements.addReviewDecision.run({
+        patch_id: patchInfo.lastInsertRowid,
+        decision: args.reviewDecision,
+        notes: null,
+      });
+    }
+
+    return patchInfo.lastInsertRowid as number;
+  }
+});

--- a/cli/createPullRequest.ts
+++ b/cli/createPullRequest.ts
@@ -1,0 +1,488 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import simpleGit from 'simple-git';
+import { getDb } from '../db/index.js';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_CHECKOUT_ROOT = path.join(process.cwd(), 'worktrees', 'pull-requests');
+
+interface PullRequestCandidateRow {
+  patch_id: number;
+  patch_text: string;
+  touched_files: string;
+  validation_status: string | null;
+  validation_summary: string | null;
+  fix_candidate_id: number;
+  classification: string;
+  confidence: number;
+  reasons: string | null;
+  cycle_id: number;
+  normalized_path: string;
+  participating_files: string;
+  scan_id: number;
+  commit_sha: string;
+  owner: string;
+  name: string;
+  default_branch: string | null;
+  local_path: string | null;
+  review_status: string;
+  replay_bundle: string | null;
+}
+
+interface ReplayBundle {
+  source_target?: string;
+  commit_sha?: string;
+  repository?: {
+    owner?: string;
+    name?: string;
+    default_branch?: string | null;
+    local_path?: string | null;
+    remote_url?: string | null;
+  };
+  cycle?: {
+    path?: string[];
+    normalized_path?: string;
+    raw_payload?: unknown;
+  };
+  candidate?: {
+    classification?: string;
+    confidence?: number;
+    reasons?: string[] | null;
+  };
+  validation?: {
+    status?: string;
+    summary?: string;
+  };
+  file_snapshots?: FileSnapshot[];
+  patch_text?: string;
+}
+
+interface FileSnapshot {
+  path: string;
+  before: string;
+  after: string;
+}
+
+interface PullRequestCandidate {
+  patchId: number;
+  fixCandidateId: number;
+  cycleId: number;
+  scanId: number;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  localPath: string | null;
+  reviewStatus: string;
+  validationStatus: string;
+  validationSummary: string;
+  classification: string;
+  confidence: number;
+  reasons: string[];
+  normalizedPath: string;
+  cyclePath: string[];
+  touchedFiles: string[];
+  commitSha: string;
+  replay: RequiredReplayBundle;
+}
+
+interface RequiredReplayBundle {
+  source_target: string;
+  commit_sha: string;
+  repository: {
+    owner: string;
+    name: string;
+    default_branch: string | null;
+    local_path: string | null;
+    remote_url: string | null;
+  };
+  cycle: {
+    path: string[];
+    normalized_path: string;
+  };
+  candidate: {
+    classification: string;
+    confidence: number;
+    reasons: string[] | null;
+  };
+  validation: {
+    status: string;
+    summary: string;
+  };
+  file_snapshots: FileSnapshot[];
+  patch_text: string;
+}
+
+export interface CreatePullRequestOptions {
+  linkedIssueNumber: number;
+  title?: string;
+  branchName?: string;
+  baseBranch?: string;
+  repoPath?: string;
+  checkoutRoot?: string;
+  remoteName?: string;
+  database?: DatabaseType;
+}
+
+export interface CreatePullRequestResult {
+  patchId: number;
+  repository: string;
+  repoPath: string;
+  branchName: string;
+  baseBranch: string;
+  title: string;
+  body: string;
+  prUrl: string;
+}
+
+export async function createPullRequestForPatch(
+  patchId: number,
+  options: CreatePullRequestOptions,
+): Promise<CreatePullRequestResult> {
+  if (!Number.isInteger(patchId) || patchId <= 0) {
+    throw new Error(`Patch ID must be a positive integer. Received: ${patchId}`);
+  }
+
+  if (!Number.isInteger(options.linkedIssueNumber) || options.linkedIssueNumber <= 0) {
+    throw new Error(`Linked issue number must be a positive integer. Received: ${options.linkedIssueNumber}`);
+  }
+
+  const database = options.database ?? getDb();
+  const candidate = loadPullRequestCandidate(patchId, database);
+
+  const branchName = options.branchName ?? `codex/issue-${options.linkedIssueNumber}-patch-${patchId}`;
+  const baseBranch = options.baseBranch ?? candidate.defaultBranch;
+  const checkoutPath = await prepareCheckout(candidate, options.repoPath, options.checkoutRoot);
+  const git = simpleGit(checkoutPath);
+  const remoteName = options.remoteName ?? 'origin';
+
+  if (options.repoPath) {
+    await ensureCheckoutIsClean(git, checkoutPath);
+    await git.raw(['fetch', '--all', '--prune']);
+  }
+
+  await git.raw(['checkout', '-B', branchName, candidate.commitSha]);
+  await applyFileSnapshots(checkoutPath, candidate.replay.file_snapshots);
+  await git.raw(['add', '--all']);
+
+  const status = await git.status();
+  if (status.files.length === 0) {
+    throw new Error(`Stored patch ${patchId} produced no file changes when applied.`);
+  }
+
+  const title = options.title ?? buildPullRequestTitle(candidate);
+  const body = buildPullRequestBody(candidate, options.linkedIssueNumber);
+
+  await git.commit(title);
+  await git.push(['-u', remoteName, branchName]);
+
+  const prUrl = await createGithubPullRequest({
+    owner: candidate.owner,
+    name: candidate.name,
+    baseBranch,
+    branchName,
+    title,
+    body,
+    cwd: checkoutPath,
+  });
+
+  return {
+    patchId: candidate.patchId,
+    repository: `${candidate.owner}/${candidate.name}`,
+    repoPath: checkoutPath,
+    branchName,
+    baseBranch,
+    title,
+    body,
+    prUrl,
+  };
+}
+
+function loadPullRequestCandidate(patchId: number, database: DatabaseType): PullRequestCandidate {
+  const row = database
+    .prepare(
+      `
+      SELECT
+        p.id AS patch_id,
+        p.patch_text,
+        p.touched_files,
+        p.validation_status,
+        p.validation_summary,
+        fc.id AS fix_candidate_id,
+        fc.classification,
+        fc.confidence,
+        fc.reasons,
+        c.id AS cycle_id,
+        c.normalized_path,
+        c.participating_files,
+        s.id AS scan_id,
+        s.commit_sha,
+        r.owner,
+        r.name,
+        r.default_branch,
+        r.local_path,
+        COALESCE(rd.decision, 'pending') AS review_status,
+        pr.replay_bundle
+      FROM patches p
+      INNER JOIN fix_candidates fc ON fc.id = p.fix_candidate_id
+      INNER JOIN cycles c ON c.id = fc.cycle_id
+      INNER JOIN scans s ON s.id = c.scan_id
+      INNER JOIN repositories r ON r.id = s.repository_id
+      LEFT JOIN patch_replays pr ON pr.patch_id = p.id
+      LEFT JOIN review_decisions rd ON rd.id = (
+        SELECT id
+        FROM review_decisions
+        WHERE patch_id = p.id
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      )
+      WHERE p.id = ?
+    `,
+    )
+    .get(patchId) as PullRequestCandidateRow | undefined;
+
+  if (!row) {
+    throw new Error(`Patch ${patchId} was not found.`);
+  }
+
+  if (row.validation_status !== 'passed') {
+    throw new Error(`Patch ${patchId} is not validated. Expected validation_status='passed'.`);
+  }
+
+  if (!['approved', 'pr_candidate'].includes(row.review_status)) {
+    throw new Error(`Patch ${patchId} must be marked approved or pr_candidate before creating a PR.`);
+  }
+
+  const replay = parseReplayBundle(row.replay_bundle, row);
+
+  return {
+    patchId: row.patch_id,
+    fixCandidateId: row.fix_candidate_id,
+    cycleId: row.cycle_id,
+    scanId: row.scan_id,
+    owner: row.owner,
+    name: row.name,
+    defaultBranch: row.default_branch ?? 'main',
+    localPath: row.local_path,
+    reviewStatus: row.review_status,
+    validationStatus: row.validation_status,
+    validationSummary: row.validation_summary ?? replay.validation.summary,
+    classification: row.classification,
+    confidence: row.confidence,
+    reasons: parseJsonArray(row.reasons),
+    normalizedPath: row.normalized_path,
+    cyclePath: parseJsonArray(row.participating_files),
+    touchedFiles: parseJsonArray(row.touched_files),
+    commitSha: row.commit_sha,
+    replay,
+  };
+}
+
+function parseReplayBundle(replayBundle: string | null, row: PullRequestCandidateRow): RequiredReplayBundle {
+  if (!replayBundle) {
+    throw new Error(`Patch ${row.patch_id} does not have a replay bundle. Re-scan it after issue #21 is merged.`);
+  }
+
+  let parsed: ReplayBundle;
+  try {
+    parsed = JSON.parse(replayBundle) as ReplayBundle;
+  } catch {
+    throw new Error(`Patch ${row.patch_id} has an invalid replay bundle payload.`);
+  }
+
+  if (!parsed.file_snapshots?.length) {
+    throw new Error(`Patch ${row.patch_id} replay bundle does not contain file snapshots.`);
+  }
+
+  return {
+    source_target: parsed.source_target ?? `${row.owner}/${row.name}`,
+    commit_sha: parsed.commit_sha ?? row.commit_sha,
+    repository: {
+      owner: parsed.repository?.owner ?? row.owner,
+      name: parsed.repository?.name ?? row.name,
+      default_branch: parsed.repository?.default_branch ?? row.default_branch ?? 'main',
+      local_path: parsed.repository?.local_path ?? row.local_path,
+      remote_url: parsed.repository?.remote_url ?? buildGitHubCloneUrl(row.owner, row.name),
+    },
+    cycle: {
+      path: parsed.cycle?.path ?? parseJsonArray(row.participating_files),
+      normalized_path: parsed.cycle?.normalized_path ?? row.normalized_path,
+    },
+    candidate: {
+      classification: parsed.candidate?.classification ?? row.classification,
+      confidence: parsed.candidate?.confidence ?? row.confidence,
+      reasons: parsed.candidate?.reasons ?? parseJsonArray(row.reasons),
+    },
+    validation: {
+      status: parsed.validation?.status ?? row.validation_status ?? 'passed',
+      summary: parsed.validation?.summary ?? row.validation_summary ?? 'Validation passed.',
+    },
+    file_snapshots: parsed.file_snapshots,
+    patch_text: parsed.patch_text ?? row.patch_text,
+  };
+}
+
+async function prepareCheckout(
+  candidate: PullRequestCandidate,
+  explicitRepoPath?: string,
+  checkoutRoot = DEFAULT_CHECKOUT_ROOT,
+): Promise<string> {
+  if (explicitRepoPath) {
+    const repoPath = path.resolve(explicitRepoPath);
+    await fs.access(repoPath);
+    return repoPath;
+  }
+
+  await fs.mkdir(checkoutRoot, { recursive: true });
+  const checkoutPath = await fs.mkdtemp(
+    path.join(
+      checkoutRoot,
+      `${sanitizeSegment(candidate.owner)}-${sanitizeSegment(candidate.name)}-patch-${candidate.patchId}-`,
+    ),
+  );
+
+  const remoteUrl = candidate.replay.repository.remote_url ?? buildGitHubCloneUrl(candidate.owner, candidate.name);
+  await simpleGit().clone(remoteUrl, checkoutPath);
+  return checkoutPath;
+}
+
+async function ensureCheckoutIsClean(git: ReturnType<typeof simpleGit>, checkoutPath: string): Promise<void> {
+  const status = await git.status();
+  if (status.files.length > 0) {
+    throw new Error(`Checkout ${checkoutPath} has uncommitted changes. Use a clean checkout or omit --repo-path.`);
+  }
+}
+
+async function applyFileSnapshots(repoPath: string, snapshots: FileSnapshot[]): Promise<void> {
+  for (const snapshot of snapshots) {
+    const absolutePath = path.join(repoPath, snapshot.path);
+    const currentContent = await readFileIfExists(absolutePath);
+    if (currentContent !== snapshot.before) {
+      throw new Error(`Snapshot precondition failed for ${snapshot.path}. The checkout does not match stored inputs.`);
+    }
+
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, snapshot.after, 'utf8');
+  }
+}
+
+async function readFileIfExists(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) {
+      return '';
+    }
+
+    throw error;
+  }
+}
+
+function buildPullRequestTitle(candidate: PullRequestCandidate): string {
+  const basenames = [...new Set(candidate.cyclePath.map((filePath) => path.basename(filePath)))];
+  if (basenames.length >= 2) {
+    return `Break circular dependency between ${basenames[0]} and ${basenames[1]}`;
+  }
+
+  return `Break circular dependency for patch ${candidate.patchId}`;
+}
+
+function buildPullRequestBody(candidate: PullRequestCandidate, linkedIssueNumber: number): string {
+  const touchedFiles =
+    candidate.touchedFiles.length > 0
+      ? candidate.touchedFiles
+      : candidate.replay.file_snapshots.map((snapshot) => snapshot.path);
+  const reasons = candidate.reasons.length > 0 ? candidate.reasons : (candidate.replay.candidate.reasons ?? []);
+  const confidence = `${Math.round(candidate.confidence * 100)}%`;
+
+  return [
+    `Closes #${linkedIssueNumber}`,
+    '',
+    '## Summary',
+    `- Classification: \`${candidate.classification}\``,
+    `- Confidence: ${confidence}`,
+    `- Cycle: \`${candidate.normalizedPath}\``,
+    `- Source target: \`${candidate.replay.source_target}\``,
+    `- Source commit: \`${candidate.commitSha}\``,
+    `- Patch ID: ${candidate.patchId}`,
+    `- Scan ID: ${candidate.scanId}`,
+    '',
+    '## Touched Files',
+    ...touchedFiles.map((filePath) => `- \`${filePath}\``),
+    '',
+    '## Reasons',
+    ...(reasons.length > 0 ? reasons.map((reason) => `- ${reason}`) : ['- No explicit reasons were stored.']),
+    '',
+    '## Validation',
+    candidate.validationSummary,
+  ].join('\n');
+}
+
+async function createGithubPullRequest(args: {
+  owner: string;
+  name: string;
+  baseBranch: string;
+  branchName: string;
+  title: string;
+  body: string;
+  cwd: string;
+}): Promise<string> {
+  try {
+    const result = await execFileAsync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--repo',
+        `${args.owner}/${args.name}`,
+        '--base',
+        args.baseBranch,
+        '--head',
+        args.branchName,
+        '--title',
+        args.title,
+        '--body',
+        args.body,
+      ],
+      { cwd: args.cwd },
+    );
+
+    const stdout = typeof result === 'string' ? result : result.stdout;
+    return stdout.trim();
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) {
+      throw new Error('GitHub CLI `gh` is required to create pull requests automatically.', { cause: error });
+    }
+
+    throw error;
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    !!error && typeof error === 'object' && 'code' in error && typeof error.code === 'string' && error.code === code
+  );
+}
+
+function buildGitHubCloneUrl(owner: string, name: string): string {
+  return `https://github.com/${owner}/${name}.git`;
+}
+
+function parseJsonArray(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+function sanitizeSegment(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9._-]+/g, '-');
+}

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -1,6 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
 import { createProgram } from './index.js';
 import { scanRepository } from './scanner.js';
@@ -16,6 +17,19 @@ vi.mock('./exportPatches.js', () => ({
     outputDir: path.join(os.tmpdir(), 'patches'),
     exportedCount: 2,
     files: [path.join(os.tmpdir(), 'patches', 'a.patch'), path.join(os.tmpdir(), 'patches', 'b.patch')],
+  }),
+}));
+
+vi.mock('./createPullRequest.js', () => ({
+  createPullRequestForPatch: vi.fn().mockResolvedValue({
+    patchId: 12,
+    repository: 'acme/widget',
+    repoPath: path.join(process.cwd(), '.test-fixtures', 'acme-widget'),
+    branchName: 'codex/issue-42-patch-12',
+    baseBranch: 'main',
+    title: 'Break circular dependency',
+    body: 'Closes #42',
+    prUrl: 'https://github.com/acme/widget/pull/123',
   }),
 }));
 
@@ -91,12 +105,63 @@ describe('CLI', () => {
     consoleSpy.mockRestore();
   });
 
-  it('has all four subcommands registered', () => {
+  it('create:pr command creates a pull request from a stored patch', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'create:pr', '12', '--issue', '42']);
+
+    expect(vi.mocked(createPullRequestForPatch)).toHaveBeenCalledWith(12, {
+      linkedIssueNumber: 42,
+      title: undefined,
+      branchName: undefined,
+      baseBranch: undefined,
+      repoPath: undefined,
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Created PR https://github.com/acme/widget/pull/123 from branch codex/issue-42-patch-12',
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('create:pr command exits on invalid issue number', async () => {
+    const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'create:pr', '12', '--issue', 'not-a-number']);
+
+    expect(consoleErrSpy).toHaveBeenCalledWith('Invalid issue number: not-a-number');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleErrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('create:pr command exits on invalid patch id', async () => {
+    const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'create:pr', 'nope', '--issue', '42']);
+
+    expect(consoleErrSpy).toHaveBeenCalledWith('Invalid patch ID: nope');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleErrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('has all five subcommands registered', () => {
     const program = createProgram();
     const commandNames = program.commands.map((cmd) => cmd.name());
     expect(commandNames).toContain('scan');
     expect(commandNames).toContain('scan:all');
     expect(commandNames).toContain('retry:failed');
+    expect(commandNames).toContain('create:pr');
     expect(commandNames).toContain('export:patches');
   });
 });

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
 import { scanRepository } from './scanner.js';
 
@@ -34,6 +35,53 @@ export function createProgram(): Command {
     .action(() => {
       console.log('Retrying failed patch candidates...');
     });
+
+  program
+    .command('create:pr <patchId>')
+    .requiredOption('--issue <number>', 'Linked issue number to close in the target repository')
+    .option('--title <title>', 'Pull request title override')
+    .option('--branch <branchName>', 'Branch name override')
+    .option('--base <branchName>', 'Base branch override')
+    .option('--repo-path <path>', 'Use an existing clean checkout instead of a scratch clone')
+    .description('Create a branch and GitHub pull request from a stored validated patch')
+    .action(
+      async (
+        patchId: string,
+        options: {
+          issue: string;
+          title?: string;
+          branch?: string;
+          base?: string;
+          repoPath?: string;
+        },
+      ) => {
+        const numericPatchId = Number(patchId);
+        if (!Number.isInteger(numericPatchId) || numericPatchId <= 0) {
+          console.error(`Invalid patch ID: ${patchId}`);
+          process.exit(1);
+        }
+
+        const linkedIssueNumber = Number(options.issue);
+        if (!Number.isInteger(linkedIssueNumber) || linkedIssueNumber <= 0) {
+          console.error(`Invalid issue number: ${options.issue}`);
+          process.exit(1);
+        }
+
+        try {
+          const result = await createPullRequestForPatch(numericPatchId, {
+            linkedIssueNumber,
+            title: options.title,
+            branchName: options.branch,
+            baseBranch: options.base,
+            repoPath: options.repoPath,
+          });
+          console.log(`Created PR ${result.prUrl} from branch ${result.branchName}`);
+        } catch (error) {
+          console.error(`Failed to create PR for patch ${patchId}:`, error);
+          process.exit(1);
+        }
+      },
+    );
 
   program
     .command('export:patches')

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import simpleGit from 'simple-git';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { analyzeRepository } from '../analyzer/analyzer.js';
@@ -47,6 +47,7 @@ vi.mock('../db/index.js', async () => {
 });
 
 describe('Scanner Worker', () => {
+  const absolutePath = path.join(process.cwd(), '.test-fixtures', 'dify-autofix-test');
   let mockGit: Record<string, ReturnType<typeof vi.fn>>;
 
   beforeEach(() => {
@@ -199,7 +200,6 @@ describe('Scanner Worker', () => {
       },
     ]);
 
-    const absolutePath = '/tmp/dify-autofix-test';
     const result = await scanRepository(absolutePath);
 
     expect(result.repoPath).toBe(path.resolve(absolutePath));
@@ -279,7 +279,10 @@ describe('Scanner Worker', () => {
     const result = await scanRepository('org/patch');
     const cycles = dbModule.getCyclesByScanId.all(result.scanId) as Array<{ id: number }>;
     const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as Array<{ id: number }>;
-    const patches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id) as Array<{ id: number; patch_text: string }>;
+    const patches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id) as Array<{
+      id: number;
+      patch_text: string;
+    }>;
     const replay = dbModule.getPatchReplayByPatchId.get(patches[0].id) as {
       source_target: string;
       commit_sha: string;
@@ -291,6 +294,7 @@ describe('Scanner Worker', () => {
     expect(replay.source_target).toBe('org/patch');
     expect(replay.commit_sha).toBe('mock-sha');
     expect(JSON.parse(replay.replay_bundle).file_snapshots).toHaveLength(1);
+    expect(JSON.parse(replay.replay_bundle).repository.remote_url).toBe('https://github.com/org/patch.git');
   });
 
   it('persists failed validation summaries when a generated patch does not validate', async () => {

--- a/cli/scanner.ts
+++ b/cli/scanner.ts
@@ -4,7 +4,6 @@ import simpleGit from 'simple-git';
 import { analyzeRepository } from '../analyzer/analyzer.js';
 import type { GeneratedPatch } from '../codemod/generatePatch.js';
 import { generatePatchForCycle } from '../codemod/generatePatch.js';
-import { validateGeneratedPatch, type ValidationResult } from './validation.js';
 import type { RepositoryDTO } from '../db/index.js';
 import {
   addCycle,
@@ -19,8 +18,11 @@ import {
   updateRepositoryStatus,
   updateScanStatus,
 } from '../db/index.js';
+import { type ValidationResult, validateGeneratedPatch } from './validation.js';
 
 type ScannedCycle = Awaited<ReturnType<typeof analyzeRepository>>[number];
+const GITHUB_HOST = 'github.com';
+const UNKNOWN_REPO = 'unknown-repo';
 
 function parseTargetUrl(targetUrlOrOwnerName: string) {
   let owner = 'unknown';
@@ -31,18 +33,18 @@ function parseTargetUrl(targetUrlOrOwnerName: string) {
     return githubPath;
   }
 
-  if (targetUrlOrOwnerName.includes('github.com')) {
+  if (targetUrlOrOwnerName.includes(GITHUB_HOST)) {
     const withoutHttps = targetUrlOrOwnerName.replace('https://', '').replace('http://', '');
-    const parts = withoutHttps.replace('.git', '').split('github.com/');
+    const parts = withoutHttps.replace('.git', '').split(`${GITHUB_HOST}/`);
     if (parts.length > 1) {
       const pathParts = parts[1].split('/');
       owner = pathParts[0];
-      name = pathParts[1] || 'unknown-repo';
+      name = pathParts[1] || UNKNOWN_REPO;
     }
   } else if (targetUrlOrOwnerName.includes('/')) {
     const parts = targetUrlOrOwnerName.split('/');
     owner = parts[0];
-    name = parts[1] || 'unknown-repo';
+    name = parts[1] || UNKNOWN_REPO;
   }
   return { owner, name };
 }
@@ -86,7 +88,15 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
     const cycles = await analyzeRepository(resolvedTarget.repoPath);
 
     for (const cycle of cycles) {
-      await persistCycle(scanId, resolvedTarget.repoPath, targetUrlOrOwnerName, commitSha, repo, cycle);
+      await persistCycle(
+        scanId,
+        resolvedTarget.repoPath,
+        targetUrlOrOwnerName,
+        commitSha,
+        resolvedTarget.remoteUrl,
+        repo,
+        cycle,
+      );
     }
 
     updateScanStatus.run({ id: scanId, status: 'completed' });
@@ -126,38 +136,45 @@ function ensureRepository(owner: string, name: string, localPath: string | null)
   return { id: info.lastInsertRowid as number, owner, name } as RepositoryDTO;
 }
 
-async function resolveScanTarget(targetUrlOrOwnerName: string, worktreesDir: string): Promise<{
+async function resolveScanTarget(
+  targetUrlOrOwnerName: string,
+  worktreesDir: string,
+): Promise<{
   owner: string;
   name: string;
   repoPath: string;
   localPath: string | null;
   cloneUrl: string | null;
+  remoteUrl: string | null;
 }> {
-  const looksLikeRemoteTarget = targetUrlOrOwnerName.includes('github.com') || targetUrlOrOwnerName.includes('://');
+  const looksLikeRemoteTarget = targetUrlOrOwnerName.includes(GITHUB_HOST) || targetUrlOrOwnerName.includes('://');
   if (!looksLikeRemoteTarget) {
     const localPath = path.resolve(targetUrlOrOwnerName);
     if (await hasExistingDirectory(localPath)) {
-      const { owner, name } = await resolveLocalRepositoryIdentity(localPath);
+      const { owner, name, remoteUrl } = await resolveLocalRepositoryIdentity(localPath);
       return {
         owner,
         name,
         repoPath: localPath,
         localPath,
         cloneUrl: null,
+        remoteUrl,
       };
     }
   }
 
   const { owner, name } = parseTargetUrl(targetUrlOrOwnerName);
+  const cloneUrl =
+    targetUrlOrOwnerName.includes(GITHUB_HOST) || !targetUrlOrOwnerName.includes('/')
+      ? targetUrlOrOwnerName
+      : resolveCloneUrl(owner, name);
   return {
     owner,
     name,
     repoPath: path.join(worktreesDir, `${owner}-${name}`),
     localPath: null,
-    cloneUrl:
-      targetUrlOrOwnerName.includes('github.com') || !targetUrlOrOwnerName.includes('/')
-        ? targetUrlOrOwnerName
-        : resolveCloneUrl(owner, name),
+    cloneUrl,
+    remoteUrl: normalizeRemoteUrl(cloneUrl, owner, name),
   };
 }
 
@@ -193,7 +210,11 @@ async function hasExistingDirectory(repoPath: string): Promise<boolean> {
   return hasClonedRepo(repoPath);
 }
 
-async function resolveLocalRepositoryIdentity(localPath: string): Promise<{ owner: string; name: string }> {
+async function resolveLocalRepositoryIdentity(localPath: string): Promise<{
+  owner: string;
+  name: string;
+  remoteUrl: string | null;
+}> {
   const git = simpleGit(localPath);
 
   try {
@@ -204,15 +225,15 @@ async function resolveLocalRepositoryIdentity(localPath: string): Promise<{ owne
     if (remoteUrl) {
       const parsedRemote = parseGithubPath(remoteUrl);
       if (parsedRemote) {
-        return parsedRemote;
+        return { ...parsedRemote, remoteUrl };
       }
     }
   } catch {
     // Fall back to a local-only identity below.
   }
 
-  const baseName = path.basename(localPath).replace(/\.git$/, '') || 'unknown-repo';
-  return { owner: 'local', name: baseName };
+  const baseName = path.basename(localPath).replace(/\.git$/, '') || UNKNOWN_REPO;
+  return { owner: 'local', name: baseName, remoteUrl: null };
 }
 
 function resolveCloneUrl(owner: string, name: string): string {
@@ -226,13 +247,11 @@ function parseGithubPath(input: string): { owner: string; name: string } | null 
     .replace(/^ssh:\/\//, '')
     .replace(/^git@/, '');
 
-  if (!normalized.includes('github.com')) {
+  if (!normalized.includes(GITHUB_HOST)) {
     return null;
   }
 
-  const githubPath = normalized
-    .replace(/^github\.com[/:]/, '')
-    .replace(/^github\.com$/, '');
+  const githubPath = normalized.replace(/^github\.com[/:]/, '').replace(/^github\.com$/, '');
 
   if (!githubPath) {
     return null;
@@ -243,7 +262,7 @@ function parseGithubPath(input: string): { owner: string; name: string } | null 
     return null;
   }
 
-  return { owner, name: name || 'unknown-repo' };
+  return { owner, name: name || UNKNOWN_REPO };
 }
 
 async function getLatestCommitSha(gitRepo: ReturnType<typeof simpleGit>): Promise<string> {
@@ -260,6 +279,7 @@ async function persistCycle(
   repoPath: string,
   sourceTarget: string,
   commitSha: string,
+  remoteUrl: string | null,
   repository: RepositoryDTO,
   cycle: ScannedCycle,
 ): Promise<void> {
@@ -298,23 +318,23 @@ async function persistCycle(
     scanId,
     sourceTarget,
     commitSha,
+    remoteUrl,
     repository,
     cycle,
     generatedPatch,
     validation,
   });
 
-  getDb()
-    .transaction((patchRow: typeof patchPayload, replayBundleJson: string) => {
-      const patchInfo = addPatch.run(patchRow);
-      addPatchReplay.run({
-        patch_id: patchInfo.lastInsertRowid as number,
-        scan_id: scanId,
-        source_target: sourceTarget,
-        commit_sha: commitSha,
-        replay_bundle: replayBundleJson,
-      });
-    })(patchPayload, JSON.stringify(replayBundle));
+  getDb().transaction((patchRow: typeof patchPayload, replayBundleJson: string) => {
+    const patchInfo = addPatch.run(patchRow);
+    addPatchReplay.run({
+      patch_id: patchInfo.lastInsertRowid as number,
+      scan_id: scanId,
+      source_target: sourceTarget,
+      commit_sha: commitSha,
+      replay_bundle: replayBundleJson,
+    });
+  })(patchPayload, JSON.stringify(replayBundle));
 }
 
 interface PatchReplayBundle {
@@ -326,6 +346,7 @@ interface PatchReplayBundle {
     name: string;
     default_branch: string | null;
     local_path: string | null;
+    remote_url: string | null;
   };
   cycle: {
     path: string[];
@@ -346,6 +367,7 @@ function buildPatchReplayBundle(args: {
   scanId: number;
   sourceTarget: string;
   commitSha: string;
+  remoteUrl: string | null;
   repository: RepositoryDTO;
   cycle: ScannedCycle;
   generatedPatch: GeneratedPatch;
@@ -360,6 +382,7 @@ function buildPatchReplayBundle(args: {
       name: args.repository.name,
       default_branch: args.repository.default_branch ?? null,
       local_path: args.repository.local_path ?? null,
+      remote_url: normalizeRemoteUrl(args.remoteUrl, args.repository.owner, args.repository.name),
     },
     cycle: {
       path: args.cycle.path,
@@ -375,4 +398,20 @@ function buildPatchReplayBundle(args: {
     file_snapshots: args.generatedPatch.fileSnapshots,
     patch_text: args.generatedPatch.patchText,
   };
+}
+
+function normalizeRemoteUrl(remoteUrl: string | null, owner: string, name: string): string | null {
+  if (remoteUrl) {
+    if (parseGithubPath(remoteUrl)) {
+      return remoteUrl;
+    }
+
+    return remoteUrl;
+  }
+
+  if (owner === 'local') {
+    return null;
+  }
+
+  return resolveCloneUrl(owner, name);
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "scan": "tsx cli/index.ts scan",
     "scan:all": "tsx cli/index.ts scan:all",
     "retry:failed": "tsx cli/index.ts retry:failed",
+    "create:pr": "tsx cli/index.ts create:pr",
     "export:patches": "tsx cli/index.ts export:patches",
     "prepare": "husky"
   },


### PR DESCRIPTION
Closes #23

Stacked on #29.

Adds a `create:pr` workflow that reconstructs a validated patch from stored replay data, prepares a checkout from either an existing repo path or a scratch clone, creates a branch at the scanned commit, reapplies the stored file snapshots with precondition checks, pushes the branch, and opens a GitHub pull request with the stored validation metadata.

This also extends replay provenance with the repository remote URL so PR creation can clone from local-scan results instead of depending on a still-present working checkout.

Verification:
- ../../node_modules/.bin/eslint cli/createPullRequest.ts cli/createPullRequest.test.ts cli/index.ts cli/index.test.ts cli/scanner.ts cli/scanner.test.ts
- ../../node_modules/.bin/biome check cli/createPullRequest.ts cli/createPullRequest.test.ts cli/index.ts cli/index.test.ts cli/scanner.ts cli/scanner.test.ts package.json
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/vitest run --config vitest.config.ts