### PR TITLE
Normalize cycle identities across scans

### DIFF
--- a/analyzer/analyzer.test.ts
+++ b/analyzer/analyzer.test.ts
@@ -124,7 +124,7 @@ describe('analyzeRepository', () => {
 
     const result = await analyzeRepository('/some/path');
     expect(result).toHaveLength(1);
-    expect(result[0].path).toEqual(['src/x.ts', 'src/y.ts']);
+    expect(result[0].path).toEqual(['src/x.ts', 'src/y.ts', 'src/x.ts']);
   });
 
   it('ignores non-circular violation rules', async () => {

--- a/analyzer/analyzer.ts
+++ b/analyzer/analyzer.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { cruise } from 'dependency-cruiser';
+import { canonicalizeCyclePath } from './cycleNormalization.js';
 import { type SemanticAnalysisResult, SemanticAnalyzer } from './semantic.js';
 
 export interface CircularDependency {
@@ -57,10 +58,12 @@ export async function analyzeRepository(repoPath: string): Promise<CircularDepen
             );
           }
 
+          const canonicalCyclePath = canonicalizeCyclePath(cyclePath);
+
           circularDependencies.push({
             type: 'circular',
-            path: cyclePath,
-            analysis: semanticAnalyzer.analyzeCycle(cyclePath),
+            path: canonicalCyclePath,
+            analysis: semanticAnalyzer.analyzeCycle(canonicalCyclePath),
           });
         }
       }

--- a/analyzer/cycleNormalization.test.ts
+++ b/analyzer/cycleNormalization.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalizeCyclePath, normalizeCyclePath } from './cycleNormalization.js';
+
+describe('cycle normalization', () => {
+  it('normalizes rotated closed cycles to one canonical path', () => {
+    expect(canonicalizeCyclePath(['src/b.ts', 'src/c.ts', 'src/a.ts', 'src/b.ts'])).toEqual([
+      'src/a.ts',
+      'src/b.ts',
+      'src/c.ts',
+      'src/a.ts',
+    ]);
+  });
+
+  it('closes open cycles before normalizing them', () => {
+    expect(canonicalizeCyclePath(['src/b.ts', 'src/a.ts'])).toEqual(['src/a.ts', 'src/b.ts', 'src/a.ts']);
+  });
+
+  it('produces a stable normalized key', () => {
+    expect(normalizeCyclePath(['src/b.ts', 'src/c.ts', 'src/a.ts', 'src/b.ts'])).toBe(
+      'src/a.ts -> src/b.ts -> src/c.ts -> src/a.ts',
+    );
+  });
+});

