### PR TITLE
Improve shared extraction planning

### DIFF
--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -79,12 +79,46 @@ describe('SemanticAnalyzer', () => {
 
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
     expect(result.classification).toBe('autofix_extract_shared');
-    expect(result.reasons[0]).toMatch(/extracting symbols/);
+    expect(result.reasons[0]).toMatch(/helperB/);
+    expect(result.reasons[0]).toMatch(/helperB\.shared\.ts/);
     expect(result.plan).toEqual({
       kind: 'extract_shared',
       sourceFile: 'b.ts',
       targetFile: 'a.ts',
       symbols: ['helperB'],
+      sharedFile: 'helperB.shared.ts',
+      preserveSourceExports: true,
+    });
+  });
+
+  it('avoids colliding with an existing shared module path', () => {
+    analyzer.project.createSourceFile(
+      '/dummy/repo/a.ts',
+      `
+      import { helperB } from './b';
+      export const mainA = () => helperB();
+    `,
+    );
+    analyzer.project.createSourceFile(
+      '/dummy/repo/b.ts',
+      `
+      import { mainA } from './a';
+      export const helperB = () => console.log("B");
+      export const sideEffectB = () => mainA();
+    `,
+    );
+    analyzer.project.createSourceFile('/dummy/repo/helperB.shared.ts', 'export const alreadyThere = true;');
+
+    const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
+
+    expect(result.classification).toBe('autofix_extract_shared');
+    expect(result.plan).toEqual({
+      kind: 'extract_shared',
+      sourceFile: 'b.ts',
+      targetFile: 'a.ts',
+      symbols: ['helperB'],
+      sharedFile: 'b-a.shared.ts',
+      preserveSourceExports: true,
     });
   });
 

