### PR TITLE
Add host-owned state update autofix strategy

### DIFF
--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -221,6 +221,67 @@ describe('SemanticAnalyzer', () => {
     });
   });
 
+  it('detects host_state_update for thin imported setters on caller-owned state', () => {
+    analyzer.project.createSourceFile(
+      '/dummy/repo/a.ts',
+      `
+      import { setLastActiveSessionKey } from './b';
+      export const runA = (host: unknown) => setLastActiveSessionKey(host, ' next ');
+    `,
+    );
+    analyzer.project.createSourceFile(
+      '/dummy/repo/b.ts',
+      `
+      import { runA } from './a';
+      import { saveSettings } from './storage';
+
+      export function applySettings(host: { settings: { lastActiveSessionKey: string }; applySessionKey: string }, next: { lastActiveSessionKey: string }) {
+        host.settings = next;
+        saveSettings(next);
+        host.applySessionKey = host.settings.lastActiveSessionKey;
+      }
+
+      export function setLastActiveSessionKey(host: { settings: { lastActiveSessionKey: string }; applySessionKey: string }, next: string) {
+        const trimmed = next.trim();
+        if (!trimmed) {
+          return;
+        }
+        if (host.settings.lastActiveSessionKey === trimmed) {
+          return;
+        }
+        applySettings(host, { ...host.settings, lastActiveSessionKey: trimmed });
+      }
+
+      export const runB = () => runA({ settings: { lastActiveSessionKey: 'main' }, applySessionKey: 'main' });
+    `,
+    );
+    analyzer.project.createSourceFile('/dummy/repo/storage.ts', 'export function saveSettings(_next: unknown) {}\n');
+
+    const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
+
+    expect(result.classification).toBe('autofix_host_state_update');
+    expect(result.upstreamabilityScore).toBe(0.87);
+    expect(result.planner).toMatchObject({
+      cycleShape: 'two_file',
+      selectedStrategy: 'host_state_update',
+      selectedClassification: 'autofix_host_state_update',
+      selectedScore: 0.87,
+    });
+    expect(result.plan).toEqual({
+      kind: 'host_state_update',
+      sourceFile: 'a.ts',
+      targetFile: 'b.ts',
+      importedFunction: 'setLastActiveSessionKey',
+      persistenceModule: 'storage.ts',
+      persistenceModuleKind: 'repo_file',
+      persistenceFunction: 'saveSettings',
+      stateObjectProperty: 'settings',
+      updatedProperty: 'lastActiveSessionKey',
+      mirrorHostProperty: 'applySessionKey',
+      trimValue: true,
+    });
+  });
+
   it('identifies suggest_manual for non-type cycles with unsupported declarations', () => {
     analyzer.project.createSourceFile(
       '/dummy/repo/a.ts',

--- a/analyzer/semantic.ts
+++ b/analyzer/semantic.ts
@@ -1,6 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { type ExportDeclaration, type ImportDeclaration, Node, Project, type SourceFile, SyntaxKind } from 'ts-morph';
+import {
+  type ExportDeclaration,
+  type FunctionDeclaration,
+  type Identifier,
+  type ImportDeclaration,
+  Node,
+  Project,
+  type SourceFile,
+  SyntaxKind,
+} from 'ts-morph';
 import type { Classification } from '../db/index.js';
 
 export interface ImportTypeFixPlan {
@@ -30,7 +39,21 @@ export interface ExtractSharedFixPlan {
   preserveSourceExports: boolean;
 }
 
-export type PlanningStrategy = 'import_type' | 'direct_import' | 'extract_shared';
+export interface HostStateUpdateFixPlan {
+  kind: 'host_state_update';
+  sourceFile: string;
+  targetFile: string;
+  importedFunction: string;
+  persistenceModule: string;
+  persistenceModuleKind: 'package' | 'repo_file';
+  persistenceFunction: string;
+  stateObjectProperty: string;
+  updatedProperty: string;
+  mirrorHostProperty?: string;
+  trimValue: boolean;
+}
+
+export type PlanningStrategy = 'import_type' | 'direct_import' | 'extract_shared' | 'host_state_update';
 export type StrategySignalValue = boolean | number | string;
 
 const missingCycleFilesReason = 'Files participating in the cycle could not be read or found.';
@@ -45,7 +68,7 @@ export interface StrategyAttempt {
   scoreBreakdown?: string[];
   classification?: Classification;
   confidence?: number;
-  plan?: ImportTypeFixPlan | DirectImportFixPlan | ExtractSharedFixPlan;
+  plan?: ImportTypeFixPlan | DirectImportFixPlan | ExtractSharedFixPlan | HostStateUpdateFixPlan;
 }
 
 export interface CyclePlanningResult {
@@ -67,7 +90,7 @@ export interface SemanticAnalysisResult {
   classification: Classification;
   confidence: number;
   reasons: string[];
-  plan?: ImportTypeFixPlan | DirectImportFixPlan | ExtractSharedFixPlan;
+  plan?: ImportTypeFixPlan | DirectImportFixPlan | ExtractSharedFixPlan | HostStateUpdateFixPlan;
   upstreamabilityScore?: number;
   planner?: CyclePlanningResult;
 }
@@ -231,6 +254,41 @@ export class SemanticAnalyzer {
           },
         }),
         evaluate: (context) => this.evaluateDirectImportAttempt(context.uniqueFiles),
+      },
+      {
+        strategy: 'host_state_update',
+        describeApplicability: (context) => ({
+          applicable: context.cycleShape === 'two_file',
+          summary:
+            context.cycleShape === 'two_file'
+              ? 'Host-owned state update localization can be evaluated for two-file cycles.'
+              : 'Host-owned state update localization is only supported for two-file cycles.',
+          signals: {
+            cycleShape: context.cycleShape,
+            cycleSize: context.uniqueFiles.length,
+          },
+        }),
+        evaluate: (context) => {
+          const [fileA, fileB] = context.uniqueFiles;
+          const sourceFileA = fileA ? context.sourceFiles.get(fileA) : undefined;
+          const sourceFileB = fileB ? context.sourceFiles.get(fileB) : undefined;
+
+          if (!fileA || !fileB || !sourceFileA || !sourceFileB) {
+            return this.createRejectedAttempt('host_state_update', missingCycleFilesReason, [missingCycleFilesReason], {
+              fileA: fileA ?? 'unknown',
+              fileB: fileB ?? 'unknown',
+            });
+          }
+
+          return this.evaluateHostStateUpdateAttempt(
+            fileA,
+            fileB,
+            sourceFileA,
+            sourceFileB,
+            context.importsAToB,
+            context.importsBToA,
+          );
+        },
       },
       {
         strategy: 'extract_shared',
@@ -481,6 +539,50 @@ export class SemanticAnalyzer {
     };
   }
 
+  private evaluateHostStateUpdateAttempt(
+    fileA: string,
+    fileB: string,
+    sourceFileA: SourceFile,
+    sourceFileB: SourceFile,
+    importsAToB: ImportDeclaration[],
+    importsBToA: ImportDeclaration[],
+  ): StrategyAttempt {
+    const plan =
+      this.buildHostStateUpdatePlan(fileA, fileB, sourceFileA, sourceFileB, importsAToB) ??
+      this.buildHostStateUpdatePlan(fileB, fileA, sourceFileB, sourceFileA, importsBToA);
+
+    if (!plan) {
+      return this.createRejectedAttempt(
+        'host_state_update',
+        'No imported setter could be localized safely into the caller-owned host state.',
+        [
+          'Imported runtime symbols either perform too much work, mutate state they do not own, or require local helpers that could not be reduced to a safe persisted state update.',
+        ],
+        {
+          fileA,
+          fileB,
+          importEdges: importsAToB.length + importsBToA.length,
+        },
+      );
+    }
+
+    const scoring = this.scoreHostStateUpdatePlan(plan);
+    return {
+      strategy: 'host_state_update',
+      status: 'candidate',
+      summary: `Localize ${plan.importedFunction} into ${plan.sourceFile} and persist ${plan.updatedProperty} without creating a shared module.`,
+      reasons: [
+        `Cycle can be resolved by localizing the imported setter ${plan.importedFunction} into ${plan.sourceFile}, because the caller already owns ${plan.stateObjectProperty}.${plan.updatedProperty}.`,
+      ],
+      signals: scoring.signals,
+      score: scoring.score,
+      scoreBreakdown: scoring.breakdown,
+      classification: 'autofix_host_state_update',
+      confidence: 0.84,
+      plan,
+    };
+  }
+
   private scoreImportTypePlan(importPlans: ImportTypeFixPlan['imports']): {
     score: number;
     breakdown: string[];
@@ -557,6 +659,30 @@ export class SemanticAnalyzer {
         sharedFile: plan.sharedFile,
         sourceFile: plan.sourceFile,
         targetFile: plan.targetFile,
+      },
+    };
+  }
+
+  private scoreHostStateUpdatePlan(plan: HostStateUpdateFixPlan): {
+    score: number;
+    breakdown: string[];
+    signals: Record<string, StrategySignalValue>;
+  } {
+    const score = this.clampScore(0.85 + (plan.mirrorHostProperty ? 0.01 : 0) + (plan.trimValue ? 0.01 : 0));
+    return {
+      score,
+      breakdown: [
+        'base 0.85 for removing a cross-module state setter without introducing a new file',
+        plan.mirrorHostProperty ? '+0.01 for preserving a mirrored host field update' : 'no mirrored-host bonus',
+        plan.trimValue ? '+0.01 for preserving value normalization in the localized helper' : 'no normalization bonus',
+      ],
+      signals: {
+        touchedFiles: 1,
+        introducesNewFile: false,
+        preservesSourceExports: false,
+        importedFunction: plan.importedFunction,
+        persistenceFunction: plan.persistenceFunction,
+        updatedProperty: plan.updatedProperty,
       },
     };
   }
@@ -710,6 +836,95 @@ export class SemanticAnalyzer {
     return importPlans;
   }
 
+  private buildHostStateUpdatePlan(
+    sourceFilePath: string,
+    targetFilePath: string,
+    sourceFile: SourceFile,
+    targetFile: SourceFile,
+    importDeclarations: ImportDeclaration[],
+  ): HostStateUpdateFixPlan | undefined {
+    const targetModuleKey = this.createRepoFileModuleKey(targetFilePath);
+
+    for (const importDecl of importDeclarations) {
+      if (importDecl.getDefaultImport() || importDecl.getNamespaceImport()) {
+        continue;
+      }
+
+      for (const namedImport of importDecl.getNamedImports()) {
+        const plan = this.tryBuildHostStateUpdatePlanForNamedImport(
+          sourceFilePath,
+          targetFilePath,
+          sourceFile,
+          targetFile,
+          namedImport,
+          targetModuleKey,
+        );
+        if (plan) {
+          return plan;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private tryBuildHostStateUpdatePlanForNamedImport(
+    sourceFilePath: string,
+    targetFilePath: string,
+    sourceFile: SourceFile,
+    targetFile: SourceFile,
+    namedImport: { getAliasNode(): Identifier | undefined; getName(): string },
+    targetModuleKey: string,
+  ): HostStateUpdateFixPlan | undefined {
+    const importedFunction = this.getImportLocalName(namedImport);
+    if (this.hasConflictingLocalName(sourceFile, importedFunction, new Set([targetModuleKey]))) {
+      return undefined;
+    }
+
+    const setterFunction = targetFile.getFunction(namedImport.getName());
+    if (!setterFunction?.isExported()) {
+      return undefined;
+    }
+
+    const setterPattern = this.parseHostStateSetter(setterFunction);
+    if (!setterPattern) {
+      return undefined;
+    }
+
+    const persistencePattern = this.analyzeHostStatePersistenceHelper(
+      targetFile,
+      setterPattern.helperFunctionName,
+      setterPattern.stateObjectProperty,
+      setterPattern.updatedProperty,
+      sourceFilePath,
+      targetFilePath,
+    );
+    if (!persistencePattern) {
+      return undefined;
+    }
+
+    const allowedPersistenceKeys = new Set<string>([
+      this.getPersistenceModuleKey(persistencePattern.persistenceModuleKind, persistencePattern.persistenceModule),
+    ]);
+    if (this.hasConflictingLocalName(sourceFile, persistencePattern.persistenceFunction, allowedPersistenceKeys)) {
+      return undefined;
+    }
+
+    return {
+      kind: 'host_state_update',
+      sourceFile: sourceFilePath,
+      targetFile: targetFilePath,
+      importedFunction,
+      persistenceModule: persistencePattern.persistenceModule,
+      persistenceModuleKind: persistencePattern.persistenceModuleKind,
+      persistenceFunction: persistencePattern.persistenceFunction,
+      stateObjectProperty: setterPattern.stateObjectProperty,
+      updatedProperty: setterPattern.updatedProperty,
+      mirrorHostProperty: persistencePattern.mirrorHostProperty,
+      trimValue: setterPattern.trimValue,
+    };
+  }
+
   private buildExtractSharedPlan(
     fileA: string,
     fileB: string,
@@ -727,6 +942,167 @@ export class SemanticAnalyzer {
     }
 
     return undefined;
+  }
+
+  private parseHostStateSetter(functionDeclaration: FunctionDeclaration):
+    | {
+        helperFunctionName: string;
+        stateObjectProperty: string;
+        updatedProperty: string;
+        trimValue: boolean;
+      }
+    | undefined {
+    const body = functionDeclaration.getBody();
+    const parameters = functionDeclaration.getParameters();
+    if (!body || !Node.isBlock(body) || parameters.length !== 2) {
+      return undefined;
+    }
+
+    const hostParamName = parameters[0]?.getName();
+    const valueParamName = parameters[1]?.getName();
+    if (!hostParamName || !valueParamName) {
+      return undefined;
+    }
+
+    let normalizedValueName = valueParamName;
+    let trimValue = false;
+    let helperFunctionName: string | undefined;
+    let stateObjectProperty: string | undefined;
+    let updatedProperty: string | undefined;
+
+    for (const statement of body.getStatements()) {
+      const trimmedVariable = this.extractTrimmedVariableName(statement, valueParamName);
+      if (trimmedVariable) {
+        normalizedValueName = trimmedVariable;
+        trimValue = true;
+        continue;
+      }
+
+      if (this.matchesEmptyGuard(statement, normalizedValueName)) {
+        continue;
+      }
+
+      const equalityGuard = this.extractEqualityGuard(statement, hostParamName, normalizedValueName);
+      if (equalityGuard) {
+        stateObjectProperty ??= equalityGuard.stateObjectProperty;
+        updatedProperty ??= equalityGuard.updatedProperty;
+        continue;
+      }
+
+      const setterCall = this.extractHostStateSetterCall(statement, hostParamName, normalizedValueName);
+      if (setterCall) {
+        helperFunctionName = setterCall.helperFunctionName;
+        stateObjectProperty ??= setterCall.stateObjectProperty;
+        updatedProperty ??= setterCall.updatedProperty;
+        continue;
+      }
+
+      return undefined;
+    }
+
+    if (!helperFunctionName || !stateObjectProperty || !updatedProperty) {
+      return undefined;
+    }
+
+    return {
+      helperFunctionName,
+      stateObjectProperty,
+      updatedProperty,
+      trimValue,
+    };
+  }
+
+  private analyzeHostStatePersistenceHelper(
+    targetFile: SourceFile,
+    helperFunctionName: string,
+    stateObjectProperty: string,
+    updatedProperty: string,
+    sourceFilePath: string,
+    targetFilePath: string,
+  ):
+    | {
+        persistenceModule: string;
+        persistenceModuleKind: 'package' | 'repo_file';
+        persistenceFunction: string;
+        mirrorHostProperty?: string;
+      }
+    | undefined {
+    const helperFunction = targetFile.getFunction(helperFunctionName);
+    const body = helperFunction?.getBody();
+    const hostParamName = helperFunction?.getParameters()[0]?.getName();
+    const settingsParamName = helperFunction?.getParameters()[1]?.getName();
+    if (
+      !helperFunction ||
+      !body ||
+      !Node.isBlock(body) ||
+      !hostParamName ||
+      !settingsParamName ||
+      helperFunction.getParameters().length !== 2
+    ) {
+      return undefined;
+    }
+
+    let persistenceFunction: string | undefined;
+    let persistenceModule: string | undefined;
+    let persistenceModuleKind: 'package' | 'repo_file' | undefined;
+    let mirrorHostProperty: string | undefined;
+
+    for (const statement of body.getStatements()) {
+      const hostStateAssignment = this.extractHostStateAssignment(
+        statement,
+        hostParamName,
+        stateObjectProperty,
+        settingsParamName,
+      );
+      if (hostStateAssignment) {
+        continue;
+      }
+
+      const persistenceCall = this.extractImportedPersistenceCall(
+        targetFile,
+        statement,
+        settingsParamName,
+        sourceFilePath,
+        targetFilePath,
+      );
+      if (persistenceCall) {
+        if (persistenceFunction !== undefined) {
+          return undefined;
+        }
+
+        persistenceFunction = persistenceCall.persistenceFunction;
+        persistenceModule = persistenceCall.persistenceModule;
+        persistenceModuleKind = persistenceCall.persistenceModuleKind;
+        continue;
+      }
+
+      const mirrorAssignment = this.extractMirrorHostPropertyAssignment(
+        statement,
+        hostParamName,
+        stateObjectProperty,
+        updatedProperty,
+      );
+      if (mirrorAssignment) {
+        if (this.isConflictingMirrorHostProperty(mirrorHostProperty, mirrorAssignment)) {
+          return undefined;
+        }
+        mirrorHostProperty = mirrorAssignment;
+        continue;
+      }
+
+      return undefined;
+    }
+
+    if (!persistenceFunction || !persistenceModule || !persistenceModuleKind) {
+      return undefined;
+    }
+
+    return {
+      persistenceModule,
+      persistenceModuleKind,
+      persistenceFunction,
+      mirrorHostProperty,
+    };
   }
 
   private createExtractSharedPlan(sourceFile: string, targetFile: string, symbols: string[]): ExtractSharedFixPlan {
@@ -1148,6 +1524,423 @@ export class SemanticAnalyzer {
       }
     }
     return imports;
+  }
+
+  private getImportLocalName(namedImport: { getAliasNode(): Identifier | undefined; getName(): string }): string {
+    return namedImport.getAliasNode()?.getText() ?? namedImport.getName();
+  }
+
+  private hasConflictingLocalName(
+    sourceFile: SourceFile,
+    symbolName: string,
+    allowedModuleKeys = new Set<string>(),
+  ): boolean {
+    return (
+      this.hasConflictingLocalDeclaration(sourceFile, symbolName) ||
+      this.hasConflictingImportBinding(sourceFile, symbolName, allowedModuleKeys)
+    );
+  }
+
+  private isAllowedImportBinding(
+    sourceFile: SourceFile,
+    importDecl: ImportDeclaration,
+    allowedModuleKeys: Set<string>,
+  ): boolean {
+    const moduleKey = this.getImportModuleKey(sourceFile, importDecl.getModuleSpecifierValue());
+    return !!moduleKey && allowedModuleKeys.has(moduleKey);
+  }
+
+  private getImportModuleKey(sourceFile: SourceFile, moduleSpecifier: string): string | undefined {
+    if (!moduleSpecifier.startsWith('.') && !path.isAbsolute(moduleSpecifier)) {
+      return this.createPackageModuleKey(moduleSpecifier);
+    }
+
+    const resolvedPath = this.resolveModulePath(sourceFile.getFilePath(), moduleSpecifier);
+    return resolvedPath ? this.createRepoFileModuleKey(this.toRepoRelativePath(resolvedPath)) : undefined;
+  }
+
+  private createRepoFileModuleKey(filePath: string): string {
+    return `file:${this.normalizeRepoRelativePath(filePath)}`;
+  }
+
+  private createPackageModuleKey(packageName: string): string {
+    return `pkg:${packageName}`;
+  }
+
+  private getPersistenceModuleKey(moduleKind: 'package' | 'repo_file', persistenceModule: string): string {
+    return moduleKind === 'repo_file'
+      ? this.createRepoFileModuleKey(persistenceModule)
+      : this.createPackageModuleKey(persistenceModule);
+  }
+
+  private hasConflictingLocalDeclaration(sourceFile: SourceFile, symbolName: string): boolean {
+    return (
+      sourceFile.getFunctions().some((declaration) => declaration.getName() === symbolName) ||
+      sourceFile.getInterfaces().some((declaration) => declaration.getName() === symbolName) ||
+      sourceFile.getTypeAliases().some((declaration) => declaration.getName() === symbolName) ||
+      sourceFile.getClasses().some((declaration) => declaration.getName() === symbolName) ||
+      sourceFile.getVariableDeclarations().some((declaration) => declaration.getName() === symbolName)
+    );
+  }
+
+  private hasConflictingImportBinding(
+    sourceFile: SourceFile,
+    symbolName: string,
+    allowedModuleKeys: Set<string>,
+  ): boolean {
+    for (const importDecl of sourceFile.getImportDeclarations()) {
+      if (this.hasConflictingDefaultOrNamespaceImport(sourceFile, importDecl, symbolName, allowedModuleKeys)) {
+        return true;
+      }
+
+      for (const namedImport of importDecl.getNamedImports()) {
+        if (this.getImportLocalName(namedImport) !== symbolName) {
+          continue;
+        }
+
+        if (this.isReusableNamedImport(sourceFile, importDecl, namedImport, symbolName, allowedModuleKeys)) {
+          continue;
+        }
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private hasConflictingDefaultOrNamespaceImport(
+    sourceFile: SourceFile,
+    importDecl: ImportDeclaration,
+    symbolName: string,
+    allowedModuleKeys: Set<string>,
+  ): boolean {
+    const defaultImportMatches = importDecl.getDefaultImport()?.getText() === symbolName;
+    const namespaceImportMatches = importDecl.getNamespaceImport()?.getText() === symbolName;
+
+    return (
+      (defaultImportMatches || namespaceImportMatches) &&
+      !this.isAllowedImportBinding(sourceFile, importDecl, allowedModuleKeys)
+    );
+  }
+
+  private isReusableNamedImport(
+    sourceFile: SourceFile,
+    importDecl: ImportDeclaration,
+    namedImport: { getAliasNode(): Identifier | undefined; getName(): string },
+    symbolName: string,
+    allowedModuleKeys: Set<string>,
+  ): boolean {
+    return (
+      this.isAllowedImportBinding(sourceFile, importDecl, allowedModuleKeys) &&
+      namedImport.getName() === symbolName &&
+      !namedImport.getAliasNode()
+    );
+  }
+
+  private isConflictingMirrorHostProperty(currentProperty: string | undefined, nextProperty: string): boolean {
+    return currentProperty !== undefined && currentProperty !== nextProperty;
+  }
+
+  private extractTrimmedVariableName(statement: Node, valueParamName: string): string | undefined {
+    if (!Node.isVariableStatement(statement)) {
+      return undefined;
+    }
+
+    const declaration = statement.getDeclarations()[0];
+    const initializer = declaration?.getInitializer();
+    if (!declaration || !initializer || !Node.isCallExpression(initializer)) {
+      return undefined;
+    }
+
+    const expression = initializer.getExpression();
+    if (!Node.isPropertyAccessExpression(expression) || expression.getName() !== 'trim') {
+      return undefined;
+    }
+
+    return expression.getExpression().getText() === valueParamName ? declaration.getName() : undefined;
+  }
+
+  private matchesEmptyGuard(statement: Node, valueName: string): boolean {
+    if (!Node.isIfStatement(statement)) {
+      return false;
+    }
+
+    const expression = statement.getExpression();
+    if (!Node.isPrefixUnaryExpression(expression) || expression.getOperatorToken() !== SyntaxKind.ExclamationToken) {
+      return false;
+    }
+
+    return expression.getOperand().getText() === valueName && this.isImmediateReturn(statement.getThenStatement());
+  }
+
+  private extractEqualityGuard(
+    statement: Node,
+    hostParamName: string,
+    valueName: string,
+  ): { stateObjectProperty: string; updatedProperty: string } | undefined {
+    if (!Node.isIfStatement(statement) || !this.isImmediateReturn(statement.getThenStatement())) {
+      return undefined;
+    }
+
+    const expression = statement.getExpression();
+    if (
+      !Node.isBinaryExpression(expression) ||
+      expression.getOperatorToken().getKind() !== SyntaxKind.EqualsEqualsEqualsToken
+    ) {
+      return undefined;
+    }
+
+    const leftChain = this.getPropertyAccessChain(expression.getLeft());
+    if (
+      !leftChain ||
+      leftChain.length !== 3 ||
+      leftChain[0] !== hostParamName ||
+      expression.getRight().getText() !== valueName
+    ) {
+      return undefined;
+    }
+
+    return {
+      stateObjectProperty: leftChain[1] ?? '',
+      updatedProperty: leftChain[2] ?? '',
+    };
+  }
+
+  private extractHostStateSetterCall(
+    statement: Node,
+    hostParamName: string,
+    valueName: string,
+  ): { helperFunctionName: string; stateObjectProperty: string; updatedProperty: string } | undefined {
+    if (!Node.isExpressionStatement(statement)) {
+      return undefined;
+    }
+
+    const expression = statement.getExpression();
+    if (!Node.isCallExpression(expression) || !Node.isIdentifier(expression.getExpression())) {
+      return undefined;
+    }
+
+    const [hostArgument, settingsArgument] = expression.getArguments();
+    if (!hostArgument || !settingsArgument || hostArgument.getText() !== hostParamName) {
+      return undefined;
+    }
+
+    if (!Node.isObjectLiteralExpression(settingsArgument)) {
+      return undefined;
+    }
+
+    if (settingsArgument.getProperties().length !== 2) {
+      return undefined;
+    }
+
+    const spreadAssignment = settingsArgument.getProperties().find((property) => Node.isSpreadAssignment(property));
+    const propertyAssignment = settingsArgument.getProperties().find((property) => Node.isPropertyAssignment(property));
+    if (!spreadAssignment || !propertyAssignment) {
+      return undefined;
+    }
+
+    const spreadChain = this.getPropertyAccessChain(spreadAssignment.getExpression());
+    if (!spreadChain || spreadChain.length !== 2 || spreadChain[0] !== hostParamName) {
+      return undefined;
+    }
+
+    const initializer = propertyAssignment.getInitializer();
+    if (!initializer || initializer.getText() !== valueName) {
+      return undefined;
+    }
+
+    return {
+      helperFunctionName: expression.getExpression().getText(),
+      stateObjectProperty: spreadChain[1] ?? '',
+      updatedProperty: propertyAssignment.getName(),
+    };
+  }
+
+  private extractHostStateAssignment(
+    statement: Node,
+    hostParamName: string,
+    stateObjectProperty: string,
+    valueName: string,
+  ): boolean {
+    if (!Node.isExpressionStatement(statement)) {
+      return false;
+    }
+
+    const expression = statement.getExpression();
+    if (!Node.isBinaryExpression(expression) || expression.getOperatorToken().getKind() !== SyntaxKind.EqualsToken) {
+      return false;
+    }
+
+    const leftChain = this.getPropertyAccessChain(expression.getLeft());
+    if (
+      !leftChain ||
+      leftChain.length !== 2 ||
+      leftChain[0] !== hostParamName ||
+      leftChain[1] !== stateObjectProperty ||
+      !Node.isIdentifier(expression.getRight())
+    ) {
+      return false;
+    }
+
+    return expression.getRight().getText() === valueName;
+  }
+
+  private extractImportedPersistenceCall(
+    sourceFile: SourceFile,
+    statement: Node,
+    settingsValueName: string,
+    sourceFilePath: string,
+    targetFilePath: string,
+  ):
+    | {
+        persistenceFunction: string;
+        persistenceModule: string;
+        persistenceModuleKind: 'package' | 'repo_file';
+      }
+    | undefined {
+    if (!Node.isExpressionStatement(statement)) {
+      return undefined;
+    }
+
+    const expression = statement.getExpression();
+    if (!Node.isCallExpression(expression) || !Node.isIdentifier(expression.getExpression())) {
+      return undefined;
+    }
+
+    const argument = expression.getArguments()[0];
+    if (!argument || argument.getText() !== settingsValueName) {
+      return undefined;
+    }
+
+    const importedBinding = this.findImportedBinding(sourceFile, expression.getExpression().getText());
+    if (!importedBinding) {
+      return undefined;
+    }
+
+    if (importedBinding.persistenceModuleKind === 'repo_file') {
+      const sourceAbsolute = path.resolve(this.repoPath, sourceFilePath);
+      const targetAbsolute = path.resolve(this.repoPath, targetFilePath);
+      const persistenceAbsolute = path.resolve(this.repoPath, importedBinding.persistenceModule);
+      if (persistenceAbsolute === sourceAbsolute || persistenceAbsolute === targetAbsolute) {
+        return undefined;
+      }
+    }
+
+    return importedBinding;
+  }
+
+  private extractMirrorHostPropertyAssignment(
+    statement: Node,
+    hostParamName: string,
+    stateObjectProperty: string,
+    updatedProperty: string,
+  ): string | undefined {
+    if (!Node.isExpressionStatement(statement)) {
+      return undefined;
+    }
+
+    const expression = statement.getExpression();
+    if (!Node.isBinaryExpression(expression) || expression.getOperatorToken().getKind() !== SyntaxKind.EqualsToken) {
+      return undefined;
+    }
+
+    const leftChain = this.getPropertyAccessChain(expression.getLeft());
+    const rightChain = this.getPropertyAccessChain(expression.getRight());
+    if (
+      !leftChain ||
+      leftChain.length !== 2 ||
+      leftChain[0] !== hostParamName ||
+      !rightChain ||
+      rightChain.length !== 3 ||
+      rightChain[0] !== hostParamName ||
+      rightChain[1] !== stateObjectProperty ||
+      rightChain[2] !== updatedProperty
+    ) {
+      return undefined;
+    }
+
+    return leftChain[1];
+  }
+
+  private findImportedBinding(
+    sourceFile: SourceFile,
+    localName: string,
+  ):
+    | {
+        persistenceFunction: string;
+        persistenceModule: string;
+        persistenceModuleKind: 'package' | 'repo_file';
+      }
+    | undefined {
+    for (const importDecl of sourceFile.getImportDeclarations()) {
+      const moduleSpecifier = importDecl.getModuleSpecifierValue();
+
+      if (importDecl.getDefaultImport()?.getText() === localName) {
+        return this.toImportedBinding(moduleSpecifier, localName, sourceFile);
+      }
+
+      const namedImport = importDecl
+        .getNamedImports()
+        .find((candidate) => this.getImportLocalName(candidate) === localName);
+      if (namedImport) {
+        return this.toImportedBinding(moduleSpecifier, namedImport.getName(), sourceFile);
+      }
+    }
+
+    return undefined;
+  }
+
+  private toImportedBinding(
+    moduleSpecifier: string,
+    localName: string,
+    sourceFile: SourceFile,
+  ): {
+    persistenceFunction: string;
+    persistenceModule: string;
+    persistenceModuleKind: 'package' | 'repo_file';
+  } {
+    if (!moduleSpecifier.startsWith('.') && !path.isAbsolute(moduleSpecifier)) {
+      return {
+        persistenceFunction: localName,
+        persistenceModule: moduleSpecifier,
+        persistenceModuleKind: 'package',
+      };
+    }
+
+    const resolvedModulePath = this.resolveModulePath(sourceFile.getFilePath(), moduleSpecifier);
+    return {
+      persistenceFunction: localName,
+      persistenceModule: resolvedModulePath ? this.toRepoRelativePath(resolvedModulePath) : moduleSpecifier,
+      persistenceModuleKind: 'repo_file',
+    };
+  }
+
+  private getPropertyAccessChain(node: Node): string[] | undefined {
+    if (Node.isIdentifier(node)) {
+      return [node.getText()];
+    }
+
+    if (!Node.isPropertyAccessExpression(node)) {
+      return undefined;
+    }
+
+    const leftChain = this.getPropertyAccessChain(node.getExpression());
+    return leftChain ? [...leftChain, node.getName()] : undefined;
+  }
+
+  private isImmediateReturn(statement: Node): boolean {
+    if (Node.isReturnStatement(statement)) {
+      return true;
+    }
+
+    const [firstStatement] = Node.isBlock(statement) ? statement.getStatements() : [];
+    return (
+      Node.isBlock(statement) &&
+      statement.getStatements().length === 1 &&
+      !!firstStatement &&
+      Node.isReturnStatement(firstStatement)
+    );
   }
 
   private checkTypeOnlyImports(importNodes: ImportDeclaration[]): boolean {

--- a/codemod/generatePatch.test.ts
+++ b/codemod/generatePatch.test.ts
@@ -124,6 +124,86 @@ describe('generatePatchForCycle', () => {
     expect(patch?.touchedFiles).toEqual(['app.ts']);
   });
 
+  it('creates a localized host-state update patch without introducing a new file', async () => {
+    const repoPath = await createRepo({
+      'a.ts': [
+        "import { setLastActiveSessionKey } from './b';",
+        '',
+        "export const runA = (host: unknown) => setLastActiveSessionKey(host, ' next ');",
+        '',
+      ].join('\n'),
+      'b.ts': [
+        "import { runA } from './a';",
+        "import { saveSettings } from './storage';",
+        '',
+        'export function applySettings(',
+        '  host: { settings: { lastActiveSessionKey: string }; applySessionKey: string },',
+        '  next: { lastActiveSessionKey: string },',
+        ') {',
+        '  host.settings = next;',
+        '  saveSettings(next);',
+        '  host.applySessionKey = host.settings.lastActiveSessionKey;',
+        '}',
+        '',
+        'export function setLastActiveSessionKey(',
+        '  host: { settings: { lastActiveSessionKey: string }; applySessionKey: string },',
+        '  next: string,',
+        ') {',
+        '  const trimmed = next.trim();',
+        '  if (!trimmed) {',
+        '    return;',
+        '  }',
+        '  if (host.settings.lastActiveSessionKey === trimmed) {',
+        '    return;',
+        '  }',
+        '  applySettings(host, { ...host.settings, lastActiveSessionKey: trimmed });',
+        '}',
+        '',
+        "export const runB = () => runA({ settings: { lastActiveSessionKey: 'main' }, applySessionKey: 'main' });",
+        '',
+      ].join('\n'),
+      'storage.ts': 'export function saveSettings(_next: unknown) {}\n',
+    });
+
+    const cycle: CircularDependency = {
+      type: 'circular',
+      path: ['a.ts', 'b.ts', 'a.ts'],
+    };
+    const analysis: SemanticAnalysisResult = {
+      classification: 'autofix_host_state_update',
+      confidence: 0.84,
+      reasons: ['localize thin imported setter into caller-owned host state'],
+      plan: {
+        kind: 'host_state_update',
+        sourceFile: 'a.ts',
+        targetFile: 'b.ts',
+        importedFunction: 'setLastActiveSessionKey',
+        persistenceModule: 'storage.ts',
+        persistenceModuleKind: 'repo_file',
+        persistenceFunction: 'saveSettings',
+        stateObjectProperty: 'settings',
+        updatedProperty: 'lastActiveSessionKey',
+        mirrorHostProperty: 'applySessionKey',
+        trimValue: true,
+      },
+    };
+
+    const patch = await generatePatchForCycle(repoPath, cycle, analysis);
+
+    expect(patch).not.toBeNull();
+    expect(patch?.touchedFiles).toEqual(['a.ts']);
+
+    const sourceSnapshot = patch?.fileSnapshots.find((snapshot) => snapshot.path === 'a.ts');
+    expect(sourceSnapshot?.after).not.toContain("import { setLastActiveSessionKey } from './b';");
+    expect(sourceSnapshot?.after).toMatch(/import \{ saveSettings \} from ['"]\.\/storage['"];/);
+    expect(sourceSnapshot?.after).toContain('function setLastActiveSessionKey(host: unknown, next: string) {');
+    expect(sourceSnapshot?.after).toContain('const trimmed = next.trim();');
+    expect(sourceSnapshot?.after).toContain('settingsHost.settings = settings;');
+    expect(sourceSnapshot?.after).toContain('settingsHost.applySessionKey = String(settings.lastActiveSessionKey);');
+    expect(sourceSnapshot?.after).toContain('saveSettings(settings);');
+    expect(patch?.patchText).not.toContain('+++ b/set-last-active-session-key.shared.ts');
+  });
+
   it('returns null when no executable plan is present', async () => {
     const repoPath = await createRepo({
       'a.ts': 'export const a = 1;\n',

--- a/codemod/generatePatch.ts
+++ b/codemod/generatePatch.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
-import { type ImportDeclaration, Project, type SourceFile, SyntaxKind } from 'ts-morph';
+import { type ImportDeclaration, Node, Project, type SourceFile, SyntaxKind } from 'ts-morph';
 import type { CircularDependency } from '../analyzer/analyzer.js';
 import type {
   DirectImportFixPlan,
   ExtractSharedFixPlan,
+  HostStateUpdateFixPlan,
   ImportTypeFixPlan,
   SemanticAnalysisResult,
 } from '../analyzer/semantic.js';
@@ -41,6 +42,10 @@ export async function generatePatchForCycle(
 
   if (analysis.plan.kind === 'extract_shared') {
     return generateExtractSharedPatch(repoPath, analysis.plan);
+  }
+
+  if (analysis.plan.kind === 'host_state_update') {
+    return generateHostStateUpdatePatch(repoPath, analysis.plan);
   }
 
   return null;
@@ -210,6 +215,75 @@ async function generateDirectImportPatch(repoPath: string, plan: DirectImportFix
   };
 }
 
+async function generateHostStateUpdatePatch(
+  repoPath: string,
+  plan: HostStateUpdateFixPlan,
+): Promise<GeneratedPatch | null> {
+  const project = createProject();
+  const sourceFile = getProjectSourceFile(project, repoPath, plan.sourceFile);
+  const before = sourceFile.getFullText();
+  const targetPath = path.resolve(repoPath, plan.targetFile);
+
+  if (sourceFile.getFunctions().some((declaration) => declaration.getName() === plan.importedFunction)) {
+    return null;
+  }
+
+  let removedImport = false;
+  for (const importDecl of sourceFile.getImportDeclarations()) {
+    if (!resolvesToFile(repoPath, sourceFile, importDecl.getModuleSpecifierValue(), targetPath)) {
+      continue;
+    }
+
+    for (const namedImport of importDecl.getNamedImports()) {
+      const localName = namedImport.getAliasNode()?.getText() ?? namedImport.getName();
+      if (localName === plan.importedFunction) {
+        namedImport.remove();
+        removedImport = true;
+      }
+    }
+
+    if (
+      importDecl.getNamedImports().length === 0 &&
+      !importDecl.getDefaultImport() &&
+      !importDecl.getNamespaceImport()
+    ) {
+      importDecl.remove();
+    }
+  }
+
+  if (!removedImport) {
+    return null;
+  }
+
+  const persistenceModuleSpecifier =
+    plan.persistenceModuleKind === 'repo_file'
+      ? moduleSpecifierForFile(path.dirname(sourceFile.getFilePath()), path.resolve(repoPath, plan.persistenceModule))
+      : plan.persistenceModule;
+  addNamedImport(sourceFile, persistenceModuleSpecifier, [plan.persistenceFunction]);
+
+  insertHelperAfterImports(sourceFile, buildHostStateUpdateHelper(plan));
+
+  return {
+    patchText: buildPatchText([
+      {
+        path: plan.sourceFile,
+        before,
+        after: sourceFile.getFullText(),
+      },
+    ]),
+    touchedFiles: [plan.sourceFile],
+    validationStatus: 'pending',
+    validationSummary: 'Generated localized host-state update candidate. Validation has not run yet.',
+    fileSnapshots: [
+      {
+        path: plan.sourceFile,
+        before,
+        after: sourceFile.getFullText(),
+      },
+    ],
+  };
+}
+
 function rewriteDirectImportPlanEntry(
   project: Project,
   repoPath: string,
@@ -360,6 +434,51 @@ function sourceFileNeedsSharedImport(sourceFile: SourceFile, symbols: string[]):
   return sourceFile
     .getDescendantsOfKind(SyntaxKind.Identifier)
     .some((identifier) => extractedNameSet.has(identifier.getText()));
+}
+
+function insertHelperAfterImports(sourceFile: SourceFile, helperText: string) {
+  const statements = sourceFile.getStatements();
+  const importStatementCount = statements.filter((statement) => Node.isImportDeclaration(statement)).length;
+  sourceFile.insertStatements(importStatementCount, `\n${helperText}\n`);
+}
+
+function buildHostStateUpdateHelper(plan: HostStateUpdateFixPlan): string {
+  const normalizedValueName = plan.trimValue ? 'trimmed' : 'next';
+  const hostPropertyGuard = plan.mirrorHostProperty ? ` || !('${plan.mirrorHostProperty}' in host)` : '';
+  const mirrorHostTypeSegment = plan.mirrorHostProperty ? `; ${plan.mirrorHostProperty}: string` : '';
+  const lines = [
+    `function ${plan.importedFunction}(host: unknown, next: string) {`,
+    `  if (!host || typeof host !== 'object') {`,
+    `    return;`,
+    `  }`,
+    `  if (!('${plan.stateObjectProperty}' in host)${hostPropertyGuard}) {`,
+    `    return;`,
+    `  }`,
+    `  const settingsHost = host as { ${plan.stateObjectProperty}: Parameters<typeof ${plan.persistenceFunction}>[0]${mirrorHostTypeSegment} };`,
+  ];
+
+  if (plan.trimValue) {
+    lines.push(`  const trimmed = next.trim();`);
+  }
+
+  lines.push(
+    `  if (!${normalizedValueName} || String(settingsHost.${plan.stateObjectProperty}.${plan.updatedProperty}) === ${normalizedValueName}) {`,
+    `    return;`,
+    `  }`,
+    `  const settings = {`,
+    `    ...settingsHost.${plan.stateObjectProperty},`,
+    `    ${plan.updatedProperty}: ${normalizedValueName},`,
+    `  } as Parameters<typeof ${plan.persistenceFunction}>[0];`,
+    `  settingsHost.${plan.stateObjectProperty} = settings;`,
+  );
+
+  if (plan.mirrorHostProperty) {
+    lines.push(`  settingsHost.${plan.mirrorHostProperty} = String(settings.${plan.updatedProperty});`);
+  }
+
+  lines.push(`  ${plan.persistenceFunction}(settings);`, `}`);
+
+  return lines.join('\n');
 }
 
 function addNamedImport(sourceFile: SourceFile, moduleSpecifier: string, names: string[]) {

--- a/db/index.ts
+++ b/db/index.ts
@@ -84,6 +84,7 @@ export type Classification =
   | 'autofix_extract_shared'
   | 'autofix_direct_import'
   | 'autofix_import_type'
+  | 'autofix_host_state_update'
   | 'suggest_manual'
   | 'unsupported';
 export type ReviewDecision = 'approved' | 'rejected' | 'ignored' | 'pr_candidate';

--- a/src/routes/findings.tsx
+++ b/src/routes/findings.tsx
@@ -26,6 +26,7 @@ const CLASSIFICATION_OPTIONS = [
   ['autofix_extract_shared', 'Extract shared'],
   ['autofix_direct_import', 'Direct import'],
   ['autofix_import_type', 'Import type'],
+  ['autofix_host_state_update', 'Host state update'],
   ['suggest_manual', 'Suggest manual'],
   ['unsupported', 'Unsupported'],
   ['unclassified', 'Unclassified'],


### PR DESCRIPTION
## Summary
- add a new `host_state_update` planning and codemod strategy for narrow two-file cycles
- localize thin imported setters into the caller when the caller already owns the mutated host state
- surface the new classification in the DB/UI and cover it with analyzer and patch-generation tests

## Verification
- `../../node_modules/.bin/vitest run --config vitest.config.ts analyzer/semantic.test.ts codemod/generatePatch.test.ts`
- `../../node_modules/.bin/eslint analyzer/semantic.ts analyzer/semantic.test.ts codemod/generatePatch.ts codemod/generatePatch.test.ts db/index.ts src/routes/findings.tsx`
- `../../node_modules/.bin/biome check analyzer/semantic.ts analyzer/semantic.test.ts codemod/generatePatch.ts codemod/generatePatch.test.ts db/index.ts src/routes/findings.tsx`
- `../../node_modules/.bin/vitest run --config vitest.config.ts`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`

## Real repo note
- `../../node_modules/.bin/tsx cli/index.ts explain /Users/justinedwards/git/openclaw`
- latest `openclaw` now reports 90 cycles and no longer contains the prior `app-chat.ts <-> app-settings.ts` cycle, so this branch validates the new strategy on fixtures while confirming the upstream fix has stuck
