### PR TITLE
Fix remote repository scans

### DIFF
--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -93,6 +93,42 @@ describe('Scanner Worker', () => {
     expect(cycles[0].normalized_path).toBe('a.ts -> b.ts -> a.ts');
   });
 
+  it('does not construct a repo git client before the clone target exists', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+
+    const cloneTarget = path.join(process.cwd(), 'worktrees', 'justin-repo');
+    const rootGit = {
+      clone: vi.fn(),
+      fetch: vi.fn(),
+      log: vi.fn(),
+      getRemotes: vi.fn(),
+    };
+    const repoGit = {
+      clone: vi.fn(),
+      fetch: vi.fn(),
+      log: vi.fn().mockResolvedValue({ latest: { hash: 'mock-sha' } }),
+      getRemotes: vi.fn(),
+    };
+
+    vi.mocked(simpleGit).mockImplementation(((baseDir?: string) => {
+      if (baseDir === undefined) {
+        return rootGit;
+      }
+
+      if (baseDir === cloneTarget) {
+        return repoGit;
+      }
+
+      throw new Error(`Unexpected simple-git baseDir: ${baseDir}`);
+    }) as unknown as typeof simpleGit);
+
+    await expect(scanRepository('justin/repo')).resolves.toMatchObject({
+      repoPath: cloneTarget,
+      cyclesFound: 1,
+    });
+    expect(rootGit.clone).toHaveBeenCalledWith('https://github.com/justin/repo.git', cloneTarget);
+  });
+
   it('fetches existing repo instead of cloning', async () => {
     vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true } as never);
 

--- a/cli/scanner.ts
+++ b/cli/scanner.ts
@@ -50,7 +50,8 @@ function parseTargetUrl(targetUrlOrOwnerName: string) {
 }
 
 export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir = './worktrees') {
-  const resolvedTarget = await resolveScanTarget(targetUrlOrOwnerName, worktreesDir);
+  const resolvedWorktreesDir = path.resolve(worktreesDir);
+  const resolvedTarget = await resolveScanTarget(targetUrlOrOwnerName, resolvedWorktreesDir);
   const { owner, name } = resolvedTarget;
 
   const repo = ensureRepository(owner, name, resolvedTarget.localPath);
@@ -58,14 +59,13 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
   updateRepositoryStatus.run({ id: repo.id, status: 'scanning' });
 
   if (!resolvedTarget.localPath) {
-    await fs.mkdir(worktreesDir, { recursive: true });
+    await fs.mkdir(resolvedWorktreesDir, { recursive: true });
 
     updateRepositoryStatus.run({ id: repo.id, status: 'downloading' });
     const git = simpleGit();
-    const gitRepo = simpleGit(resolvedTarget.repoPath);
 
     try {
-      await syncRepositoryClone(git, gitRepo, resolvedTarget);
+      await syncRepositoryClone(git, resolvedTarget);
     } catch (error) {
       updateRepositoryStatus.run({ id: repo.id, status: 'clone_failed' });
       throw error;
@@ -180,7 +180,6 @@ async function resolveScanTarget(
 
 async function syncRepositoryClone(
   git: ReturnType<typeof simpleGit>,
-  gitRepo: ReturnType<typeof simpleGit>,
   target: {
     owner: string;
     name: string;
@@ -190,6 +189,7 @@ async function syncRepositoryClone(
   },
 ): Promise<void> {
   if (await hasClonedRepo(target.repoPath)) {
+    const gitRepo = simpleGit(target.repoPath);
     await gitRepo.fetch();
     return;
   }


### PR DESCRIPTION
Closes #31

A live smoke run on merged `main` showed that remote scans were constructing `simple-git` against the target checkout path before the repository had been cloned. This patch resolves the worktree path up front, delays repo-scoped `simple-git` construction until the checkout exists, and adds a regression test that fails if we ever instantiate the repo client before clone.

Live verification:
- `../../node_modules/.bin/tsx cli/index.ts scan /Users/justinedwards/git/openclaw` -> completed successfully with 87 cycles
- `../../node_modules/.bin/tsx cli/index.ts scan langgenius/dify` -> completed successfully with 93 cycles after the fix
- `create:pr` replayed a stored patch artifact onto real `chatbox` content, pushed branch `codex/issue-31-patch-1` to a local bare remote, and generated the expected PR payload

Focused verification:
- `../../node_modules/.bin/vitest run --config vitest.config.ts cli/scanner.test.ts`
- `../../node_modules/.bin/eslint cli/scanner.ts cli/scanner.test.ts`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`