--- a/analyzer/semantic.ts
+++ b/analyzer/semantic.ts
@@ -26,6 +26,8 @@ export interface ExtractSharedFixPlan {
   sourceFile: string;
   targetFile: string;
   symbols: string[];
+  sharedFile: string;
+  preserveSourceExports: boolean;
 }
 
 export interface SemanticAnalysisResult {
@@ -138,17 +140,21 @@ export class SemanticAnalyzer {
     );
 
     if (extractionPlan) {
-      const { sourceFile, targetFile, symbols } = extractionPlan;
+      const { sourceFile, targetFile, symbols, sharedFile, preserveSourceExports } = extractionPlan;
 
       return {
         classification: 'autofix_extract_shared',
         confidence: 0.8,
-        reasons: [`Cycle can be resolved by extracting symbols from ${sourceFile} into a shared file.`],
+        reasons: [
+          `Cycle can be resolved by extracting ${symbols.join(', ')} from ${sourceFile} into ${sharedFile} while preserving the ${sourceFile} API.`,
+        ],
         plan: {
           kind: 'extract_shared',
           sourceFile,
           targetFile,
           symbols,
+          sharedFile,
+          preserveSourceExports,
         },
       };
     }
@@ -272,24 +278,101 @@ export class SemanticAnalyzer {
     symbolsFromBUsedInA: string[],
   ): ExtractSharedFixPlan | undefined {
     if (this.isExtractable(sourceFileB, symbolsFromBUsedInA, [fileA])) {
-      return {
-        kind: 'extract_shared',
-        sourceFile: fileB,
-        targetFile: fileA,
-        symbols: symbolsFromBUsedInA,
-      };
+      return this.createExtractSharedPlan(fileB, fileA, symbolsFromBUsedInA);
     }
 
     if (this.isExtractable(sourceFileA, symbolsFromAUsedInB, [fileB])) {
-      return {
-        kind: 'extract_shared',
-        sourceFile: fileA,
-        targetFile: fileB,
-        symbols: symbolsFromAUsedInB,
-      };
+      return this.createExtractSharedPlan(fileA, fileB, symbolsFromAUsedInB);
     }
 
     return undefined;
+  }
+
+  private createExtractSharedPlan(sourceFile: string, targetFile: string, symbols: string[]): ExtractSharedFixPlan {
+    return {
+      kind: 'extract_shared',
+      sourceFile,
+      targetFile,
+      symbols,
+      sharedFile: this.chooseSharedFilePath(sourceFile, targetFile, symbols),
+      preserveSourceExports: true,
+    };
+  }
+
+  private chooseSharedFilePath(sourceFile: string, targetFile: string, symbols: string[]): string {
+    const sourceDir = path.dirname(sourceFile);
+    const sourceExt = path.extname(sourceFile);
+    const targetExt = path.extname(targetFile);
+    const preferredExt = sourceExt === targetExt ? sourceExt : '.ts';
+    const sourceStem = path.basename(sourceFile, sourceExt);
+    const targetStem = path.basename(targetFile, targetExt);
+    const parentStem = sourceDir === '.' ? sourceStem : path.basename(sourceDir);
+    const candidateStems = new Set<string>();
+
+    if (symbols.length === 1) {
+      candidateStems.add(this.formatSharedModuleStem(symbols[0], sourceStem));
+    }
+
+    if (!this.isGenericSharedStem(sourceStem)) {
+      candidateStems.add(sourceStem);
+    }
+
+    if (!this.isGenericSharedStem(parentStem)) {
+      candidateStems.add(parentStem);
+    }
+
+    if (symbols.length === 1 && !this.isGenericSharedStem(sourceStem)) {
+      candidateStems.add(`${sourceStem}-${this.formatSharedModuleStem(symbols[0], sourceStem)}`);
+    }
+
+    candidateStems.add(`${sourceStem}-${targetStem}`);
+
+    for (const candidateStem of candidateStems) {
+      const sharedFile = this.normalizeRepoRelativePath(path.join(sourceDir, `${candidateStem}.shared${preferredExt}`));
+      if (sharedFile === sourceFile || sharedFile === targetFile) {
+        continue;
+      }
+
+      if (!this.pathExistsInRepo(sharedFile)) {
+        return sharedFile;
+      }
+    }
+
+    return this.normalizeRepoRelativePath(path.join(sourceDir, `${sourceStem}-${targetStem}.shared${preferredExt}`));
+  }
+
+  private formatSharedModuleStem(symbol: string, referenceStem: string): string {
+    if (referenceStem.includes('-')) {
+      return this.toSeparatedCase(symbol, '-');
+    }
+
+    if (referenceStem.includes('_')) {
+      return this.toSeparatedCase(symbol, '_');
+    }
+
+    return symbol;
+  }
+
+  private toSeparatedCase(value: string, separator: '-' | '_'): string {
+    return value
+      .replaceAll(/([a-z0-9])([A-Z])/g, `$1${separator}$2`)
+      .replaceAll(/[^a-zA-Z0-9]+/g, separator)
+      .replaceAll(new RegExp(`${separator}+`, 'g'), separator)
+      .replaceAll(new RegExp(`^${separator}|${separator}$`, 'g'), '')
+      .toLowerCase();
+  }
+
+  private isGenericSharedStem(stem: string): boolean {
+    return stem.length <= 1 || ['index', 'types', 'type', 'utils', 'shared'].includes(stem.toLowerCase());
+  }
+
+  private pathExistsInRepo(relativePath: string): boolean {
+    const absolutePath = path.join(this.repoPath, relativePath);
+    return !!this.project.getSourceFile(absolutePath) || fs.existsSync(absolutePath);
+  }
+
+  private normalizeRepoRelativePath(filePath: string): string {
+    return filePath.split(path.sep).join('/');
   }
 
   private buildDirectImportPlan(cycleFiles: string[]): DirectImportSearchResult {

--- a/codemod/generatePatch.test.ts
+++ b/codemod/generatePatch.test.ts
@@ -72,15 +72,20 @@ describe('generatePatchForCycle', () => {
         sourceFile: 'b.ts',
         targetFile: 'a.ts',
         symbols: ['helperB'],
+        sharedFile: 'helperB.shared.ts',
+        preserveSourceExports: true,
       },
     };
 
     const patch = await generatePatchForCycle(repoPath, cycle, analysis);
 
     expect(patch).not.toBeNull();
-    expect(patch?.patchText).toContain('b-a.shared');
+    expect(patch?.patchText).toContain('helperB.shared');
     expect(patch?.patchText).toContain("export const helperB = () => 'ok';");
-    expect(patch?.touchedFiles).toEqual(['b.ts', 'a.ts', 'b-a.shared.ts']);
+    expect(patch?.touchedFiles).toEqual(['b.ts', 'a.ts', 'helperB.shared.ts']);
+    const sourceSnapshot = patch?.fileSnapshots.find((snapshot) => snapshot.path === 'b.ts');
+    expect(sourceSnapshot?.after).toMatch(/export \{ helperB \} from ['"]\.\/helperB\.shared['"];/);
+    expect(sourceSnapshot?.after).not.toMatch(/import \{ helperB \} from ['"]\.\/helperB\.shared['"];/);
   });
 
   it('creates a direct-import patch when a safe leaf is reachable through a barrel', async () => {

--- a/codemod/generatePatch.ts
+++ b/codemod/generatePatch.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { type ImportDeclaration, Project, type SourceFile } from 'ts-morph';
+import { type ImportDeclaration, Project, type SourceFile, SyntaxKind } from 'ts-morph';
 import type { CircularDependency } from '../analyzer/analyzer.js';
 import type {
   DirectImportFixPlan,
@@ -110,8 +110,8 @@ async function generateExtractSharedPatch(
   const project = createProject();
   const sourceFile = getProjectSourceFile(project, repoPath, plan.sourceFile);
   const targetFile = getProjectSourceFile(project, repoPath, plan.targetFile);
-  const sharedFilePath = chooseSharedFilePath(repoPath, plan.sourceFile, plan.targetFile);
-  const sharedRelativePath = path.relative(repoPath, sharedFilePath).split(path.sep).join('/');
+  const sharedFilePath = path.resolve(repoPath, plan.sharedFile);
+  const sharedRelativePath = plan.sharedFile;
 
   const sourceBefore = sourceFile.getFullText();
   const targetBefore = targetFile.getFullText();
@@ -141,8 +141,12 @@ async function generateExtractSharedPatch(
   );
 
   addNamedImport(targetFile, sharedImportSpecifier, plan.symbols);
-  addNamedImport(sourceFile, sharedImportSpecifierFromSource, plan.symbols);
-  addNamedExport(sourceFile, sharedImportSpecifierFromSource, plan.symbols);
+  if (sourceFileNeedsSharedImport(sourceFile, plan.symbols)) {
+    addNamedImport(sourceFile, sharedImportSpecifierFromSource, plan.symbols);
+  }
+  if (plan.preserveSourceExports) {
+    addNamedExport(sourceFile, sharedImportSpecifierFromSource, plan.symbols);
+  }
 
   const extension = path.extname(sharedFilePath);
   const sharedFile = project.createSourceFile(sharedFilePath, `${extractedDeclarations.join('\n\n')}\n`, {
@@ -318,17 +322,6 @@ function createUnifiedPatch(snapshot: FileSnapshot): string {
   ].join('\n');
 }
 
-function chooseSharedFilePath(repoPath: string, sourceFile: string, targetFile: string): string {
-  const sourceDir = path.dirname(path.resolve(repoPath, sourceFile));
-  const sourceExt = path.extname(sourceFile);
-  const targetExt = path.extname(targetFile);
-  const preferredExt = sourceExt === targetExt ? sourceExt : '.ts';
-  const sourceStem = path.basename(sourceFile, sourceExt);
-  const targetStem = path.basename(targetFile, targetExt);
-
-  return path.join(sourceDir, `${sourceStem}-${targetStem}.shared${preferredExt}`);
-}
-
 function findExtractableDeclaration(sourceFile: SourceFile, symbol: string) {
   return (
     sourceFile.getInterface(symbol) ||
@@ -360,6 +353,13 @@ function cleanupImports(sourceFile: SourceFile, targetFile: string, extractedNam
       importDecl.remove();
     }
   }
+}
+
+function sourceFileNeedsSharedImport(sourceFile: SourceFile, symbols: string[]): boolean {
+  const extractedNameSet = new Set(symbols);
+  return sourceFile
+    .getDescendantsOfKind(SyntaxKind.Identifier)
+    .some((identifier) => extractedNameSet.has(identifier.getText()));
 }
 
 function addNamedImport(sourceFile: SourceFile, moduleSpecifier: string, names: string[]) {


### PR DESCRIPTION
Closes #34

This is the first maintainer-friendliness slice for shared extraction. It makes the semantic plan explicit about the shared module path and API-preservation strategy, and updates the codemod to honor that richer plan.

What changed:
- `extract_shared` plans now include `sharedFile` and `preserveSourceExports`
- shared module naming is now symbol/source driven instead of always `<source>-<target>.shared.ts`
- plan generation avoids colliding with an existing shared-module path
- source modules now preserve their API with a re-export, without adding an unnecessary import when the source no longer references the extracted symbol

This does not solve the whole acceptance problem yet, but it removes one major source of arbitrary file naming and one concrete diff-quality problem in the shared extraction path.

Verification:
- `../../node_modules/.bin/vitest run --config vitest.config.ts analyzer/semantic.test.ts codemod/generatePatch.test.ts`
- `../../node_modules/.bin/vitest run --config vitest.config.ts`
- `../../node_modules/.bin/eslint analyzer/semantic.ts analyzer/semantic.test.ts codemod/generatePatch.ts codemod/generatePatch.test.ts`
- `../../node_modules/.bin/biome check analyzer/semantic.ts analyzer/semantic.test.ts codemod/generatePatch.ts codemod/generatePatch.test.ts`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`