### PR TITLE
Add multi-strategy cycle planner

### DIFF
--- a/analyzer/analyzer.test.ts
+++ b/analyzer/analyzer.test.ts
@@ -201,4 +201,40 @@ describe('analyzeRepository', () => {
     const result = await analyzeRepository('/some/path');
     expect(result).toHaveLength(2);
   });
+
+  it('normalizes dependency-cruiser paths back to repo-relative paths', async () => {
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/repos/autofix/worktrees/issue-123');
+
+    mockCruise.mockResolvedValue({
+      output: {
+        summary: {
+          violations: [
+            {
+              type: 'cycle',
+              from: '../../../openclaw/src/a.ts',
+              to: '../../../openclaw/src/b.ts',
+              rule: { name: 'no-circular', severity: 'warn' },
+              cycle: [{ name: '../../../openclaw/src/b.ts' }, { name: '../../../openclaw/src/a.ts' }],
+            },
+          ],
+          error: 0,
+          warn: 1,
+          info: 0,
+          ignore: 0,
+          totalCruised: 2,
+          totalDependenciesCruised: 2,
+          optionsUsed: {},
+        },
+        modules: [],
+      },
+      exitCode: 0,
+    } as unknown as IReporterOutput);
+
+    const result = await analyzeRepository('/repos/openclaw');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toEqual(['src/a.ts', 'src/b.ts', 'src/a.ts']);
+
+    cwdSpy.mockRestore();
+  });
 });

--- a/analyzer/analyzer.ts
+++ b/analyzer/analyzer.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { cruise } from 'dependency-cruiser';
 import { type SemanticAnalysisResult, SemanticAnalyzer } from './semantic.js';
 
