### PR TITLE
Add evidence-driven upstreamability scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ worktrees/
 
 # Testing
 coverage/
+.test-fixtures/

--- a/analyzer/analyzer.ts
+++ b/analyzer/analyzer.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
 import { cruise } from 'dependency-cruiser';
+import { profileRepository } from '../cli/repoProfile.js';
 import { canonicalizeCyclePath } from './cycleNormalization.js';
+import { loadHistoricalEvidence } from './semantic/evidence.js';
+import type { PlannerRepositoryProfile } from './semantic.js';
 import { type SemanticAnalysisResult, SemanticAnalyzer } from './semantic.js';
 
 export interface CircularDependency {
@@ -11,6 +14,8 @@ export interface CircularDependency {
 
 export async function analyzeRepository(repoPath: string): Promise<CircularDependency[]> {
   const resolvedRepoPath = path.resolve(repoPath);
+  const repositoryProfile = await safePlannerRepositoryProfile(resolvedRepoPath);
+  const historicalEvidence = loadHistoricalEvidence(repositoryProfile);
 
   try {
     const result = await cruise([resolvedRepoPath], {
@@ -34,7 +39,10 @@ export async function analyzeRepository(repoPath: string): Promise<CircularDepen
     });
 
     const circularDependencies: CircularDependency[] = [];
-    const semanticAnalyzer = new SemanticAnalyzer(resolvedRepoPath);
+    const semanticAnalyzer = new SemanticAnalyzer(resolvedRepoPath, {
+      repositoryProfile,
+      historicalEvidence,
+    });
 
     const output = result.output;
     if (typeof output === 'string') {
@@ -73,6 +81,19 @@ export async function analyzeRepository(repoPath: string): Promise<CircularDepen
   } catch (error) {
     console.error('Error analyzing repository:', error);
     throw error;
+  }
+}
+
+async function safePlannerRepositoryProfile(repoPath: string): Promise<PlannerRepositoryProfile | undefined> {
+  try {
+    const profile = await profileRepository(repoPath);
+    return {
+      packageManager: profile.packageManager,
+      workspaceMode: profile.workspaceMode,
+      validationCommandCount: profile.validationCommands.length,
+    };
+  } catch {
+    return void 0;
   }
 }
 

--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -73,7 +73,15 @@ describe('SemanticAnalyzer', () => {
       selectedStrategy: 'import_type',
       selectedClassification: 'autofix_import_type',
       selectedScore: 0.94,
+      features: {
+        cycleSize: 2,
+        cycleShape: 'two_file',
+        explicitImportEdges: 2,
+        loadedFiles: 2,
+        missingFiles: 0,
+      },
     });
+    expect(result.planner?.rankedCandidates[0]?.strategy).toBe('import_type');
     expect(result.planner?.attempts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -206,7 +214,7 @@ describe('SemanticAnalyzer', () => {
       cycleShape: 'multi_file',
       selectedStrategy: 'direct_import',
       selectedClassification: 'autofix_direct_import',
-      selectedScore: 0.89,
+      selectedScore: 0.9,
     });
     expect(result.plan).toEqual({
       kind: 'direct_import',
@@ -219,6 +227,112 @@ describe('SemanticAnalyzer', () => {
         },
       ],
     });
+  });
+
+  it('adjusts candidate scoring with historical evidence and repository features', () => {
+    analyzer = new SemanticAnalyzer('/dummy/repo', {
+      repositoryProfile: {
+        packageManager: 'pnpm',
+        workspaceMode: 'workspace',
+        validationCommandCount: 4,
+      },
+      historicalEvidence: {
+        totalBenchmarkCases: 6,
+        totalReviewedPatches: 4,
+        totalValidatedPatches: 4,
+        strategies: {
+          import_type: {
+            benchmarkMatches: 0,
+            profileMatches: 0,
+            approvedReviews: 0,
+            rejectedReviews: 0,
+            prCandidates: 0,
+            ignoredReviews: 0,
+            passedValidations: 0,
+            failedValidations: 0,
+          },
+          direct_import: {
+            benchmarkMatches: 4,
+            profileMatches: 2,
+            approvedReviews: 3,
+            rejectedReviews: 0,
+            prCandidates: 1,
+            ignoredReviews: 0,
+            passedValidations: 4,
+            failedValidations: 0,
+          },
+          extract_shared: {
+            benchmarkMatches: 0,
+            profileMatches: 0,
+            approvedReviews: 0,
+            rejectedReviews: 0,
+            prCandidates: 0,
+            ignoredReviews: 0,
+            passedValidations: 0,
+            failedValidations: 0,
+          },
+          host_state_update: {
+            benchmarkMatches: 0,
+            profileMatches: 0,
+            approvedReviews: 0,
+            rejectedReviews: 0,
+            prCandidates: 0,
+            ignoredReviews: 0,
+            passedValidations: 0,
+            failedValidations: 0,
+          },
+        },
+      },
+    });
+
+    analyzer.project.createSourceFile(
+      '/dummy/repo/app.ts',
+      `
+      import { Foo } from './index';
+      export const appValue = Foo + 1;
+    `,
+    );
+    analyzer.project.createSourceFile(
+      '/dummy/repo/index.ts',
+      `
+      export { Foo } from './foo';
+      export { Bar } from './bar';
+    `,
+    );
+    analyzer.project.createSourceFile('/dummy/repo/foo.ts', 'export const Foo = 1;');
+    analyzer.project.createSourceFile(
+      '/dummy/repo/bar.ts',
+      `
+      import { appValue } from './app';
+      export const Bar = appValue + 1;
+    `,
+    );
+
+    const result = analyzer.analyzeCycle(['app.ts', 'index.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('autofix_direct_import');
+    expect(result.upstreamabilityScore).toBeGreaterThan(0.89);
+    expect(result.planner).toMatchObject({
+      features: {
+        hasBarrelFile: true,
+        packageManager: 'pnpm',
+        workspaceMode: 'workspace',
+        validationCommandCount: 4,
+      },
+    });
+    expect(result.planner?.rankedCandidates[0]?.signals).toMatchObject({
+      historicalBenchmarkMatches: 4,
+      historicalProfileMatches: 2,
+      historicalReviewedPatches: 4,
+      historicalValidatedPatches: 4,
+    });
+    expect(result.planner?.rankedCandidates[0]?.scoreBreakdown).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('matching benchmark case'),
+        expect.stringContaining('review outcomes'),
+        expect.stringContaining('validation history'),
+      ]),
+    );
   });
 
   it('detects host_state_update for thin imported setters on caller-owned state', () => {

--- a/analyzer/semantic/SemanticAnalyzer.ts
+++ b/analyzer/semantic/SemanticAnalyzer.ts
@@ -11,9 +11,13 @@ import {
   SyntaxKind,
 } from 'ts-morph';
 import type { Classification } from '../../db/index.js';
+import { createEmptyHistoricalEvidenceSnapshot } from './evidence.js';
+import { extractCycleFeatures } from './features.js';
 import {
+  applyHistoricalEvidence,
   createNotApplicableAttempt,
   createRejectedAttempt,
+  rankCandidateAttempts,
   scoreDirectImportPlan,
   scoreExtractSharedPlan,
   scoreHostStateUpdatePlan,
@@ -26,8 +30,10 @@ import type {
   DirectImportFixPlan,
   DirectImportSearchResult,
   ExtractSharedFixPlan,
+  HistoricalEvidenceSnapshot,
   HostStateUpdateFixPlan,
   ImportTypeFixPlan,
+  PlannerRepositoryProfile,
   SemanticAnalysisResult,
   StrategyAttempt,
   StrategyDefinition,
@@ -37,7 +43,13 @@ import { missingCycleFilesReason } from './types.js';
 export class SemanticAnalyzer {
   public project: Project;
 
-  constructor(public repoPath: string) {
+  constructor(
+    public repoPath: string,
+    private readonly plannerOptions: {
+      repositoryProfile?: PlannerRepositoryProfile;
+      historicalEvidence?: HistoricalEvidenceSnapshot;
+    } = {},
+  ) {
     this.project = new Project({
       compilerOptions: {
         allowJs: true,
@@ -78,7 +90,8 @@ export class SemanticAnalyzer {
   public planCycle(cyclePath: string[]): CyclePlanningResult {
     const context = this.buildPlanningContext(cyclePath);
     const attempts = this.getStrategyDefinitions().map((strategy) => this.evaluateStrategy(strategy, context));
-    const selectedAttempt = selectBestAttempt(attempts);
+    const rankedCandidates = rankCandidateAttempts(attempts);
+    const selectedAttempt = rankedCandidates[0] ?? selectBestAttempt(attempts);
     const fallbackDecision = this.determineFallbackDecision(context, attempts);
 
     return {
@@ -86,6 +99,7 @@ export class SemanticAnalyzer {
       cycleSize: context.uniqueFiles.length,
       cycleShape: context.cycleShape,
       cycleSignals: context.cycleSignals,
+      features: context.features,
       fallbackClassification: selectedAttempt?.classification ?? fallbackDecision.classification,
       fallbackConfidence: selectedAttempt?.confidence ?? fallbackDecision.confidence,
       fallbackReasons: selectedAttempt?.reasons ?? fallbackDecision.reasons,
@@ -93,8 +107,9 @@ export class SemanticAnalyzer {
       selectedClassification: selectedAttempt?.classification,
       selectedScore: selectedAttempt?.score,
       selectionSummary: selectedAttempt
-        ? `Selected ${selectedAttempt.strategy} with score ${selectedAttempt.score ?? 0} after evaluating ${attempts.length} strategies.`
+        ? `Selected ${selectedAttempt.strategy} with score ${selectedAttempt.score ?? 0} after evaluating ${attempts.length} strategies; ${rankedCandidates.length} candidate(s) cleared the safety filters.`
         : `No strategy cleared the safety filters; falling back to ${fallbackDecision.classification}.`,
+      rankedCandidates,
       attempts,
     };
   }
@@ -110,6 +125,11 @@ export class SemanticAnalyzer {
     const sourceFileB = fileB ? sourceFiles.get(fileB) : undefined;
     const importsAToB = sourceFileA && fileB ? this.findImportsTo(sourceFileA, fileB) : [];
     const importsBToA = sourceFileB && fileA ? this.findImportsTo(sourceFileB, fileA) : [];
+    const cycleSignals = {
+      explicitImportEdges: importsAToB.length + importsBToA.length,
+      loadedFiles: [...sourceFiles.values()].filter(Boolean).length,
+      missingFiles: [...sourceFiles.values()].filter((sourceFile) => !sourceFile).length,
+    };
 
     return {
       cyclePath,
@@ -118,11 +138,15 @@ export class SemanticAnalyzer {
       sourceFiles,
       importsAToB,
       importsBToA,
-      cycleSignals: {
-        explicitImportEdges: importsAToB.length + importsBToA.length,
-        loadedFiles: [...sourceFiles.values()].filter(Boolean).length,
-        missingFiles: [...sourceFiles.values()].filter((sourceFile) => !sourceFile).length,
-      },
+      cycleSignals,
+      repositoryProfile: this.plannerOptions.repositoryProfile,
+      historicalEvidence: this.plannerOptions.historicalEvidence ?? createEmptyHistoricalEvidenceSnapshot(),
+      features: extractCycleFeatures({
+        uniqueFiles,
+        cycleShape,
+        cycleSignals,
+        repositoryProfile: this.plannerOptions.repositoryProfile,
+      }),
     };
   }
 
@@ -248,7 +272,8 @@ export class SemanticAnalyzer {
       return createNotApplicableAttempt(strategy.strategy, applicability.summary, applicability.signals);
     }
 
-    return strategy.evaluate(context);
+    const attempt = strategy.evaluate(context);
+    return applyHistoricalEvidence(attempt, context.features, context.historicalEvidence);
   }
 
   private determineFallbackDecision(

--- a/analyzer/semantic/evidence.ts
+++ b/analyzer/semantic/evidence.ts
@@ -1,0 +1,177 @@
+import type { BenchmarkCaseDTO } from '../../db/index.js';
+import { getBenchmarkCases, getDb } from '../../db/index.js';
+import type {
+  HistoricalEvidenceSnapshot,
+  PlannerRepositoryProfile,
+  PlanningStrategy,
+  StrategyHistoricalEvidence,
+} from './types.js';
+
+const STRATEGIES: PlanningStrategy[] = ['import_type', 'direct_import', 'extract_shared', 'host_state_update'];
+
+const STRATEGY_LABELS: Record<PlanningStrategy, string[]> = {
+  import_type: ['import_type', 'type_runtime_split'],
+  direct_import: ['direct_import', 'barrel_reexport_cleanup'],
+  extract_shared: ['extract_shared', 'leaf_cluster_extraction'],
+  host_state_update: ['host_owned_state_update', 'stateful_singleton_split'],
+};
+
+const CLASSIFICATION_TO_STRATEGY: Partial<Record<string, PlanningStrategy>> = {
+  autofix_import_type: 'import_type',
+  autofix_direct_import: 'direct_import',
+  autofix_extract_shared: 'extract_shared',
+  autofix_host_state_update: 'host_state_update',
+};
+
+interface ReviewEvidenceRow {
+  classification: string;
+  validation_status: string | null;
+  decision: string | null;
+}
+
+interface BenchmarkSignalsShape {
+  repository_profile?: {
+    package_manager?: PlannerRepositoryProfile['packageManager'];
+    workspace_mode?: PlannerRepositoryProfile['workspaceMode'];
+  };
+}
+
+export function createEmptyHistoricalEvidenceSnapshot(): HistoricalEvidenceSnapshot {
+  return {
+    totalBenchmarkCases: 0,
+    totalReviewedPatches: 0,
+    totalValidatedPatches: 0,
+    strategies: {
+      import_type: createEmptyStrategyEvidence(),
+      direct_import: createEmptyStrategyEvidence(),
+      extract_shared: createEmptyStrategyEvidence(),
+      host_state_update: createEmptyStrategyEvidence(),
+    },
+  };
+}
+
+export function loadHistoricalEvidence(repositoryProfile?: PlannerRepositoryProfile): HistoricalEvidenceSnapshot {
+  const snapshot = createEmptyHistoricalEvidenceSnapshot();
+  const benchmarkCases = getBenchmarkCases.all() as BenchmarkCaseDTO[];
+
+  snapshot.totalBenchmarkCases = benchmarkCases.length;
+  for (const benchmarkCase of benchmarkCases) {
+    applyBenchmarkCase(snapshot, benchmarkCase, repositoryProfile);
+  }
+
+  const reviewRows = getDb()
+    .prepare(
+      `
+        SELECT
+          fc.classification,
+          p.validation_status,
+          rd.decision
+        FROM fix_candidates fc
+        LEFT JOIN patches p ON p.fix_candidate_id = fc.id
+        LEFT JOIN review_decisions rd ON rd.patch_id = p.id
+      `,
+    )
+    .all() as ReviewEvidenceRow[];
+
+  for (const row of reviewRows) {
+    const strategy = CLASSIFICATION_TO_STRATEGY[row.classification];
+    if (!strategy) {
+      continue;
+    }
+
+    const evidence = snapshot.strategies[strategy];
+    if (row.validation_status === 'passed') {
+      evidence.passedValidations += 1;
+      snapshot.totalValidatedPatches += 1;
+    } else if (row.validation_status === 'failed') {
+      evidence.failedValidations += 1;
+      snapshot.totalValidatedPatches += 1;
+    }
+
+    switch (row.decision) {
+      case 'approved': {
+        evidence.approvedReviews += 1;
+        snapshot.totalReviewedPatches += 1;
+        break;
+      }
+      case 'rejected': {
+        evidence.rejectedReviews += 1;
+        snapshot.totalReviewedPatches += 1;
+        break;
+      }
+      case 'pr_candidate': {
+        evidence.prCandidates += 1;
+        snapshot.totalReviewedPatches += 1;
+        break;
+      }
+      case 'ignored': {
+        evidence.ignoredReviews += 1;
+        snapshot.totalReviewedPatches += 1;
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+
+  return snapshot;
+}
+
+function applyBenchmarkCase(
+  snapshot: HistoricalEvidenceSnapshot,
+  benchmarkCase: BenchmarkCaseDTO,
+  repositoryProfile?: PlannerRepositoryProfile,
+): void {
+  const labels = parseJsonArray(benchmarkCase.strategy_labels);
+  const signals = parseBenchmarkSignals(benchmarkCase.validation_signals);
+
+  for (const strategy of STRATEGIES) {
+    if (!labels.some((label) => STRATEGY_LABELS[strategy].includes(label))) {
+      continue;
+    }
+
+    const evidence = snapshot.strategies[strategy];
+    evidence.benchmarkMatches += 1;
+
+    if (repositoryProfile && signals.repository_profile) {
+      if (signals.repository_profile.package_manager === repositoryProfile.packageManager) {
+        evidence.profileMatches += 1;
+      }
+      if (signals.repository_profile.workspace_mode === repositoryProfile.workspaceMode) {
+        evidence.profileMatches += 1;
+      }
+    }
+  }
+}
+
+function createEmptyStrategyEvidence(): StrategyHistoricalEvidence {
+  return {
+    benchmarkMatches: 0,
+    profileMatches: 0,
+    approvedReviews: 0,
+    rejectedReviews: 0,
+    prCandidates: 0,
+    ignoredReviews: 0,
+    passedValidations: 0,
+    failedValidations: 0,
+  };
+}
+
+function parseJsonArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseBenchmarkSignals(value: string): BenchmarkSignalsShape {
+  try {
+    const parsed = JSON.parse(value) as BenchmarkSignalsShape;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}

--- a/analyzer/semantic/features.ts
+++ b/analyzer/semantic/features.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+import type { CycleFeatureVector, PlannerRepositoryProfile } from './types.js';
+
+export function extractCycleFeatures(args: {
+  uniqueFiles: string[];
+  cycleShape: 'two_file' | 'multi_file';
+  cycleSignals: {
+    explicitImportEdges: number;
+    loadedFiles: number;
+    missingFiles: number;
+  };
+  repositoryProfile?: PlannerRepositoryProfile;
+}): CycleFeatureVector {
+  const { uniqueFiles, cycleShape, cycleSignals, repositoryProfile } = args;
+
+  return {
+    cycleSize: uniqueFiles.length,
+    cycleShape,
+    explicitImportEdges: cycleSignals.explicitImportEdges,
+    loadedFiles: cycleSignals.loadedFiles,
+    missingFiles: cycleSignals.missingFiles,
+    hasBarrelFile: uniqueFiles.some((filePath) => /^index\.[cm]?[jt]sx?$/.test(path.basename(filePath))),
+    hasSharedModuleFile: uniqueFiles.some((filePath) => filePath.includes('.shared.')),
+    typescriptFileCount: uniqueFiles.filter((filePath) => /\.[cm]?tsx?$/.test(filePath)).length,
+    tsxFileCount: uniqueFiles.filter((filePath) => /\.[cm]?tsx$/.test(filePath)).length,
+    packageManager: repositoryProfile?.packageManager ?? 'unknown',
+    workspaceMode: repositoryProfile?.workspaceMode ?? 'unknown',
+    validationCommandCount: repositoryProfile?.validationCommandCount ?? 0,
+  };
+}

--- a/analyzer/semantic/scoring.ts
+++ b/analyzer/semantic/scoring.ts
@@ -1,7 +1,9 @@
 import path from 'node:path';
 import type {
+  CycleFeatureVector,
   DirectImportFixPlan,
   ExtractSharedFixPlan,
+  HistoricalEvidenceSnapshot,
   HostStateUpdateFixPlan,
   ImportTypeFixPlan,
   PlanningStrategy,
@@ -114,27 +116,103 @@ export function scoreHostStateUpdatePlan(plan: HostStateUpdateFixPlan): {
 }
 
 export function selectBestAttempt(attempts: StrategyAttempt[]): StrategyAttempt | undefined {
-  let bestAttempt: StrategyAttempt | undefined;
+  return rankCandidateAttempts(attempts)[0];
+}
+
+export function rankCandidateAttempts(attempts: StrategyAttempt[]): StrategyAttempt[] {
+  const rankedAttempts: StrategyAttempt[] = [];
 
   for (const attempt of attempts) {
     if (attempt.status !== 'candidate') {
       continue;
     }
 
-    if (!bestAttempt) {
-      bestAttempt = attempt;
-      continue;
+    let insertAt = 0;
+    while (insertAt < rankedAttempts.length && compareAttempts(rankedAttempts[insertAt], attempt) < 0) {
+      insertAt += 1;
     }
 
-    const scoreDelta = (attempt.score ?? 0) - (bestAttempt.score ?? 0);
-    const confidenceDelta = (attempt.confidence ?? 0) - (bestAttempt.confidence ?? 0);
+    rankedAttempts.splice(insertAt, 0, attempt);
+  }
 
-    if (scoreDelta > 0 || (scoreDelta === 0 && confidenceDelta > 0)) {
-      bestAttempt = attempt;
+  return rankedAttempts;
+}
+
+export function applyHistoricalEvidence(
+  attempt: StrategyAttempt,
+  features: CycleFeatureVector,
+  historicalEvidence: HistoricalEvidenceSnapshot,
+): StrategyAttempt {
+  if (attempt.status !== 'candidate') {
+    return attempt;
+  }
+
+  const evidence = historicalEvidence.strategies[attempt.strategy];
+  if (!evidence) {
+    return attempt;
+  }
+
+  let adjustedScore = attempt.score ?? 0;
+  const breakdown = [...(attempt.scoreBreakdown ?? [])];
+
+  if (evidence.benchmarkMatches > 0) {
+    const benchmarkBonus = Math.min(0.03, evidence.benchmarkMatches * 0.005);
+    adjustedScore += benchmarkBonus;
+    breakdown.push(`+${benchmarkBonus.toFixed(2)} from ${evidence.benchmarkMatches} matching benchmark case(s)`);
+  }
+
+  if (evidence.profileMatches > 0) {
+    const profileBonus = Math.min(0.02, evidence.profileMatches * 0.01);
+    adjustedScore += profileBonus;
+    breakdown.push(`+${profileBonus.toFixed(2)} from repository-profile matches in historical cases`);
+  }
+
+  const reviewedCount =
+    evidence.approvedReviews + evidence.rejectedReviews + evidence.prCandidates + evidence.ignoredReviews;
+  if (reviewedCount > 0) {
+    const positiveReviewWeight = evidence.approvedReviews + evidence.prCandidates * 0.5;
+    const approvalRatio = positiveReviewWeight / reviewedCount;
+    const reviewDelta = clampSignedAdjustment((approvalRatio - 0.5) * 0.08, 0.04);
+    if (reviewDelta !== 0) {
+      adjustedScore += reviewDelta;
+      breakdown.push(`${formatSignedScore(reviewDelta)} from review outcomes (${reviewedCount} reviewed patch(es))`);
     }
   }
 
-  return bestAttempt;
+  const validatedCount = evidence.passedValidations + evidence.failedValidations;
+  if (validatedCount > 0) {
+    const validationRatio = evidence.passedValidations / validatedCount;
+    const validationDelta = clampSignedAdjustment((validationRatio - 0.5) * 0.06, 0.03);
+    if (validationDelta !== 0) {
+      adjustedScore += validationDelta;
+      breakdown.push(
+        `${formatSignedScore(validationDelta)} from validation history (${evidence.passedValidations}/${validatedCount} passed)`,
+      );
+    }
+  }
+
+  if (attempt.strategy === 'direct_import' && features.hasBarrelFile) {
+    adjustedScore += 0.01;
+    breakdown.push('+0.01 because the cycle already contains a barrel entrypoint');
+  }
+
+  if (attempt.strategy === 'extract_shared' && features.validationCommandCount > 2) {
+    adjustedScore -= 0.01;
+    breakdown.push('-0.01 because new shared modules are more fragile under heavier repo validation');
+  }
+
+  return {
+    ...attempt,
+    score: clampScore(adjustedScore),
+    scoreBreakdown: breakdown,
+    signals: {
+      ...attempt.signals,
+      historicalBenchmarkMatches: evidence.benchmarkMatches,
+      historicalProfileMatches: evidence.profileMatches,
+      historicalReviewedPatches: reviewedCount,
+      historicalValidatedPatches: validatedCount,
+    },
+  };
 }
 
 export function createNotApplicableAttempt(
@@ -168,4 +246,21 @@ export function createRejectedAttempt(
 
 function clampScore(value: number): number {
   return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function compareAttempts(left: StrategyAttempt, right: StrategyAttempt): number {
+  const scoreDelta = (right.score ?? 0) - (left.score ?? 0);
+  if (scoreDelta !== 0) {
+    return scoreDelta;
+  }
+
+  return (right.confidence ?? 0) - (left.confidence ?? 0);
+}
+
+function clampSignedAdjustment(value: number, cap: number): number {
+  return Number(Math.max(-cap, Math.min(cap, value)).toFixed(2));
+}
+
+function formatSignedScore(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}`;
 }

--- a/analyzer/semantic/types.ts
+++ b/analyzer/semantic/types.ts
@@ -45,6 +45,45 @@ export interface HostStateUpdateFixPlan {
 export type PlanningStrategy = 'import_type' | 'direct_import' | 'extract_shared' | 'host_state_update';
 export type StrategySignalValue = boolean | number | string;
 
+export interface PlannerRepositoryProfile {
+  packageManager: 'bun' | 'npm' | 'pnpm' | 'unknown' | 'yarn';
+  workspaceMode: 'single-package' | 'unknown' | 'workspace';
+  validationCommandCount: number;
+}
+
+export interface CycleFeatureVector {
+  cycleSize: number;
+  cycleShape: 'two_file' | 'multi_file';
+  explicitImportEdges: number;
+  loadedFiles: number;
+  missingFiles: number;
+  hasBarrelFile: boolean;
+  hasSharedModuleFile: boolean;
+  typescriptFileCount: number;
+  tsxFileCount: number;
+  packageManager: PlannerRepositoryProfile['packageManager'];
+  workspaceMode: PlannerRepositoryProfile['workspaceMode'];
+  validationCommandCount: number;
+}
+
+export interface StrategyHistoricalEvidence {
+  benchmarkMatches: number;
+  profileMatches: number;
+  approvedReviews: number;
+  rejectedReviews: number;
+  prCandidates: number;
+  ignoredReviews: number;
+  passedValidations: number;
+  failedValidations: number;
+}
+
+export interface HistoricalEvidenceSnapshot {
+  totalBenchmarkCases: number;
+  totalReviewedPatches: number;
+  totalValidatedPatches: number;
+  strategies: Record<PlanningStrategy, StrategyHistoricalEvidence>;
+}
+
 export const missingCycleFilesReason = 'Files participating in the cycle could not be read or found.';
 
 export interface StrategyAttempt {
@@ -53,6 +92,7 @@ export interface StrategyAttempt {
   summary: string;
   reasons: string[];
   signals: Record<string, StrategySignalValue>;
+  baseScore?: number;
   score?: number;
   scoreBreakdown?: string[];
   classification?: Classification;
@@ -65,6 +105,7 @@ export interface CyclePlanningResult {
   cycleSize: number;
   cycleShape: 'two_file' | 'multi_file';
   cycleSignals: Record<string, StrategySignalValue>;
+  features: CycleFeatureVector;
   fallbackClassification: Classification;
   fallbackConfidence: number;
   fallbackReasons: string[];
@@ -72,6 +113,7 @@ export interface CyclePlanningResult {
   selectedClassification?: Classification;
   selectedScore?: number;
   selectionSummary: string;
+  rankedCandidates: StrategyAttempt[];
   attempts: StrategyAttempt[];
 }
 
@@ -97,6 +139,9 @@ export interface CyclePlanningContext {
   importsAToB: ImportDeclaration[];
   importsBToA: ImportDeclaration[];
   cycleSignals: Record<string, StrategySignalValue>;
+  repositoryProfile?: PlannerRepositoryProfile;
+  historicalEvidence: HistoricalEvidenceSnapshot;
+  features: CycleFeatureVector;
 }
 
 export interface StrategyDefinition {

--- a/cli/createPullRequest.test.ts
+++ b/cli/createPullRequest.test.ts
@@ -96,6 +96,7 @@ describe('createPullRequestForPatch', () => {
     expect(ghArgs).toContain('codex/issue-42-patch-1');
     expect(ghArgs).toContain('--body');
     expect(ghArgs.at(-1)).toContain('Validation passed: original cycle removed.');
+    expect(ghArgs.at(-1)).toContain('Upstreamability score: 91%');
     expect(ghArgs.at(-1)).toContain('Closes #42');
   });
 
@@ -138,10 +139,52 @@ describe('createPullRequestForPatch', () => {
     ).rejects.toThrow('must be marked approved or pr_candidate');
   });
 
+  it('rejects PR creation when the upstreamability score is below the threshold', async () => {
+    const patchId = insertPatchCandidate({
+      reviewDecision: 'approved',
+      validationStatus: 'passed',
+      remoteUrl: 'git@github.com:acme/widget.git',
+      upstreamabilityScore: 0.55,
+    });
+
+    await expect(
+      createPullRequestForPatch(patchId, {
+        linkedIssueNumber: 77,
+        repoPath,
+        database: db,
+      }),
+    ).rejects.toThrow('below the PR threshold');
+  });
+
+  it('allows PR creation below the threshold when explicitly overridden', async () => {
+    const patchId = insertPatchCandidate({
+      reviewDecision: 'approved',
+      validationStatus: 'passed',
+      remoteUrl: 'git@github.com:acme/widget.git',
+      upstreamabilityScore: 0.55,
+    });
+    await fs.mkdir(path.join(repoPath, 'src'), { recursive: true });
+    await fs.writeFile(path.join(repoPath, 'src', 'a.ts'), 'before', 'utf8');
+
+    repoGit.status.mockResolvedValueOnce({ files: [] }).mockResolvedValueOnce({ files: [{ path: 'src/a.ts' }] });
+
+    await expect(
+      createPullRequestForPatch(patchId, {
+        linkedIssueNumber: 77,
+        repoPath,
+        database: db,
+        allowBelowThreshold: true,
+      }),
+    ).resolves.toMatchObject({
+      branchName: 'codex/issue-77-patch-1',
+    });
+  });
+
   function insertPatchCandidate(args: {
     reviewDecision: 'approved' | 'pr_candidate' | 'pending';
     validationStatus: 'passed' | 'failed';
     remoteUrl: string | null;
+    upstreamabilityScore?: number;
   }): number {
     const repositoryInfo = statements.addRepository.run({
       owner: 'acme',
@@ -195,6 +238,7 @@ describe('createPullRequestForPatch', () => {
         candidate: {
           classification: 'autofix_extract_shared',
           confidence: 0.91,
+          upstreamabilityScore: args.upstreamabilityScore ?? 0.91,
           reasons: ['safe shared symbol'],
         },
         validation: {

--- a/cli/createPullRequest/candidate.ts
+++ b/cli/createPullRequest/candidate.ts
@@ -73,6 +73,7 @@ export function loadPullRequestCandidate(patchId: number, database: DatabaseType
     validationSummary: row.validation_summary ?? replay.validation.summary,
     classification: row.classification,
     confidence: row.confidence,
+    upstreamabilityScore: replay.candidate.upstreamabilityScore ?? null,
     reasons: parseJsonArray(row.reasons),
     normalizedPath: row.normalized_path,
     cyclePath: parseJsonArray(row.participating_files),
@@ -115,6 +116,7 @@ function parseReplayBundle(replayBundle: string | null, row: PullRequestCandidat
     candidate: {
       classification: parsed.candidate?.classification ?? row.classification,
       confidence: parsed.candidate?.confidence ?? row.confidence,
+      upstreamabilityScore: parsed.candidate?.upstreamabilityScore,
       reasons: parsed.candidate?.reasons ?? parseJsonArray(row.reasons),
     },
     validation: {

--- a/cli/createPullRequest/index.ts
+++ b/cli/createPullRequest/index.ts
@@ -1,6 +1,7 @@
 import type { Database as DatabaseType } from 'better-sqlite3';
 import simpleGit from 'simple-git';
 import { getDb } from '../../db/index.js';
+import { resolveMinimumUpstreamabilityScore } from '../promotionPolicy.js';
 import { loadPullRequestCandidate } from './candidate.js';
 import { applyFileSnapshots, ensureCheckoutIsClean, prepareCheckout } from './checkout.js';
 import { buildPullRequestBody, buildPullRequestTitle, createGithubPullRequest } from './render.js';
@@ -22,6 +23,21 @@ export async function createPullRequestForPatch(
 
   const database: DatabaseType = options.database ?? getDb();
   const candidate = loadPullRequestCandidate(patchId, database);
+  const minimumScore = resolveMinimumUpstreamabilityScore(options.minimumUpstreamabilityScore);
+
+  if (!options.allowBelowThreshold) {
+    if (candidate.upstreamabilityScore === null) {
+      throw new Error(
+        `Patch ${patchId} does not have an upstreamability score. Re-scan it or pass allowBelowThreshold for a manual experiment.`,
+      );
+    }
+
+    if (candidate.upstreamabilityScore < minimumScore) {
+      throw new Error(
+        `Patch ${patchId} scored ${candidate.upstreamabilityScore.toFixed(2)}, below the PR threshold of ${minimumScore.toFixed(2)}.`,
+      );
+    }
+  }
 
   const branchName = options.branchName ?? `codex/issue-${options.linkedIssueNumber}-patch-${patchId}`;
   const baseBranch = options.baseBranch ?? candidate.defaultBranch;

--- a/cli/createPullRequest/render.ts
+++ b/cli/createPullRequest/render.ts
@@ -22,6 +22,8 @@ export function buildPullRequestBody(candidate: PullRequestCandidate, linkedIssu
       : candidate.replay.file_snapshots.map((snapshot) => snapshot.path);
   const reasons = candidate.reasons.length > 0 ? candidate.reasons : (candidate.replay.candidate.reasons ?? []);
   const confidence = `${Math.round(candidate.confidence * 100)}%`;
+  const upstreamability =
+    candidate.upstreamabilityScore === null ? 'unknown' : `${Math.round(candidate.upstreamabilityScore * 100)}%`;
 
   return [
     `Closes #${linkedIssueNumber}`,
@@ -29,6 +31,7 @@ export function buildPullRequestBody(candidate: PullRequestCandidate, linkedIssu
     '## Summary',
     `- Classification: \`${candidate.classification}\``,
     `- Confidence: ${confidence}`,
+    `- Upstreamability score: ${upstreamability}`,
     `- Cycle: \`${candidate.normalizedPath}\``,
     `- Source target: \`${candidate.replay.source_target}\``,
     `- Source commit: \`${candidate.commitSha}\``,

--- a/cli/createPullRequest/types.ts
+++ b/cli/createPullRequest/types.ts
@@ -41,6 +41,7 @@ export interface ReplayBundle {
   candidate?: {
     classification?: string;
     confidence?: number;
+    upstreamabilityScore?: number;
     reasons?: string[] | null;
   };
   validation?: {
@@ -74,6 +75,7 @@ export interface RequiredReplayBundle {
   candidate: {
     classification: string;
     confidence: number;
+    upstreamabilityScore?: number;
     reasons: string[] | null;
   };
   validation: {
@@ -98,6 +100,7 @@ export interface PullRequestCandidate {
   validationSummary: string;
   classification: string;
   confidence: number;
+  upstreamabilityScore: number | null;
   reasons: string[];
   normalizedPath: string;
   cyclePath: string[];
@@ -114,6 +117,8 @@ export interface CreatePullRequestOptions {
   repoPath?: string;
   checkoutRoot?: string;
   remoteName?: string;
+  minimumUpstreamabilityScore?: number;
+  allowBelowThreshold?: boolean;
   database?: DatabaseType;
 }
 

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -126,13 +126,47 @@ vi.mock('../analyzer/analyzer.js', () => ({
             loadedFiles: 2,
             missingFiles: 0,
           },
+          features: {
+            cycleSize: 2,
+            cycleShape: 'two_file',
+            explicitImportEdges: 2,
+            loadedFiles: 2,
+            missingFiles: 0,
+            hasBarrelFile: false,
+            hasSharedModuleFile: false,
+            typescriptFileCount: 2,
+            tsxFileCount: 0,
+            packageManager: 'unknown',
+            workspaceMode: 'unknown',
+            validationCommandCount: 0,
+          },
           fallbackClassification: 'autofix_import_type',
           fallbackConfidence: 0.9,
           fallbackReasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
           selectedStrategy: 'import_type',
           selectedClassification: 'autofix_import_type',
           selectedScore: 0.94,
-          selectionSummary: 'Selected import_type with score 0.94 after evaluating 3 strategies.',
+          selectionSummary:
+            'Selected import_type with score 0.94 after evaluating 4 strategies; 1 candidate(s) cleared the safety filters.',
+          rankedCandidates: [
+            {
+              strategy: 'import_type',
+              status: 'candidate',
+              summary: 'Convert 2 import edge(s) to type-only imports.',
+              reasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+              signals: {
+                touchedFiles: 2,
+                importEdges: 2,
+                introducesNewFile: false,
+                preservesSourceExports: true,
+              },
+              baseScore: 0.94,
+              score: 0.94,
+              scoreBreakdown: ['base 0.97 for least-invasive rewrite', '-0.03 for touching 2 files'],
+              classification: 'autofix_import_type',
+              confidence: 0.9,
+            },
+          ],
           attempts: [],
         },
       },
@@ -260,13 +294,47 @@ describe('CLI', () => {
                     loadedFiles: 2,
                     missingFiles: 0,
                   },
+                  features: {
+                    cycleSize: 2,
+                    cycleShape: 'two_file',
+                    explicitImportEdges: 2,
+                    loadedFiles: 2,
+                    missingFiles: 0,
+                    hasBarrelFile: false,
+                    hasSharedModuleFile: false,
+                    typescriptFileCount: 2,
+                    tsxFileCount: 0,
+                    packageManager: 'unknown',
+                    workspaceMode: 'unknown',
+                    validationCommandCount: 0,
+                  },
                   fallbackClassification: 'autofix_import_type',
                   fallbackConfidence: 0.9,
                   fallbackReasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
                   selectedStrategy: 'import_type',
                   selectedClassification: 'autofix_import_type',
                   selectedScore: 0.94,
-                  selectionSummary: 'Selected import_type with score 0.94 after evaluating 3 strategies.',
+                  selectionSummary:
+                    'Selected import_type with score 0.94 after evaluating 4 strategies; 1 candidate(s) cleared the safety filters.',
+                  rankedCandidates: [
+                    {
+                      strategy: 'import_type',
+                      status: 'candidate',
+                      summary: 'Convert 2 import edge(s) to type-only imports.',
+                      reasons: ['Cycle can be resolved by converting concrete imports to type-only imports.'],
+                      signals: {
+                        touchedFiles: 2,
+                        importEdges: 2,
+                        introducesNewFile: false,
+                        preservesSourceExports: true,
+                      },
+                      baseScore: 0.94,
+                      score: 0.94,
+                      scoreBreakdown: ['base 0.97 for least-invasive rewrite', '-0.03 for touching 2 files'],
+                      classification: 'autofix_import_type',
+                      confidence: 0.9,
+                    },
+                  ],
                   attempts: [],
                 },
               },
@@ -355,6 +423,8 @@ describe('CLI', () => {
       branchName: undefined,
       baseBranch: undefined,
       repoPath: undefined,
+      minimumUpstreamabilityScore: undefined,
+      allowBelowThreshold: undefined,
     });
     expect(consoleSpy).toHaveBeenCalledWith(
       'Created PR https://github.com/acme/widget/pull/123 from branch codex/issue-42-patch-12',
@@ -409,6 +479,36 @@ describe('CLI', () => {
 
     consoleErrSpy.mockRestore();
     exitSpy.mockRestore();
+  });
+
+  it('create:pr command forwards threshold options', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'create:pr',
+      '12',
+      '--issue',
+      '42',
+      '--min-score',
+      '0.9',
+      '--allow-below-threshold',
+    ]);
+
+    expect(vi.mocked(createPullRequestForPatch)).toHaveBeenLastCalledWith(12, {
+      linkedIssueNumber: 42,
+      title: undefined,
+      branchName: undefined,
+      baseBranch: undefined,
+      repoPath: undefined,
+      minimumUpstreamabilityScore: 0.9,
+      allowBelowThreshold: true,
+    });
+
+    consoleSpy.mockRestore();
   });
 
   it('create:pr command exits on invalid patch id', async () => {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -157,6 +157,8 @@ export function createProgram(): Command {
     .option('--branch <branchName>', 'Branch name override')
     .option('--base <branchName>', 'Base branch override')
     .option('--repo-path <path>', 'Use an existing clean checkout instead of a scratch clone')
+    .option('--min-score <score>', 'Minimum upstreamability score required before opening a PR', parseScore)
+    .option('--allow-below-threshold', 'Allow PR creation even when the stored upstreamability score is too low')
     .description('Create a branch and GitHub pull request from a stored validated patch')
     .action(
       async (
@@ -167,6 +169,8 @@ export function createProgram(): Command {
           branch?: string;
           base?: string;
           repoPath?: string;
+          minScore?: number;
+          allowBelowThreshold?: boolean;
         },
       ) => {
         const numericPatchId = Number(patchId);
@@ -188,6 +192,8 @@ export function createProgram(): Command {
             branchName: options.branch,
             baseBranch: options.base,
             repoPath: options.repoPath,
+            minimumUpstreamabilityScore: options.minScore,
+            allowBelowThreshold: options.allowBelowThreshold,
           });
           console.log(`Created PR ${result.prUrl} from branch ${result.branchName}`);
         } catch (error) {
@@ -213,6 +219,15 @@ function parseInteger(value: string): number {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed < 0) {
     throw new Error(`Expected a non-negative integer. Received: ${value}`);
+  }
+
+  return parsed;
+}
+
+function parseScore(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error(`Expected a score between 0 and 1. Received: ${value}`);
   }
 
   return parsed;

--- a/cli/promotionPolicy.ts
+++ b/cli/promotionPolicy.ts
@@ -1,0 +1,46 @@
+export const DEFAULT_MIN_PATCH_CONFIDENCE = 0.8;
+export const DEFAULT_MIN_UPSTREAMABILITY_SCORE = 0.78;
+const MIN_SCORE_ENV_VAR = 'AUTOFIX_MIN_PR_SCORE';
+
+export interface PromotionPolicyCandidate {
+  classification: string;
+  confidence: number;
+  upstreamabilityScore?: number;
+  hasPlan?: boolean;
+}
+
+export function shouldPromotePatchCandidate(candidate: PromotionPolicyCandidate): boolean {
+  if (!candidate.hasPlan) {
+    return false;
+  }
+
+  if (!candidate.classification.startsWith('autofix_')) {
+    return false;
+  }
+
+  return (
+    candidate.confidence >= DEFAULT_MIN_PATCH_CONFIDENCE &&
+    (candidate.upstreamabilityScore ?? 0) >= DEFAULT_MIN_UPSTREAMABILITY_SCORE
+  );
+}
+
+export function resolveMinimumUpstreamabilityScore(explicitValue?: number): number {
+  if (explicitValue !== undefined) {
+    return validateScore(explicitValue, 'explicit minimum upstreamability score');
+  }
+
+  const envValue = process.env[MIN_SCORE_ENV_VAR];
+  if (!envValue) {
+    return DEFAULT_MIN_UPSTREAMABILITY_SCORE;
+  }
+
+  return validateScore(Number(envValue), `environment variable ${MIN_SCORE_ENV_VAR}`);
+}
+
+function validateScore(value: number, source: string): number {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`Expected ${source} to be a number between 0 and 1. Received: ${value}`);
+  }
+
+  return Number(value.toFixed(2));
+}

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -321,6 +321,7 @@ describe('Scanner Worker', () => {
           classification: 'autofix_import_type',
           confidence: 0.9,
           reasons: ['mock reason'],
+          upstreamabilityScore: 0.94,
           plan: {
             kind: 'import_type',
             imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
@@ -361,6 +362,7 @@ describe('Scanner Worker', () => {
     expect(replay.commit_sha).toBe('mock-sha');
     expect(JSON.parse(replay.replay_bundle).file_snapshots).toHaveLength(1);
     expect(JSON.parse(replay.replay_bundle).repository.remote_url).toBe('https://github.com/org/patch.git');
+    expect(JSON.parse(replay.replay_bundle).candidate.upstreamabilityScore).toBe(0.94);
   });
 
   it('persists failed validation summaries when a generated patch does not validate', async () => {
@@ -373,6 +375,7 @@ describe('Scanner Worker', () => {
           classification: 'autofix_import_type',
           confidence: 0.9,
           reasons: ['mock reason'],
+          upstreamabilityScore: 0.94,
           plan: {
             kind: 'import_type',
             imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
@@ -414,5 +417,34 @@ describe('Scanner Worker', () => {
     expect(patches[0].validation_status).toBe('failed');
     expect(patches[0].validation_summary).toContain('original cycle is still present');
     expect(JSON.parse(replay.replay_bundle).validation.summary).toContain('original cycle is still present');
+  });
+
+  it('does not generate a patch when the candidate is below the promotion threshold', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(analyzeRepository).mockResolvedValue([
+      {
+        type: 'circular',
+        path: ['a.ts', 'b.ts', 'a.ts'],
+        analysis: {
+          classification: 'autofix_import_type',
+          confidence: 0.79,
+          reasons: ['mock reason'],
+          upstreamabilityScore: 0.77,
+          plan: {
+            kind: 'import_type',
+            imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+          },
+        },
+      },
+    ]);
+
+    const result = await scanRepository('org/below-threshold');
+    const cycles = dbModule.getCyclesByScanId.all(result.scanId) as Array<{ id: number }>;
+    const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as Array<{ id: number }>;
+    const patches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id);
+
+    expect(candidates).toHaveLength(1);
+    expect(patches).toEqual([]);
+    expect(generatePatchForCycle).not.toHaveBeenCalled();
   });
 });

--- a/cli/scanner/persistence.ts
+++ b/cli/scanner/persistence.ts
@@ -1,5 +1,6 @@
 import type { SimpleGit } from 'simple-git';
 import { canonicalizeCyclePath, normalizeCyclePath } from '../../analyzer/cycleNormalization.js';
+import type { SemanticAnalysisResult } from '../../analyzer/semantic.js';
 import type { GeneratedPatch } from '../../codemod/generatePatch.js';
 import { generatePatchForCycle } from '../../codemod/generatePatch.js';
 import type { RepositoryDTO } from '../../db/index.js';
@@ -13,6 +14,7 @@ import {
   getRepositoryByOwnerName,
   updateRepositoryLocalPath,
 } from '../../db/index.js';
+import { shouldPromotePatchCandidate } from '../promotionPolicy.js';
 import type { ValidationResult } from '../validation.js';
 import { validateGeneratedPatch } from '../validation.js';
 import type { PatchReplayBundle, ScannedCycle } from './types.js';
@@ -104,6 +106,10 @@ export async function persistCycle(
     reasons: JSON.stringify(persistedCycle.analysis.reasons),
   });
 
+  if (!shouldGeneratePatch(persistedCycle.analysis)) {
+    return;
+  }
+
   const generatedPatch = await generatePatchForCycle(repoPath, persistedCycle, persistedCycle.analysis);
   if (!generatedPatch) {
     return;
@@ -140,6 +146,15 @@ export async function persistCycle(
   })(patchPayload, JSON.stringify(replayBundle));
 }
 
+function shouldGeneratePatch(analysis: SemanticAnalysisResult): boolean {
+  return shouldPromotePatchCandidate({
+    classification: analysis.classification,
+    confidence: analysis.confidence,
+    upstreamabilityScore: analysis.upstreamabilityScore,
+    hasPlan: Boolean(analysis.plan),
+  });
+}
+
 function buildPatchReplayBundle(args: {
   scanId: number;
   sourceTarget: string;
@@ -174,6 +189,7 @@ function buildPatchReplayBundle(args: {
     candidate: {
       classification: args.cycle.analysis?.classification ?? 'unsupported',
       confidence: args.cycle.analysis?.confidence ?? 0,
+      upstreamabilityScore: args.cycle.analysis?.upstreamabilityScore,
       reasons: args.cycle.analysis?.reasons ?? null,
     },
     validation: args.validation,

--- a/cli/scanner/types.ts
+++ b/cli/scanner/types.ts
@@ -32,6 +32,7 @@ export interface PatchReplayBundle {
   candidate: {
     classification: string;
     confidence: number;
+    upstreamabilityScore?: number;
     reasons: string[] | null;
   };
   validation: ValidationResult;

--- a/cli/validation.test.ts
+++ b/cli/validation.test.ts
@@ -57,7 +57,13 @@ describe('validateGeneratedPatch', () => {
     );
 
     expect(result.status).toBe('passed');
+    expect(result.failureCategory).toBeNull();
     expect(result.summary).toContain('original cycle removed');
+    expect(result.details).toMatchObject({
+      beforeCycleCount: 0,
+      afterCycleCount: 0,
+      introducedCycleCount: 0,
+    });
   });
 
   it('runs repo-native validation commands before the TypeScript check', async () => {
@@ -143,6 +149,7 @@ describe('validateGeneratedPatch', () => {
     );
 
     expect(result.status).toBe('failed');
+    expect(result.failureCategory).toBe('original_cycle_persisted');
     expect(result.summary).toContain('original cycle is still present');
   });
 
@@ -178,6 +185,43 @@ describe('validateGeneratedPatch', () => {
     );
 
     expect(result.status).toBe('failed');
+    expect(result.failureCategory).toBe('original_cycle_persisted');
     expect(result.summary).toContain('original cycle is still present');
+  });
+
+  it('fails when the rewrite introduces a new cycle that was not present before', async () => {
+    const repoPath = await createRepo({
+      'a.ts': 'export const a = 1;\n',
+      'b.ts': 'export const b = 2;\n',
+    });
+
+    vi.spyOn(analyzerModule, 'analyzeRepository')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ type: 'circular', path: ['x.ts', 'y.ts', 'x.ts'] } as CircularDependency]);
+
+    const generatedPatch: GeneratedPatch = {
+      patchText: 'diff',
+      touchedFiles: ['a.ts'],
+      validationStatus: 'pending',
+      validationSummary: 'pending',
+      fileSnapshots: [
+        {
+          path: 'a.ts',
+          before: 'export const a = 1;\n',
+          after: 'export const a = 2;\n',
+        },
+      ],
+    };
+
+    const result = await validateGeneratedPatch(
+      repoPath,
+      { type: 'circular', path: ['a.ts', 'b.ts', 'a.ts'] },
+      generatedPatch,
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.failureCategory).toBe('new_cycles_introduced');
+    expect(result.summary).toContain('introduced 1 new cycle');
+    expect(result.details?.introducedCycles).toEqual(['x.ts -> y.ts -> x.ts']);
   });
 });

--- a/cli/validation.ts
+++ b/cli/validation.ts
@@ -12,9 +12,27 @@ import { profileRepository } from './repoProfile.js';
 
 const execFileAsync = promisify(execFile);
 
+export type ValidationFailureCategory =
+  | 'original_cycle_persisted'
+  | 'new_cycles_introduced'
+  | 'repo_validation_failed'
+  | 'typecheck_failed';
+
+export interface ValidationDetails {
+  originalCycleKey: string;
+  beforeCycleCount: number;
+  afterCycleCount: number;
+  introducedCycleCount: number;
+  introducedCycles: string[];
+  repoValidationCommands: string[];
+  failingCommand?: string;
+}
+
 export interface ValidationResult {
   status: 'passed' | 'failed';
   summary: string;
+  failureCategory?: ValidationFailureCategory | null;
+  details?: ValidationDetails;
 }
 
 export async function validateGeneratedPatch(
@@ -25,6 +43,10 @@ export async function validateGeneratedPatch(
   const validationPath = await fs.mkdtemp(path.join(os.tmpdir(), 'cycle-validation-'));
 
   try {
+    const beforeCycleKey = normalizeCyclePath(cycle.path);
+    const baselineCycles = await analyzeRepository(repoPath);
+    const baselineCycleKeys = new Set(baselineCycles.map((baselineCycle) => normalizeCyclePath(baselineCycle.path)));
+
     await fs.cp(repoPath, validationPath, {
       recursive: true,
       filter: (source) => !source.includes(`${path.sep}.git${path.sep}`) && !source.endsWith(`${path.sep}.git`),
@@ -32,14 +54,33 @@ export async function validateGeneratedPatch(
 
     await applySnapshots(validationPath, generatedPatch);
 
-    const beforeCycleKey = normalizeCyclePath(cycle.path);
     const validatedCycles = await analyzeRepository(validationPath);
     const cycleKeys = new Set(validatedCycles.map((validatedCycle) => normalizeCyclePath(validatedCycle.path)));
+    const introducedCycles = [...cycleKeys].filter((cycleKey) => !baselineCycleKeys.has(cycleKey));
+    const validationDetails: ValidationDetails = {
+      originalCycleKey: beforeCycleKey,
+      beforeCycleCount: baselineCycles.length,
+      afterCycleCount: validatedCycles.length,
+      introducedCycleCount: introducedCycles.length,
+      introducedCycles,
+      repoValidationCommands: [],
+    };
 
     if (cycleKeys.has(beforeCycleKey)) {
       return {
         status: 'failed',
         summary: 'Validation failed: the original cycle is still present after applying the rewrite.',
+        failureCategory: 'original_cycle_persisted',
+        details: validationDetails,
+      };
+    }
+
+    if (introducedCycles.length > 0) {
+      return {
+        status: 'failed',
+        summary: `Validation failed: the rewrite introduced ${introducedCycles.length} new cycle(s).`,
+        failureCategory: 'new_cycles_introduced',
+        details: validationDetails,
       };
     }
 
@@ -48,10 +89,16 @@ export async function validateGeneratedPatch(
       validationPath,
       repositoryProfile?.validationCommands ?? [],
     );
+    validationDetails.repoValidationCommands = repositoryProfile?.validationCommands ?? [];
     if (!repoValidationResult.ok) {
       return {
         status: 'failed',
         summary: `Validation failed: repo-native validation command failed (${repoValidationResult.command}).\n${repoValidationResult.output}`,
+        failureCategory: 'repo_validation_failed',
+        details: {
+          ...validationDetails,
+          failingCommand: repoValidationResult.command,
+        },
       };
     }
 
@@ -60,6 +107,8 @@ export async function validateGeneratedPatch(
       return {
         status: 'failed',
         summary: `Validation failed: TypeScript check did not pass.\n${typecheckResult.output}`,
+        failureCategory: 'typecheck_failed',
+        details: validationDetails,
       };
     }
 
@@ -69,7 +118,9 @@ export async function validateGeneratedPatch(
 
     return {
       status: 'passed',
-      summary: `Validation passed: original cycle removed. ${repoValidationSummary}TypeScript check passed. Remaining cycles detected: ${validatedCycles.length}.`,
+      summary: `Validation passed: original cycle removed. ${repoValidationSummary}TypeScript check passed. Cycle count ${baselineCycles.length} -> ${validatedCycles.length}.`,
+      failureCategory: null,
+      details: validationDetails,
     };
   } finally {
     await fs.rm(validationPath, { recursive: true, force: true });


### PR DESCRIPTION
Adds an explicit feature-extraction stage, feeds benchmark and review history into planner scoring, returns ranked candidate attempts, enriches validation with before/after cycle graph details, and gates patch promotion plus PR creation behind an upstreamability threshold with an override path.\n\nCloses #33\nAdvances #35\n\nVerification:\n- ../../node_modules/.bin/vitest run\n- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json\n- ../../node_modules/.bin/eslint analyzer/analyzer.ts analyzer/semantic/SemanticAnalyzer.ts analyzer/semantic/scoring.ts analyzer/semantic/types.ts analyzer/semantic/features.ts analyzer/semantic/evidence.ts analyzer/semantic.test.ts cli/index.ts cli/index.test.ts cli/scanner/types.ts cli/scanner/persistence.ts cli/scanner.test.ts cli/validation.ts cli/validation.test.ts cli/createPullRequest/index.ts cli/createPullRequest/candidate.ts cli/createPullRequest/render.ts cli/createPullRequest/types.ts cli/createPullRequest.test.ts cli/promotionPolicy.ts\n- ../../node_modules/.bin/biome check analyzer/analyzer.ts analyzer/semantic/SemanticAnalyzer.ts analyzer/semantic/scoring.ts analyzer/semantic/types.ts analyzer/semantic/features.ts analyzer/semantic/evidence.ts analyzer/semantic.test.ts cli/index.ts cli/index.test.ts cli/scanner/types.ts cli/scanner/persistence.ts cli/scanner.test.ts cli/validation.ts cli/validation.test.ts cli/createPullRequest/index.ts cli/createPullRequest/candidate.ts cli/createPullRequest/render.ts cli/createPullRequest/types.ts cli/createPullRequest.test.ts cli/promotionPolicy.ts\n- ../../node_modules/.bin/vite build\n- git diff --check