--- a/analyzer/cycleNormalization.ts
+++ b/analyzer/cycleNormalization.ts
@@ -1,0 +1,42 @@
+function stripClosingNode(cyclePath: string[]): string[] {
+  if (cyclePath.length > 1 && cyclePath[0] === cyclePath.at(-1)) {
+    return cyclePath.slice(0, -1);
+  }
+
+  return [...cyclePath];
+}
+
+function compareCycleSegments(left: string[], right: string[]): number {
+  const maxLength = Math.max(left.length, right.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftValue = left[index] ?? '';
+    const rightValue = right[index] ?? '';
+    const comparison = leftValue.localeCompare(rightValue);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+export function canonicalizeCyclePath(cyclePath: string[]): string[] {
+  const openCyclePath = stripClosingNode(cyclePath);
+  if (openCyclePath.length === 0) {
+    return [];
+  }
+
+  let canonicalOpenPath = openCyclePath;
+  for (let startIndex = 1; startIndex < openCyclePath.length; startIndex += 1) {
+    const rotatedPath = [...openCyclePath.slice(startIndex), ...openCyclePath.slice(0, startIndex)];
+    if (compareCycleSegments(rotatedPath, canonicalOpenPath) < 0) {
+      canonicalOpenPath = rotatedPath;
+    }
+  }
+
+  return [...canonicalOpenPath, canonicalOpenPath[0]];
+}
+
+export function normalizeCyclePath(cyclePath: string[]): string {
+  return canonicalizeCyclePath(cyclePath).join(' -> ');
+}

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -93,6 +93,36 @@ describe('Scanner Worker', () => {
     expect(cycles[0].normalized_path).toBe('a.ts -> b.ts -> a.ts');
   });
 
+  it('stores rotated cycles under a canonical normalized path', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(analyzeRepository).mockResolvedValue([{ type: 'circular', path: ['b.ts', 'a.ts', 'b.ts'] }]);
+
+    const result = await scanRepository('justin/repo');
+    const cycles = dbModule.getCyclesByScanId.all(result.scanId) as {
+      normalized_path: string;
+      participating_files: string;
+    }[];
+
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].normalized_path).toBe('a.ts -> b.ts -> a.ts');
+    expect(JSON.parse(cycles[0].participating_files)).toEqual(['a.ts', 'b.ts', 'a.ts']);
+  });
+
+  it('deduplicates equivalent rotated cycles within the same scan', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(analyzeRepository).mockResolvedValue([
+      { type: 'circular', path: ['a.ts', 'b.ts', 'c.ts', 'a.ts'] },
+      { type: 'circular', path: ['b.ts', 'c.ts', 'a.ts', 'b.ts'] },
+    ]);
+
+    const result = await scanRepository('justin/repo');
+    const cycles = dbModule.getCyclesByScanId.all(result.scanId) as { normalized_path: string }[];
+
+    expect(result.cyclesFound).toBe(1);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].normalized_path).toBe('a.ts -> b.ts -> c.ts -> a.ts');
+  });
+
   it('does not construct a repo git client before the clone target exists', async () => {
     vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
 

--- a/cli/scanner.ts
+++ b/cli/scanner.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import simpleGit from 'simple-git';
 import { analyzeRepository } from '../analyzer/analyzer.js';
+import { canonicalizeCyclePath, normalizeCyclePath } from '../analyzer/cycleNormalization.js';
 import type { GeneratedPatch } from '../codemod/generatePatch.js';
 import { generatePatchForCycle } from '../codemod/generatePatch.js';
 import type { RepositoryDTO } from '../db/index.js';
@@ -85,7 +86,7 @@ export async function scanRepository(targetUrlOrOwnerName: string, worktreesDir 
   const scanId = scanInfo.lastInsertRowid as number;
 
   try {
-    const cycles = await analyzeRepository(resolvedTarget.repoPath);
+    const cycles = dedupeCycles(await analyzeRepository(resolvedTarget.repoPath));
 
     for (const cycle of cycles) {
       await persistCycle(
@@ -274,6 +275,25 @@ async function getLatestCommitSha(gitRepo: ReturnType<typeof simpleGit>): Promis
   }
 }
 
+function dedupeCycles(cycles: ScannedCycle[]): ScannedCycle[] {
+  const dedupedCycles = new Map<string, ScannedCycle>();
+
+  for (const cycle of cycles) {
+    const canonicalPath = canonicalizeCyclePath(cycle.path);
+    const normalizedPath = normalizeCyclePath(canonicalPath);
+    if (dedupedCycles.has(normalizedPath)) {
+      continue;
+    }
+
+    dedupedCycles.set(normalizedPath, {
+      ...cycle,
+      path: canonicalPath,
+    });
+  }
+
+  return [...dedupedCycles.values()];
+}
+
 async function persistCycle(
   scanId: number,
   repoPath: string,
@@ -283,30 +303,36 @@ async function persistCycle(
   repository: RepositoryDTO,
   cycle: ScannedCycle,
 ): Promise<void> {
+  const canonicalPath = canonicalizeCyclePath(cycle.path);
+  const persistedCycle = {
+    ...cycle,
+    path: canonicalPath,
+  };
+
   const cycleInfo = addCycle.run({
     scan_id: scanId,
-    normalized_path: cycle.path.join(' -> '),
-    participating_files: JSON.stringify(cycle.path),
-    raw_payload: JSON.stringify(cycle),
+    normalized_path: normalizeCyclePath(canonicalPath),
+    participating_files: JSON.stringify(canonicalPath),
+    raw_payload: JSON.stringify(persistedCycle),
   });
 
-  if (!cycle.analysis) {
+  if (!persistedCycle.analysis) {
     return;
   }
 
   const fixCandidateInfo = addFixCandidate.run({
     cycle_id: cycleInfo.lastInsertRowid as number,
-    classification: cycle.analysis.classification,
-    confidence: cycle.analysis.confidence,
-    reasons: JSON.stringify(cycle.analysis.reasons),
+    classification: persistedCycle.analysis.classification,
+    confidence: persistedCycle.analysis.confidence,
+    reasons: JSON.stringify(persistedCycle.analysis.reasons),
   });
 
-  const generatedPatch = await generatePatchForCycle(repoPath, cycle, cycle.analysis);
+  const generatedPatch = await generatePatchForCycle(repoPath, persistedCycle, persistedCycle.analysis);
   if (!generatedPatch) {
     return;
   }
 
-  const validation = await validateGeneratedPatch(repoPath, cycle, generatedPatch);
+  const validation = await validateGeneratedPatch(repoPath, persistedCycle, generatedPatch);
   const patchPayload = {
     fix_candidate_id: fixCandidateInfo.lastInsertRowid as number,
     patch_text: generatedPatch.patchText,
@@ -320,7 +346,7 @@ async function persistCycle(
     commitSha,
     remoteUrl,
     repository,
-    cycle,
+    cycle: persistedCycle,
     generatedPatch,
     validation,
   });
@@ -373,6 +399,8 @@ function buildPatchReplayBundle(args: {
   generatedPatch: GeneratedPatch;
   validation: ValidationResult;
 }): PatchReplayBundle {
+  const canonicalPath = canonicalizeCyclePath(args.cycle.path);
+
   return {
     scan_id: args.scanId,
     source_target: args.sourceTarget,
@@ -385,9 +413,12 @@ function buildPatchReplayBundle(args: {
       remote_url: normalizeRemoteUrl(args.remoteUrl, args.repository.owner, args.repository.name),
     },
     cycle: {
-      path: args.cycle.path,
-      normalized_path: args.cycle.path.join(' -> '),
-      raw_payload: args.cycle,
+      path: canonicalPath,
+      normalized_path: normalizeCyclePath(canonicalPath),
+      raw_payload: {
+        ...args.cycle,
+        path: canonicalPath,
+      },
     },
     candidate: {
       classification: args.cycle.analysis?.classification ?? 'unsupported',

--- a/cli/validation.test.ts
+++ b/cli/validation.test.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import * as analyzerModule from '../analyzer/analyzer.js';
 import type { CircularDependency } from '../analyzer/analyzer.js';
+import * as analyzerModule from '../analyzer/analyzer.js';
 import type { GeneratedPatch } from '../codemod/generatePatch.js';
 import { validateGeneratedPatch } from './validation.js';
 
@@ -139,6 +139,41 @@ describe('validateGeneratedPatch', () => {
     const result = await validateGeneratedPatch(
       repoPath,
       { type: 'circular', path: ['a.ts', 'b.ts', 'a.ts'] },
+      generatedPatch,
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.summary).toContain('original cycle is still present');
+  });
+
+  it('treats rotated equivalents as the same original cycle during validation', async () => {
+    const repoPath = await createRepo({
+      'a.ts': 'export const a = 1;\n',
+      'b.ts': 'export const b = 2;\n',
+      'c.ts': 'export const c = 3;\n',
+    });
+
+    vi.spyOn(analyzerModule, 'analyzeRepository').mockResolvedValue([
+      { type: 'circular', path: ['b.ts', 'c.ts', 'a.ts', 'b.ts'] } as CircularDependency,
+    ]);
+
+    const generatedPatch: GeneratedPatch = {
+      patchText: 'diff',
+      touchedFiles: ['a.ts'],
+      validationStatus: 'pending',
+      validationSummary: 'pending',
+      fileSnapshots: [
+        {
+          path: 'a.ts',
+          before: 'export const a = 1;\n',
+          after: 'export const a = 2;\n',
+        },
+      ],
+    };
+
+    const result = await validateGeneratedPatch(
+      repoPath,
+      { type: 'circular', path: ['a.ts', 'b.ts', 'c.ts', 'a.ts'] },
       generatedPatch,
     );
 

--- a/cli/validation.ts
+++ b/cli/validation.ts
@@ -1,11 +1,12 @@
+import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
-import { createRequire } from 'node:module';
-import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { analyzeRepository } from '../analyzer/analyzer.js';
 import type { CircularDependency } from '../analyzer/analyzer.js';
+import { analyzeRepository } from '../analyzer/analyzer.js';
+import { normalizeCyclePath } from '../analyzer/cycleNormalization.js';
 import type { GeneratedPatch } from '../codemod/generatePatch.js';
 import { profileRepository } from './repoProfile.js';
 
@@ -81,10 +82,6 @@ async function applySnapshots(repoPath: string, generatedPatch: GeneratedPatch):
     await fs.mkdir(path.dirname(absolutePath), { recursive: true });
     await fs.writeFile(absolutePath, snapshot.after, 'utf8');
   }
-}
-
-function normalizeCyclePath(cyclePath: string[]): string {
-  return cyclePath.join(' -> ');
 }
 
 async function safeProfileRepository(repoPath: string) {


### PR DESCRIPTION
## Summary
- add shared cycle normalization utilities and canonicalize analyzer output
- deduplicate rotated equivalents before persisting scan results
- use canonical cycle identities during validation and replay-bundle storage
- add coverage for rotated persistence, dedupe, and validation behavior

## Verification
- `../../node_modules/.bin/vitest run`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `../../node_modules/.bin/eslint analyzer/analyzer.ts analyzer/analyzer.test.ts analyzer/cycleNormalization.ts analyzer/cycleNormalization.test.ts cli/scanner.ts cli/scanner.test.ts cli/validation.ts cli/validation.test.ts`
- `../../node_modules/.bin/biome check analyzer/analyzer.ts analyzer/analyzer.test.ts analyzer/cycleNormalization.ts analyzer/cycleNormalization.test.ts cli/scanner.ts cli/scanner.test.ts cli/validation.ts cli/validation.test.ts`
- `../../node_modules/.bin/vite build`

Closes #43