@@ -8,8 +9,10 @@ export interface CircularDependency {
 }
 
 export async function analyzeRepository(repoPath: string): Promise<CircularDependency[]> {
+  const resolvedRepoPath = path.resolve(repoPath);
+
   try {
-    const result = await cruise([repoPath], {
+    const result = await cruise([resolvedRepoPath], {
       exclude: {
         path: ['node_modules', 'dist', 'coverage', 'build', String.raw`\.git`, String.raw`\.next`, String.raw`\.cache`],
       },
@@ -30,7 +33,7 @@ export async function analyzeRepository(repoPath: string): Promise<CircularDepen
     });
 
     const circularDependencies: CircularDependency[] = [];
-    const semanticAnalyzer = new SemanticAnalyzer(repoPath);
+    const semanticAnalyzer = new SemanticAnalyzer(resolvedRepoPath);
 
     const output = result.output;
     if (typeof output === 'string') {
@@ -43,9 +46,15 @@ export async function analyzeRepository(repoPath: string): Promise<CircularDepen
           const cyclePath: string[] = [];
           const violationWithCycle = violation as { cycle?: Array<{ name: string }> } & typeof violation;
           if (violation.type === 'cycle' && violationWithCycle.cycle) {
-            cyclePath.push(violation.from, ...violationWithCycle.cycle.map((c) => c.name));
+            cyclePath.push(
+              normalizeModulePath(resolvedRepoPath, violation.from),
+              ...violationWithCycle.cycle.map((c) => normalizeModulePath(resolvedRepoPath, c.name)),
+            );
           } else {
-            cyclePath.push(violation.from, violation.to);
+            cyclePath.push(
+              normalizeModulePath(resolvedRepoPath, violation.from),
+              normalizeModulePath(resolvedRepoPath, violation.to),
+            );
           }
 
           circularDependencies.push({
@@ -62,4 +71,28 @@ export async function analyzeRepository(repoPath: string): Promise<CircularDepen
     console.error('Error analyzing repository:', error);
     throw error;
   }
+}
+
+function normalizeModulePath(repoPath: string, modulePath: string): string {
+  const normalizedModulePath = modulePath.split(path.sep).join('/');
+  if (path.isAbsolute(modulePath)) {
+    return path.relative(repoPath, modulePath).split(path.sep).join('/');
+  }
+
+  const repoRelativeCandidate = path.resolve(repoPath, modulePath);
+  if (isWithinRepo(repoPath, repoRelativeCandidate)) {
+    return path.relative(repoPath, repoRelativeCandidate).split(path.sep).join('/');
+  }
+
+  const cwdRelativeCandidate = path.resolve(process.cwd(), modulePath);
+  if (isWithinRepo(repoPath, cwdRelativeCandidate)) {
+    return path.relative(repoPath, cwdRelativeCandidate).split(path.sep).join('/');
+  }
+
+  return normalizedModulePath;
+}
+
+function isWithinRepo(repoPath: string, candidatePath: string): boolean {
+  const relativePath = path.relative(repoPath, candidatePath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }

--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -22,6 +22,17 @@ describe('SemanticAnalyzer', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'c.ts', 'a.ts']);
     expect(result.classification).toBe('unsupported');
     expect(result.reasons[0]).toMatch(/Only two-file cycles/);
+    expect(result.planner).toMatchObject({
+      cycleShape: 'multi_file',
+      selectedStrategy: undefined,
+    });
+    expect(result.planner?.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ strategy: 'import_type', status: 'not_applicable' }),
+        expect.objectContaining({ strategy: 'direct_import', status: 'rejected' }),
+        expect.objectContaining({ strategy: 'extract_shared', status: 'not_applicable' }),
+      ]),
+    );
   });
 
   it('rejects cycles where files cannot be read', () => {
@@ -29,6 +40,11 @@ describe('SemanticAnalyzer', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
     expect(result.classification).toBe('unsupported');
     expect(result.reasons[0]).toMatch(/could not be read/);
+    expect(result.planner).toMatchObject({
+      cycleShape: 'two_file',
+      selectedStrategy: undefined,
+    });
+    expect(result.planner?.cycleSignals.missingFiles).toBe(2);
   });
 
   it('detects type-only cycles', () => {
@@ -51,6 +67,26 @@ describe('SemanticAnalyzer', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
     expect(result.classification).toBe('autofix_import_type');
     expect(result.reasons[0]).toMatch(/converting concrete imports to type-only/);
+    expect(result.upstreamabilityScore).toBe(0.94);
+    expect(result.planner).toMatchObject({
+      cycleShape: 'two_file',
+      selectedStrategy: 'import_type',
+      selectedClassification: 'autofix_import_type',
+      selectedScore: 0.94,
+    });
+    expect(result.planner?.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          strategy: 'import_type',
+          status: 'candidate',
+          signals: expect.objectContaining({
+            importEdges: 2,
+            introducesNewFile: false,
+          }),
+        }),
+        expect.objectContaining({ strategy: 'direct_import', status: 'not_applicable' }),
+      ]),
+    );
     expect(result.plan).toEqual({
       kind: 'import_type',
       imports: [
@@ -81,6 +117,24 @@ describe('SemanticAnalyzer', () => {
     expect(result.classification).toBe('autofix_extract_shared');
     expect(result.reasons[0]).toMatch(/helperB/);
     expect(result.reasons[0]).toMatch(/helperB\.shared\.ts/);
+    expect(result.planner).toMatchObject({
+      cycleShape: 'two_file',
+      selectedStrategy: 'extract_shared',
+      selectedClassification: 'autofix_extract_shared',
+    });
+    expect(result.planner?.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          strategy: 'extract_shared',
+          status: 'candidate',
+          signals: expect.objectContaining({
+            introducesNewFile: true,
+            preservesSourceExports: true,
+            sharedFile: 'helperB.shared.ts',
+          }),
+        }),
+      ]),
+    );
     expect(result.plan).toEqual({
       kind: 'extract_shared',
       sourceFile: 'b.ts',
@@ -148,6 +202,12 @@ describe('SemanticAnalyzer', () => {
 
     const result = analyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
     expect(result.classification).toBe('autofix_direct_import');
+    expect(result.planner).toMatchObject({
+      cycleShape: 'multi_file',
+      selectedStrategy: 'direct_import',
+      selectedClassification: 'autofix_direct_import',
+      selectedScore: 0.89,
+    });
     expect(result.plan).toEqual({
       kind: 'direct_import',
       imports: [
@@ -207,6 +267,16 @@ describe('SemanticAnalyzer', () => {
 
     const result = analyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
     expect(result.classification).toBe('suggest_manual');
+    expect(result.planner?.selectionSummary).toMatch(/falling back to suggest_manual/);
+    expect(result.planner?.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          strategy: 'direct_import',
+          status: 'rejected',
+          reasons: expect.arrayContaining([expect.stringMatching(/ambiguous or side-effectful/)]),
+        }),
+      ]),
+    );
   });
 
   it('suggests manual when imports are not found', () => {
@@ -215,6 +285,8 @@ describe('SemanticAnalyzer', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
     expect(result.classification).toBe('suggest_manual');
     expect(result.reasons[0]).toMatch(/explicit imports/);
+    expect(result.planner?.selectionSummary).toMatch(/falling back to suggest_manual/);
+    expect(result.planner?.cycleSignals.explicitImportEdges).toBe(0);
   });
 
   it('rejects extraction if symbol is not exported', () => {

--- a/analyzer/semantic.ts
+++ b/analyzer/semantic.ts
@@ -30,16 +30,71 @@ export interface ExtractSharedFixPlan {
   preserveSourceExports: boolean;
 }
 
+export type PlanningStrategy = 'import_type' | 'direct_import' | 'extract_shared';
+export type StrategySignalValue = boolean | number | string;
+
+const missingCycleFilesReason = 'Files participating in the cycle could not be read or found.';
+
+export interface StrategyAttempt {
+  strategy: PlanningStrategy;
+  status: 'candidate' | 'rejected' | 'not_applicable';
+  summary: string;
+  reasons: string[];
+  signals: Record<string, StrategySignalValue>;
+  score?: number;
+  scoreBreakdown?: string[];
+  classification?: Classification;
+  confidence?: number;
+  plan?: ImportTypeFixPlan | DirectImportFixPlan | ExtractSharedFixPlan;
+}
+
+export interface CyclePlanningResult {
+  cycleFiles: string[];
+  cycleSize: number;
+  cycleShape: 'two_file' | 'multi_file';
+  cycleSignals: Record<string, StrategySignalValue>;
+  fallbackClassification: Classification;
+  fallbackConfidence: number;
+  fallbackReasons: string[];
+  selectedStrategy?: PlanningStrategy;
+  selectedClassification?: Classification;
+  selectedScore?: number;
+  selectionSummary: string;
+  attempts: StrategyAttempt[];
+}
+
 export interface SemanticAnalysisResult {
   classification: Classification;
   confidence: number;
   reasons: string[];
   plan?: ImportTypeFixPlan | DirectImportFixPlan | ExtractSharedFixPlan;
+  upstreamabilityScore?: number;
+  planner?: CyclePlanningResult;
 }
 
 interface DirectImportSearchResult {
   plan?: DirectImportFixPlan['imports'];
   sawBarrelScenario: boolean;
+}
+
+interface CyclePlanningContext {
+  cyclePath: string[];
+  uniqueFiles: string[];
+  cycleShape: 'two_file' | 'multi_file';
+  sourceFiles: Map<string, SourceFile | undefined>;
+  importsAToB: ImportDeclaration[];
+  importsBToA: ImportDeclaration[];
+  cycleSignals: Record<string, StrategySignalValue>;
+}
+
+interface StrategyDefinition {
+  strategy: PlanningStrategy;
+  describeApplicability: (context: CyclePlanningContext) => {
+    applicable: boolean;
+    summary: string;
+    signals: Record<string, StrategySignalValue>;
+  };
+  evaluate: (context: CyclePlanningContext) => StrategyAttempt;
 }
 
 export class SemanticAnalyzer {
@@ -56,26 +111,185 @@ export class SemanticAnalyzer {
   }
 
   public analyzeCycle(cyclePath: string[]): SemanticAnalysisResult {
-    const uniqueFiles = [...new Set(cyclePath)];
-    const directImportResult = uniqueFiles.length > 2 ? this.buildDirectImportPlan(uniqueFiles) : undefined;
+    const planning = this.planCycle(cyclePath);
+    const selectedAttempt =
+      planning.selectedStrategy === undefined
+        ? undefined
+        : planning.attempts.find(
+            (attempt) => attempt.strategy === planning.selectedStrategy && attempt.status === 'candidate',
+          );
 
-    if (directImportResult?.plan && directImportResult.plan.length > 0) {
-      const { barrelFile, targetFile, symbols } = directImportResult.plan[0];
+    if (selectedAttempt?.classification && selectedAttempt.confidence !== undefined) {
       return {
-        classification: 'autofix_direct_import',
-        confidence: 0.85,
-        reasons: [
-          `Cycle can be resolved by importing ${symbols.join(', ')} directly from ${targetFile} instead of ${barrelFile}.`,
-        ],
-        plan: {
-          kind: 'direct_import',
-          imports: directImportResult.plan,
-        },
+        classification: selectedAttempt.classification,
+        confidence: selectedAttempt.confidence,
+        reasons: selectedAttempt.reasons,
+        plan: selectedAttempt.plan,
+        upstreamabilityScore: selectedAttempt.score,
+        planner: planning,
       };
     }
 
-    if (uniqueFiles.length > 2) {
-      if (directImportResult?.sawBarrelScenario) {
+    return {
+      classification: planning.fallbackClassification,
+      confidence: planning.fallbackConfidence,
+      reasons: planning.fallbackReasons,
+      planner: planning,
+    };
+  }
+
+  public planCycle(cyclePath: string[]): CyclePlanningResult {
+    const context = this.buildPlanningContext(cyclePath);
+    const attempts = this.getStrategyDefinitions().map((strategy) => this.evaluateStrategy(strategy, context));
+    const selectedAttempt = this.selectBestAttempt(attempts);
+    const fallbackDecision = this.determineFallbackDecision(context, attempts);
+
+    return {
+      cycleFiles: context.uniqueFiles,
+      cycleSize: context.uniqueFiles.length,
+      cycleShape: context.cycleShape,
+      cycleSignals: context.cycleSignals,
+      fallbackClassification: selectedAttempt?.classification ?? fallbackDecision.classification,
+      fallbackConfidence: selectedAttempt?.confidence ?? fallbackDecision.confidence,
+      fallbackReasons: selectedAttempt?.reasons ?? fallbackDecision.reasons,
+      selectedStrategy: selectedAttempt?.strategy,
+      selectedClassification: selectedAttempt?.classification,
+      selectedScore: selectedAttempt?.score,
+      selectionSummary: selectedAttempt
+        ? `Selected ${selectedAttempt.strategy} with score ${selectedAttempt.score ?? 0} after evaluating ${attempts.length} strategies.`
+        : `No strategy cleared the safety filters; falling back to ${fallbackDecision.classification}.`,
+      attempts,
+    };
+  }
+
+  private buildPlanningContext(cyclePath: string[]): CyclePlanningContext {
+    const uniqueFiles = [...new Set(cyclePath)];
+    const cycleShape = uniqueFiles.length === 2 ? 'two_file' : 'multi_file';
+    const sourceFiles = new Map<string, SourceFile | undefined>(
+      uniqueFiles.map((filePath) => [filePath, this.loadCycleSourceFile(filePath)]),
+    );
+    const [fileA, fileB] = uniqueFiles;
+    const sourceFileA = fileA ? sourceFiles.get(fileA) : undefined;
+    const sourceFileB = fileB ? sourceFiles.get(fileB) : undefined;
+    const importsAToB = sourceFileA && fileB ? this.findImportsTo(sourceFileA, fileB) : [];
+    const importsBToA = sourceFileB && fileA ? this.findImportsTo(sourceFileB, fileA) : [];
+
+    return {
+      cyclePath,
+      uniqueFiles,
+      cycleShape,
+      sourceFiles,
+      importsAToB,
+      importsBToA,
+      cycleSignals: {
+        explicitImportEdges: importsAToB.length + importsBToA.length,
+        loadedFiles: [...sourceFiles.values()].filter(Boolean).length,
+        missingFiles: [...sourceFiles.values()].filter((sourceFile) => !sourceFile).length,
+      },
+    };
+  }
+
+  private getStrategyDefinitions(): StrategyDefinition[] {
+    return [
+      {
+        strategy: 'import_type',
+        describeApplicability: (context) => ({
+          applicable: context.cycleShape === 'two_file',
+          summary:
+            context.cycleShape === 'two_file'
+              ? 'Type-only import conversion can be evaluated for two-file cycles.'
+              : 'Type-only conversion is only supported for two-file cycles.',
+          signals: {
+            cycleShape: context.cycleShape,
+            cycleSize: context.uniqueFiles.length,
+          },
+        }),
+        evaluate: (context) => {
+          const [fileA, fileB] = context.uniqueFiles;
+
+          if (this.contextHasMissingFiles(context)) {
+            return this.createRejectedAttempt('import_type', missingCycleFilesReason, [missingCycleFilesReason], {
+              fileA: fileA ?? 'unknown',
+              fileB: fileB ?? 'unknown',
+            });
+          }
+
+          return this.evaluateImportTypeAttempt(fileA ?? '', fileB ?? '', context.importsAToB, context.importsBToA);
+        },
+      },
+      {
+        strategy: 'direct_import',
+        describeApplicability: (context) => ({
+          applicable: context.cycleShape === 'multi_file',
+          summary:
+            context.cycleShape === 'multi_file'
+              ? 'Direct-import rewriting can be evaluated for barrel-driven multi-file cycles.'
+              : 'Direct-import rewriting only applies to barrel-driven cycles with 3+ files.',
+          signals: {
+            cycleShape: context.cycleShape,
+            cycleSize: context.uniqueFiles.length,
+          },
+        }),
+        evaluate: (context) => this.evaluateDirectImportAttempt(context.uniqueFiles),
+      },
+      {
+        strategy: 'extract_shared',
+        describeApplicability: (context) => ({
+          applicable: context.cycleShape === 'two_file',
+          summary:
+            context.cycleShape === 'two_file'
+              ? 'Shared-module extraction can be evaluated for two-file cycles.'
+              : 'Shared extraction is only supported for two-file cycles.',
+          signals: {
+            cycleShape: context.cycleShape,
+            cycleSize: context.uniqueFiles.length,
+          },
+        }),
+        evaluate: (context) => {
+          const [fileA, fileB] = context.uniqueFiles;
+          const sourceFileA = fileA ? context.sourceFiles.get(fileA) : undefined;
+          const sourceFileB = fileB ? context.sourceFiles.get(fileB) : undefined;
+
+          if (!fileA || !fileB || !sourceFileA || !sourceFileB) {
+            return this.createRejectedAttempt('extract_shared', missingCycleFilesReason, [missingCycleFilesReason], {
+              fileA: fileA ?? 'unknown',
+              fileB: fileB ?? 'unknown',
+            });
+          }
+
+          return this.evaluateExtractSharedAttempt(
+            fileA,
+            fileB,
+            sourceFileA,
+            sourceFileB,
+            context.importsAToB,
+            context.importsBToA,
+          );
+        },
+      },
+    ];
+  }
+
+  private evaluateStrategy(strategy: StrategyDefinition, context: CyclePlanningContext): StrategyAttempt {
+    const applicability = strategy.describeApplicability(context);
+    if (!applicability.applicable) {
+      return this.createNotApplicableAttempt(strategy.strategy, applicability.summary, applicability.signals);
+    }
+
+    return strategy.evaluate(context);
+  }
+
+  private determineFallbackDecision(
+    context: CyclePlanningContext,
+    attempts: StrategyAttempt[],
+  ): {
+    classification: Classification;
+    confidence: number;
+    reasons: string[];
+  } {
+    if (context.cycleShape === 'multi_file') {
+      const directImportAttempt = attempts.find((attempt) => attempt.strategy === 'direct_import');
+      if (directImportAttempt?.reasons.some((reason) => reason.includes('Barrel re-export graph is ambiguous'))) {
         return {
           classification: 'suggest_manual',
           confidence: 0.6,
@@ -83,31 +297,24 @@ export class SemanticAnalyzer {
         };
       }
 
-      /* v8 ignore next 5 */
       return {
         classification: 'unsupported',
         confidence: 1,
-        reasons: ['Only two-file cycles are supported for autofix in v1.'],
+        reasons: [
+          'Only two-file cycles are supported for autofix in v1, except for safe barrel direct-import rewrites.',
+        ],
       };
     }
 
-    const [fileA, fileB] = uniqueFiles;
-    const sfA = this.loadCycleSourceFile(fileA);
-    const sfB = this.loadCycleSourceFile(fileB);
-
-    if (!sfA || !sfB) {
-      /* v8 ignore next 5 */
+    if (this.contextHasMissingFiles(context)) {
       return {
         classification: 'unsupported',
         confidence: 1,
-        reasons: ['Files participating in the cycle could not be read or found.'],
+        reasons: [missingCycleFilesReason],
       };
     }
 
-    const importsAToB = this.findImportsTo(sfA, fileB);
-    const importsBToA = this.findImportsTo(sfB, fileA);
-
-    if (importsAToB.length === 0 && importsBToA.length === 0) {
+    if (context.importsAToB.length === 0 && context.importsBToA.length === 0) {
       return {
         classification: 'suggest_manual',
         confidence: 0.8,
@@ -115,56 +322,15 @@ export class SemanticAnalyzer {
       };
     }
 
-    const typeOnlyImports = this.buildImportTypePlan(fileA, fileB, importsAToB, importsBToA);
-    if (typeOnlyImports.length > 0) {
-      return {
-        classification: 'autofix_import_type',
-        confidence: 0.9,
-        reasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
-        plan: {
-          kind: 'import_type',
-          imports: typeOnlyImports,
-        },
-      };
-    }
-
-    const symbolsFromBUsedInA = this.getImportedSymbolNames(importsAToB);
-    const symbolsFromAUsedInB = this.getImportedSymbolNames(importsBToA);
-    const extractionPlan = this.buildExtractSharedPlan(
-      fileA,
-      fileB,
-      sfA,
-      sfB,
-      symbolsFromAUsedInB,
-      symbolsFromBUsedInA,
-    );
-
-    if (extractionPlan) {
-      const { sourceFile, targetFile, symbols, sharedFile, preserveSourceExports } = extractionPlan;
-
-      return {
-        classification: 'autofix_extract_shared',
-        confidence: 0.8,
-        reasons: [
-          `Cycle can be resolved by extracting ${symbols.join(', ')} from ${sourceFile} into ${sharedFile} while preserving the ${sourceFile} API.`,
-        ],
-        plan: {
-          kind: 'extract_shared',
-          sourceFile,
-          targetFile,
-          symbols,
-          sharedFile,
-          preserveSourceExports,
-        },
-      };
-    }
-
-    // fallback
     return {
       classification: 'suggest_manual',
       confidence: 0.5,
       reasons: ['Implementation logic extraction requires deeper symbol analysis. Defaulting to manual review.'],
     };
+  }
+
+  private contextHasMissingFiles(context: CyclePlanningContext): boolean {
+    return [...context.sourceFiles.values()].some((sourceFile) => !sourceFile);
   }
 
   private getImportedSymbolNames(importNodes: ImportDeclaration[]): string[] {
@@ -175,6 +341,281 @@ export class SemanticAnalyzer {
       }
     }
     return [...names];
+  }
+
+  private evaluateImportTypeAttempt(
+    fileA: string,
+    fileB: string,
+    importsAToB: ImportDeclaration[],
+    importsBToA: ImportDeclaration[],
+  ): StrategyAttempt {
+    const importPlans = this.buildImportTypePlan(fileA, fileB, importsAToB, importsBToA);
+    if (importPlans.length === 0) {
+      const importEdgeCount = importsAToB.length + importsBToA.length;
+      return this.createRejectedAttempt(
+        'import_type',
+        'Imports cross the cycle, but at least one edge is used in runtime positions.',
+        importEdgeCount === 0
+          ? ['Could not statically resolve any explicit import edge that can be converted to type-only.']
+          : ['At least one import edge is used at runtime, so a type-only rewrite would be unsafe.'],
+        {
+          importEdgeCount,
+          fileA,
+          fileB,
+        },
+      );
+    }
+
+    const scoring = this.scoreImportTypePlan(importPlans);
+    return {
+      strategy: 'import_type',
+      status: 'candidate',
+      summary: `Convert ${importPlans.length} import edge(s) to type-only imports.`,
+      reasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+      signals: scoring.signals,
+      score: scoring.score,
+      scoreBreakdown: scoring.breakdown,
+      classification: 'autofix_import_type',
+      confidence: 0.9,
+      plan: {
+        kind: 'import_type',
+        imports: importPlans,
+      },
+    };
+  }
+
+  private evaluateExtractSharedAttempt(
+    fileA: string,
+    fileB: string,
+    sourceFileA: SourceFile,
+    sourceFileB: SourceFile,
+    importsAToB: ImportDeclaration[],
+    importsBToA: ImportDeclaration[],
+  ): StrategyAttempt {
+    const symbolsFromBUsedInA = this.getImportedSymbolNames(importsAToB);
+    const symbolsFromAUsedInB = this.getImportedSymbolNames(importsBToA);
+    const extractionPlan = this.buildExtractSharedPlan(
+      fileA,
+      fileB,
+      sourceFileA,
+      sourceFileB,
+      symbolsFromAUsedInB,
+      symbolsFromBUsedInA,
+    );
+
+    if (!extractionPlan) {
+      return this.createRejectedAttempt(
+        'extract_shared',
+        'No leaf-like exported symbol could be extracted safely without recreating the cycle.',
+        [
+          'Imported symbols are either not exported, rely on runtime state from the cycle, or use declaration shapes that are not yet supported.',
+        ],
+        {
+          symbolsFromAUsedInB: symbolsFromAUsedInB.join(',') || 'none',
+          symbolsFromBUsedInA: symbolsFromBUsedInA.join(',') || 'none',
+          fileA,
+          fileB,
+        },
+      );
+    }
+
+    const scoring = this.scoreExtractSharedPlan(extractionPlan);
+    return {
+      strategy: 'extract_shared',
+      status: 'candidate',
+      summary: `Extract ${extractionPlan.symbols.join(', ')} into ${extractionPlan.sharedFile} and preserve ${extractionPlan.sourceFile}'s exports.`,
+      reasons: [
+        `Cycle can be resolved by extracting ${extractionPlan.symbols.join(', ')} from ${extractionPlan.sourceFile} into ${extractionPlan.sharedFile} while preserving the ${extractionPlan.sourceFile} API.`,
+      ],
+      signals: scoring.signals,
+      score: scoring.score,
+      scoreBreakdown: scoring.breakdown,
+      classification: 'autofix_extract_shared',
+      confidence: 0.8,
+      plan: extractionPlan,
+    };
+  }
+
+  private evaluateDirectImportAttempt(cycleFiles: string[]): StrategyAttempt {
+    const directImportResult = this.buildDirectImportPlan(cycleFiles);
+    if (!directImportResult.plan || directImportResult.plan.length === 0) {
+      if (directImportResult.sawBarrelScenario) {
+        return this.createRejectedAttempt(
+          'direct_import',
+          'Barrel re-export graph is ambiguous or side-effectful.',
+          ['Barrel re-export graph is ambiguous or side-effectful, so a direct-import rewrite is not safe.'],
+          {
+            cycleSize: cycleFiles.length,
+          },
+        );
+      }
+
+      return this.createRejectedAttempt(
+        'direct_import',
+        'No safe barrel import rewrite was found for this cycle.',
+        ['No safe barrel import chain was detected between the cycle participants.'],
+        {
+          cycleSize: cycleFiles.length,
+        },
+      );
+    }
+
+    const scoring = this.scoreDirectImportPlan(directImportResult.plan);
+    const firstPlan = directImportResult.plan[0];
+    return {
+      strategy: 'direct_import',
+      status: 'candidate',
+      summary: `Rewrite ${directImportResult.plan.length} barrel import edge(s) to direct imports.`,
+      reasons: [
+        `Cycle can be resolved by importing ${firstPlan.symbols.join(', ')} directly from ${firstPlan.targetFile} instead of ${firstPlan.barrelFile}.`,
+      ],
+      signals: scoring.signals,
+      score: scoring.score,
+      scoreBreakdown: scoring.breakdown,
+      classification: 'autofix_direct_import',
+      confidence: 0.85,
+      plan: {
+        kind: 'direct_import',
+        imports: directImportResult.plan,
+      },
+    };
+  }
+
+  private scoreImportTypePlan(importPlans: ImportTypeFixPlan['imports']): {
+    score: number;
+    breakdown: string[];
+    signals: Record<string, StrategySignalValue>;
+  } {
+    const touchedFiles = new Set(importPlans.map((plan) => plan.sourceFile));
+    const score = this.clampScore(0.97 - Math.max(0, touchedFiles.size - 1) * 0.03);
+    return {
+      score,
+      breakdown: [
+        `base 0.97 for least-invasive rewrite`,
+        touchedFiles.size > 1 ? `-0.03 for touching ${touchedFiles.size} files` : 'no penalty for single touched file',
+      ],
+      signals: {
+        touchedFiles: touchedFiles.size,
+        importEdges: importPlans.length,
+        introducesNewFile: false,
+        preservesSourceExports: true,
+      },
+    };
+  }
+
+  private scoreDirectImportPlan(importPlans: DirectImportFixPlan['imports']): {
+    score: number;
+    breakdown: string[];
+    signals: Record<string, StrategySignalValue>;
+  } {
+    const touchedFiles = new Set(importPlans.map((plan) => plan.sourceFile));
+    const score = this.clampScore(0.89 - Math.max(0, touchedFiles.size - 1) * 0.04);
+    return {
+      score,
+      breakdown: [
+        `base 0.89 for removing a barrel hop`,
+        touchedFiles.size > 1 ? `-0.04 for touching ${touchedFiles.size} files` : 'no penalty for single touched file',
+      ],
+      signals: {
+        touchedFiles: touchedFiles.size,
+        importEdges: importPlans.length,
+        introducesNewFile: false,
+        preservesSourceExports: true,
+        bypassesBarrel: true,
+      },
+    };
+  }
+
+  private scoreExtractSharedPlan(plan: ExtractSharedFixPlan): {
+    score: number;
+    breakdown: string[];
+    signals: Record<string, StrategySignalValue>;
+  } {
+    const symbolNamedSharedFile = plan.symbols.length === 1 && path.basename(plan.sharedFile).includes(plan.symbols[0]);
+    const score = this.clampScore(
+      0.68 +
+        (plan.preserveSourceExports ? 0.08 : 0) +
+        (plan.symbols.length === 1 ? 0.06 : 0) +
+        (symbolNamedSharedFile ? 0.04 : 0) -
+        Math.max(0, plan.symbols.length - 1) * 0.03,
+    );
+    return {
+      score,
+      breakdown: [
+        'base 0.68 for introducing a shared module',
+        plan.preserveSourceExports ? '+0.08 for preserving the source module API' : 'no API-preservation bonus',
+        plan.symbols.length === 1
+          ? '+0.06 for single-symbol extraction'
+          : `-${Math.max(0, plan.symbols.length - 1) * 0.03} for extracting multiple symbols`,
+        symbolNamedSharedFile ? '+0.04 for a symbol-driven shared filename' : 'no filename clarity bonus',
+      ],
+      signals: {
+        touchedFiles: 3,
+        symbolCount: plan.symbols.length,
+        introducesNewFile: true,
+        preservesSourceExports: plan.preserveSourceExports,
+        sharedFile: plan.sharedFile,
+        sourceFile: plan.sourceFile,
+        targetFile: plan.targetFile,
+      },
+    };
+  }
+
+  private selectBestAttempt(attempts: StrategyAttempt[]): StrategyAttempt | undefined {
+    let bestAttempt: StrategyAttempt | undefined;
+
+    for (const attempt of attempts) {
+      if (attempt.status !== 'candidate') {
+        continue;
+      }
+
+      if (!bestAttempt) {
+        bestAttempt = attempt;
+        continue;
+      }
+
+      const scoreDelta = (attempt.score ?? 0) - (bestAttempt.score ?? 0);
+      const confidenceDelta = (attempt.confidence ?? 0) - (bestAttempt.confidence ?? 0);
+
+      if (scoreDelta > 0 || (scoreDelta === 0 && confidenceDelta > 0)) {
+        bestAttempt = attempt;
+      }
+    }
+
+    return bestAttempt;
+  }
+
+  private createNotApplicableAttempt(
+    strategy: PlanningStrategy,
+    summary: string,
+    signals: Record<string, StrategySignalValue>,
+  ): StrategyAttempt {
+    return {
+      strategy,
+      status: 'not_applicable',
+      summary,
+      reasons: [summary],
+      signals,
+    };
+  }
+
+  private createRejectedAttempt(
+    strategy: PlanningStrategy,
+    summary: string,
+    reasons: string[],
+    signals: Record<string, StrategySignalValue>,
+  ): StrategyAttempt {
+    return {
+      strategy,
+      status: 'rejected',
+      summary,
+      reasons,
+      signals,
+    };
+  }
+
+  private clampScore(value: number): number {
+    return Math.max(0, Math.min(1, Number(value.toFixed(2))));
   }
 
   private isExtractable(sourceFile: SourceFile, symbolNames: string[], cycleFiles: string[]): boolean {

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -1,6 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { analyzeRepository } from '../analyzer/analyzer.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
 import { createProgram } from './index.js';
@@ -10,6 +11,39 @@ const exportedDir = path.join(os.tmpdir(), 'patches');
 
 vi.mock('./scanner.js', () => ({
   scanRepository: vi.fn().mockResolvedValue({ scanId: 999, cyclesFound: 2 }),
+}));
+
+vi.mock('../analyzer/analyzer.js', () => ({
+  analyzeRepository: vi.fn().mockResolvedValue([
+    {
+      type: 'circular',
+      path: ['a.ts', 'b.ts', 'a.ts'],
+      analysis: {
+        classification: 'autofix_import_type',
+        confidence: 0.9,
+        reasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+        upstreamabilityScore: 0.94,
+        planner: {
+          cycleFiles: ['a.ts', 'b.ts'],
+          cycleSize: 2,
+          cycleShape: 'two_file',
+          cycleSignals: {
+            explicitImportEdges: 2,
+            loadedFiles: 2,
+            missingFiles: 0,
+          },
+          fallbackClassification: 'autofix_import_type',
+          fallbackConfidence: 0.9,
+          fallbackReasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+          selectedStrategy: 'import_type',
+          selectedClassification: 'autofix_import_type',
+          selectedScore: 0.94,
+          selectionSummary: 'Selected import_type with score 0.94 after evaluating 3 strategies.',
+          attempts: [],
+        },
+      },
+    },
+  ]),
 }));
 
 vi.mock('./exportPatches.js', () => ({
@@ -69,6 +103,59 @@ describe('CLI', () => {
 
     consoleErrSpy.mockRestore();
     exitSpy.mockRestore();
+  });
+
+  it('explain command prints planner output as JSON', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'explain', '/some/repo']);
+
+    expect(vi.mocked(analyzeRepository)).toHaveBeenCalledWith('/some/repo');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          repo: '/some/repo',
+          cycleCount: 1,
+          cycles: [
+            {
+              id: 1,
+              path: ['a.ts', 'b.ts', 'a.ts'],
+              analysis: {
+                classification: 'autofix_import_type',
+                confidence: 0.9,
+                reasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+                plan: undefined,
+                upstreamabilityScore: 0.94,
+                planner: {
+                  cycleFiles: ['a.ts', 'b.ts'],
+                  cycleSize: 2,
+                  cycleShape: 'two_file',
+                  cycleSignals: {
+                    explicitImportEdges: 2,
+                    loadedFiles: 2,
+                    missingFiles: 0,
+                  },
+                  fallbackClassification: 'autofix_import_type',
+                  fallbackConfidence: 0.9,
+                  fallbackReasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+                  selectedStrategy: 'import_type',
+                  selectedClassification: 'autofix_import_type',
+                  selectedScore: 0.94,
+                  selectionSummary: 'Selected import_type with score 0.94 after evaluating 3 strategies.',
+                  attempts: [],
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    consoleSpy.mockRestore();
   });
 
   it('scan:all command logs scanning message', () => {
@@ -155,10 +242,11 @@ describe('CLI', () => {
     exitSpy.mockRestore();
   });
 
-  it('has all five subcommands registered', () => {
+  it('has all six subcommands registered', () => {
     const program = createProgram();
     const commandNames = program.commands.map((cmd) => cmd.name());
     expect(commandNames).toContain('scan');
+    expect(commandNames).toContain('explain');
     expect(commandNames).toContain('scan:all');
     expect(commandNames).toContain('retry:failed');
     expect(commandNames).toContain('create:pr');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { analyzeRepository } from '../analyzer/analyzer.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
 import { scanRepository } from './scanner.js';
@@ -18,6 +19,42 @@ export function createProgram(): Command {
         console.log(`Scan completed successfully (Scan ID: ${result.scanId}). Found ${result.cyclesFound} cycles.`);
       } catch (error) {
         console.error(`Failed to scan repository ${repo}:`, error);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('explain <repo>')
+    .description('Explain the planner output for each detected cycle in a target repository')
+    .action(async (repo: string) => {
+      try {
+        const cycles = await analyzeRepository(repo);
+        console.log(
+          JSON.stringify(
+            {
+              repo,
+              cycleCount: cycles.length,
+              cycles: cycles.map((cycle, index) => ({
+                id: index + 1,
+                path: cycle.path,
+                analysis: cycle.analysis
+                  ? {
+                      classification: cycle.analysis.classification,
+                      confidence: cycle.analysis.confidence,
+                      reasons: cycle.analysis.reasons,
+                      plan: cycle.analysis.plan,
+                      upstreamabilityScore: cycle.analysis.upstreamabilityScore,
+                      planner: cycle.analysis.planner,
+                    }
+                  : undefined,
+              })),
+            },
+            null,
+            2,
+          ),
+        );
+      } catch (error) {
+        console.error(`Failed to explain repository ${repo}:`, error);
         process.exit(1);
       }
     });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "biome format --write .",
     "check": "biome check --write . && eslint --fix . && pnpm run test:coverage",
     "scan": "tsx cli/index.ts scan",
+    "explain": "tsx cli/index.ts explain",
     "scan:all": "tsx cli/index.ts scan:all",
     "retry:failed": "tsx cli/index.ts retry:failed",
     "create:pr": "tsx cli/index.ts create:pr",


### PR DESCRIPTION
## Summary
- add a strategy planner that evaluates import-type, direct-import, and extract-shared attempts for each cycle
- expose planner output through a new `explain` CLI command with per-strategy scores, signals, and selection summaries
- normalize dependency-cruiser paths back to repo-relative paths so live repo analysis stays actionable

## Verification
- ../../node_modules/.bin/eslint analyzer/analyzer.ts analyzer/analyzer.test.ts analyzer/semantic.ts analyzer/semantic.test.ts cli/index.ts cli/index.test.ts
- ../../node_modules/.bin/biome check analyzer/analyzer.ts analyzer/analyzer.test.ts analyzer/semantic.ts analyzer/semantic.test.ts cli/index.ts cli/index.test.ts package.json
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/vitest run --config vitest.config.ts