### PR TITLE
Add real-repo acceptance benchmark workflow

### DIFF
--- a/cli/acceptanceBenchmark.test.ts
+++ b/cli/acceptanceBenchmark.test.ts
@@ -1,0 +1,414 @@
+import path from 'node:path';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BenchmarkCorpusEntry } from '../benchmarks/repo-corpus.js';
+import { type AcceptanceBenchmarkCaseDTO, createDatabase, createStatements, initSchema } from '../db/index.js';
+import {
+  annotateAcceptanceBenchmarkCase,
+  getAcceptanceBenchmarkReport,
+  runAcceptanceBenchmark,
+} from './acceptanceBenchmark.js';
+
+// eslint-disable-next-line sonarjs/publicly-writable-directories
+const TEST_LOCAL_REPO_PATH = '/tmp/openclaw';
+
+interface SeededCycleOptions {
+  normalizedPath: string;
+  classification: string;
+  confidence: number;
+  upstreamabilityScore?: number | null;
+  reviewStatus?: 'approved' | 'pending' | 'pr_candidate' | 'rejected';
+  validationStatus?: string | null;
+  validationSummary?: string | null;
+  touchedFiles?: string[];
+  featureVector?: Record<string, unknown>;
+  plannerAttempts?: Array<Record<string, unknown>>;
+  plannerSummary?: string;
+}
+
+function createTestDb(): DatabaseType {
+  const db = createDatabase(':memory:');
+  initSchema(db);
+  return db;
+}
+
+function seedAcceptanceScan(
+  db: DatabaseType,
+  repositorySlug: string,
+  repoPath: string,
+  commitSha: string,
+  cycles: SeededCycleOptions[],
+) {
+  const statements = createStatements(db);
+  const [owner, name] = repositorySlug.split('/');
+  const repoInfo = statements.addRepository.run({
+    owner,
+    name,
+    default_branch: 'main',
+    local_path: repoPath,
+  });
+  const scanInfo = statements.addScan.run({
+    repository_id: repoInfo.lastInsertRowid,
+    commit_sha: commitSha,
+    status: 'completed',
+  });
+
+  for (const [index, cycle] of cycles.entries()) {
+    const rawPayload = JSON.stringify({
+      type: 'circular',
+      path: cycle.normalizedPath.split(' -> '),
+      analysis: {
+        classification: cycle.classification,
+        confidence: cycle.confidence,
+        upstreamabilityScore: cycle.upstreamabilityScore ?? null,
+        planner: {
+          features: cycle.featureVector ?? {
+            cycleSize: 2,
+            cycleShape: 'two_file',
+            packageManager: 'pnpm',
+            workspaceMode: 'workspace',
+            validationCommandCount: 3,
+          },
+          attempts: cycle.plannerAttempts ?? [
+            {
+              strategy: cycle.classification.replace('autofix_', ''),
+              status: 'candidate',
+              classification: cycle.classification,
+              score: cycle.upstreamabilityScore ?? 0.8,
+            },
+          ],
+          selectionSummary: cycle.plannerSummary ?? `Selected ${cycle.classification} for cycle ${index + 1}.`,
+        },
+      },
+    });
+
+    const cycleInfo = statements.addCycle.run({
+      scan_id: scanInfo.lastInsertRowid,
+      normalized_path: cycle.normalizedPath,
+      participating_files: JSON.stringify(cycle.normalizedPath.split(' -> ')),
+      raw_payload: rawPayload,
+    });
+
+    const fixCandidateInfo = statements.addFixCandidate.run({
+      cycle_id: cycleInfo.lastInsertRowid,
+      classification: cycle.classification,
+      confidence: cycle.confidence,
+      reasons: JSON.stringify(['Autofix candidate identified during benchmark seeding.']),
+    });
+
+    const patchInfo = statements.addPatch.run({
+      fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+      patch_text: `diff --git a/file-${index}.ts b/file-${index}.ts`,
+      touched_files: JSON.stringify(cycle.touchedFiles ?? ['a.ts', 'b.ts']),
+      validation_status: cycle.validationStatus ?? 'passed',
+      validation_summary: cycle.validationSummary ?? 'Cycle removed',
+    });
+
+    if (cycle.reviewStatus && cycle.reviewStatus !== 'pending') {
+      statements.addReviewDecision.run({
+        patch_id: patchInfo.lastInsertRowid,
+        decision: cycle.reviewStatus,
+        notes: `${cycle.reviewStatus} during benchmark review`,
+      });
+    }
+  }
+
+  return {
+    scanId: Number(scanInfo.lastInsertRowid),
+    cyclesFound: cycles.length,
+  };
+}
+
+describe('acceptance benchmark workflow', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('benchmarks local corpus checkouts and snapshots planner data into acceptance cases', async () => {
+    const db = createTestDb();
+    const repoPath = path.join(process.cwd(), '.test-fixtures', 'openclaw');
+    const entry: BenchmarkCorpusEntry = {
+      slug: 'openclaw/openclaw',
+      groups: ['calibration'],
+      description: 'Calibration repo',
+      patterns: ['host_owned_state_update'],
+    };
+
+    const scanRepo = vi.fn(async (targetRepoPath: string, worktreesDir?: string) => {
+      expect(targetRepoPath).toBe(repoPath);
+      expect(worktreesDir).toBe(path.join(process.cwd(), '.test-fixtures', 'scan-worktrees'));
+
+      return {
+        ...seedAcceptanceScan(db, entry.slug, repoPath, 'abc123', [
+          {
+            normalizedPath: 'a.ts -> b.ts -> a.ts',
+            classification: 'autofix_import_type',
+            confidence: 0.93,
+            upstreamabilityScore: 0.91,
+            reviewStatus: 'approved',
+            featureVector: {
+              cycleSize: 2,
+              hasBarrelFile: false,
+              packageManager: 'pnpm',
+              workspaceMode: 'workspace',
+              validationCommandCount: 4,
+            },
+          },
+          {
+            normalizedPath: 'c.ts -> d.ts -> c.ts',
+            classification: 'autofix_extract_shared',
+            confidence: 0.78,
+            upstreamabilityScore: 0.74,
+            reviewStatus: 'pending',
+            touchedFiles: ['c.ts', 'd.ts', 'shared.ts'],
+            featureVector: {
+              cycleSize: 2,
+              hasSharedModuleFile: false,
+              introducesNewFile: true,
+              packageManager: 'pnpm',
+              workspaceMode: 'workspace',
+              validationCommandCount: 4,
+            },
+          },
+        ]),
+        repoPath,
+      };
+    });
+
+    const result = await runAcceptanceBenchmark({
+      database: db,
+      entries: [entry],
+      searchRoots: [path.join(process.cwd(), '.test-fixtures')],
+      scanWorktreesDir: path.join(process.cwd(), '.test-fixtures', 'scan-worktrees'),
+      dependencies: {
+        findLocalCheckout: () => repoPath,
+        scanRepository: scanRepo,
+      },
+    });
+
+    expect(result).toMatchObject({
+      corpusSize: 1,
+      repositoriesBenchmarked: 1,
+      repositoriesCloned: 0,
+      repositoriesSkipped: 0,
+      totalCycles: 2,
+      totalAcceptanceCases: 2,
+      repositoryResults: [
+        {
+          slug: 'openclaw/openclaw',
+          repoPath,
+          status: 'benchmarked',
+          cyclesFound: 2,
+          benchmarkedCases: 2,
+        },
+      ],
+    });
+    expect(result.acceptanceSummary).toEqual([
+      {
+        classification: 'autofix_extract_shared',
+        totalCases: 1,
+        acceptedCases: 0,
+        rejectedCases: 0,
+        needsReviewCases: 1,
+        acceptanceRate: 0,
+      },
+      {
+        classification: 'autofix_import_type',
+        totalCases: 1,
+        acceptedCases: 1,
+        rejectedCases: 0,
+        needsReviewCases: 0,
+        acceptanceRate: 1,
+      },
+    ]);
+
+    const report = getAcceptanceBenchmarkReport(db);
+    expect(report.totalCases).toBe(2);
+
+    const importTypeCase = report.cases.find((candidate) => candidate.classification === 'autofix_import_type');
+    expect(importTypeCase).toMatchObject({
+      repository: 'openclaw/openclaw',
+      commit_sha: 'abc123',
+      acceptability: 'accepted',
+      review_status: 'approved',
+    });
+    expect(JSON.parse(importTypeCase?.feature_vector ?? '{}')).toMatchObject({
+      cycleSize: 2,
+      packageManager: 'pnpm',
+    });
+    expect(JSON.parse(importTypeCase?.planner_attempts ?? '[]')).toEqual([
+      expect.objectContaining({
+        classification: 'autofix_import_type',
+      }),
+    ]);
+
+    db.close();
+  });
+
+  it('skips repositories without a local checkout when cloning is disabled', async () => {
+    const db = createTestDb();
+    const entry: BenchmarkCorpusEntry = {
+      slug: 'microsoft/vscode',
+      groups: ['stable-core'],
+      description: 'Core corpus repo',
+      patterns: ['direct_import'],
+    };
+
+    const result = await runAcceptanceBenchmark({
+      database: db,
+      entries: [entry],
+      cloneMissing: false,
+      dependencies: {
+        findLocalCheckout: () => null,
+        scanRepository: vi.fn(),
+      },
+    });
+
+    expect(result).toMatchObject({
+      repositoriesBenchmarked: 0,
+      repositoriesCloned: 0,
+      repositoriesSkipped: 1,
+      totalAcceptanceCases: 0,
+      repositoryResults: [
+        {
+          slug: 'microsoft/vscode',
+          repoPath: null,
+          status: 'skipped',
+          reason: 'No local checkout matched the configured search roots',
+        },
+      ],
+    });
+
+    db.close();
+  });
+
+  it('clones missing repositories when requested and captures rejected benchmark cases', async () => {
+    const db = createTestDb();
+    const entry: BenchmarkCorpusEntry = {
+      slug: 'anomalyco/opencode',
+      groups: ['watchlist'],
+      description: 'Watchlist repo',
+      patterns: ['extract_shared'],
+    };
+    const clonedRepoPath = path.join(process.cwd(), '.test-fixtures', 'anomalyco', 'opencode');
+    const cloneRepository = vi.fn(async () => clonedRepoPath);
+
+    const result = await runAcceptanceBenchmark({
+      database: db,
+      entries: [entry],
+      cloneMissing: true,
+      workspaceDir: path.join(process.cwd(), '.test-fixtures', 'worktrees'),
+      dependencies: {
+        findLocalCheckout: () => null,
+        cloneRepository,
+        scanRepository: vi.fn(async () => ({
+          ...seedAcceptanceScan(db, entry.slug, clonedRepoPath, 'def456', [
+            {
+              normalizedPath: 'x.ts -> y.ts -> x.ts',
+              classification: 'autofix_host_state_update',
+              confidence: 0.81,
+              upstreamabilityScore: 0.79,
+              reviewStatus: 'rejected',
+              validationStatus: 'failed',
+              validationSummary: 'Repo-native validation failed',
+            },
+          ]),
+          repoPath: clonedRepoPath,
+        })),
+      },
+    });
+
+    expect(cloneRepository).toHaveBeenCalledWith(entry, path.join(process.cwd(), '.test-fixtures', 'worktrees'));
+    expect(result).toMatchObject({
+      repositoriesBenchmarked: 1,
+      repositoriesCloned: 1,
+      repositoriesSkipped: 0,
+      totalAcceptanceCases: 1,
+      repositoryResults: [
+        {
+          slug: 'anomalyco/opencode',
+          repoPath: clonedRepoPath,
+          status: 'cloned',
+          benchmarkedCases: 1,
+        },
+      ],
+    });
+
+    const report = getAcceptanceBenchmarkReport(db);
+    expect(report.summary).toEqual([
+      {
+        classification: 'autofix_host_state_update',
+        totalCases: 1,
+        acceptedCases: 0,
+        rejectedCases: 1,
+        needsReviewCases: 0,
+        acceptanceRate: 0,
+      },
+    ]);
+
+    db.close();
+  });
+
+  it('annotates stored benchmark cases and updates the report summary', () => {
+    const db = createTestDb();
+    const statements = createStatements(db);
+
+    statements.upsertAcceptanceBenchmarkCase.run({
+      repository: 'openclaw/openclaw',
+      local_path: TEST_LOCAL_REPO_PATH,
+      commit_sha: 'abc123',
+      scan_id: 1,
+      cycle_id: 2,
+      fix_candidate_id: 3,
+      patch_id: 4,
+      normalized_path: 'a.ts -> b.ts -> a.ts',
+      classification: 'autofix_import_type',
+      confidence: 0.9,
+      upstreamability_score: 0.88,
+      validation_status: 'passed',
+      validation_summary: 'Cycle removed',
+      review_status: 'pending',
+      touched_files: '["a.ts","b.ts"]',
+      feature_vector: '{"cycleSize":2}',
+      planner_summary: 'Selected import_type',
+      planner_attempts: '[]',
+      acceptability: 'needs_review',
+      rejection_reason: null,
+      acceptability_note: null,
+    });
+
+    const initialReport = getAcceptanceBenchmarkReport(db);
+    const [benchmarkCase] = initialReport.cases as AcceptanceBenchmarkCaseDTO[];
+    expect(benchmarkCase.acceptability).toBe('needs_review');
+
+    const updated = annotateAcceptanceBenchmarkCase(
+      benchmarkCase.id,
+      {
+        acceptability: 'rejected',
+        rejectionReason: 'semantic_wrong',
+        note: 'Reject because it changes runtime behavior',
+      },
+      db,
+    );
+
+    expect(updated).toMatchObject({
+      id: benchmarkCase.id,
+      acceptability: 'rejected',
+      rejection_reason: 'semantic_wrong',
+      acceptability_note: 'Reject because it changes runtime behavior',
+    });
+
+    expect(getAcceptanceBenchmarkReport(db).summary).toEqual([
+      {
+        classification: 'autofix_import_type',
+        totalCases: 1,
+        acceptedCases: 0,
+        rejectedCases: 1,
+        needsReviewCases: 0,
+        acceptanceRate: 0,
+      },
+    ]);
+
+    db.close();
+  });
+});

--- a/cli/acceptanceBenchmark.ts
+++ b/cli/acceptanceBenchmark.ts
@@ -1,0 +1,405 @@
+import { existsSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import simpleGit from 'simple-git';
+import type { BenchmarkCorpusEntry } from '../benchmarks/repo-corpus.js';
+import { BENCHMARK_REPO_CORPUS } from '../benchmarks/repo-corpus.js';
+import {
+  type AcceptanceBenchmarkCaseDTO,
+  type AcceptanceBenchmarkDecision,
+  type AcceptanceBenchmarkRejectionReason,
+  createStatements,
+  getDb,
+} from '../db/index.js';
+import {
+  defaultWorkspaceDir,
+  findLocalCheckout,
+  normalizeSearchRoots,
+  selectCorpusEntries,
+} from './benchmarkCorpus.js';
+import { scanRepository } from './scanner.js';
+
+export interface AcceptanceBenchmarkOptions {
+  database?: DatabaseType;
+  entries?: BenchmarkCorpusEntry[];
+  onlyRepositories?: string[];
+  searchRoots?: string[];
+  workspaceDir?: string;
+  cloneMissing?: boolean;
+  limit?: number;
+  scanWorktreesDir?: string;
+  dependencies?: AcceptanceBenchmarkDependencies;
+}
+
+export interface AcceptanceBenchmarkDependencies {
+  findLocalCheckout?: typeof findLocalCheckout;
+  cloneRepository?: typeof cloneCorpusRepository;
+  scanRepository?: typeof scanRepository;
+}
+
+export interface AcceptanceBenchmarkRepositoryResult {
+  slug: string;
+  repoPath: string | null;
+  status: 'benchmarked' | 'cloned' | 'skipped';
+  scanId?: number;
+  cyclesFound?: number;
+  benchmarkedCases?: number;
+  reason?: string;
+}
+
+export interface AcceptanceBenchmarkSummaryRow {
+  classification: string;
+  totalCases: number;
+  acceptedCases: number;
+  rejectedCases: number;
+  needsReviewCases: number;
+  acceptanceRate: number;
+}
+
+export interface AcceptanceBenchmarkResult {
+  corpusSize: number;
+  repositoriesBenchmarked: number;
+  repositoriesCloned: number;
+  repositoriesSkipped: number;
+  totalCycles: number;
+  totalAcceptanceCases: number;
+  workspaceDir: string;
+  searchRoots: string[];
+  repositoryResults: AcceptanceBenchmarkRepositoryResult[];
+  acceptanceSummary: AcceptanceBenchmarkSummaryRow[];
+}
+
+export interface AcceptanceBenchmarkAnnotation {
+  acceptability: AcceptanceBenchmarkDecision;
+  rejectionReason?: AcceptanceBenchmarkRejectionReason;
+  note?: string;
+}
+
+interface AcceptanceSnapshotRow {
+  commit_sha: string;
+  cycle_id: number;
+  normalized_path: string;
+  raw_payload: string | null;
+  fix_candidate_id: number | null;
+  classification: string | null;
+  confidence: number | null;
+  patch_id: number | null;
+  validation_status: string | null;
+  validation_summary: string | null;
+  touched_files: string | null;
+  review_status: string;
+}
+
+interface AcceptanceBenchmarkSummaryQueryRow {
+  classification?: string;
+  total_cases?: number;
+  accepted_cases?: number;
+  rejected_cases?: number;
+  needs_review_cases?: number;
+}
+
+interface AcceptanceRawPayload {
+  analysis?: {
+    classification?: string;
+    confidence?: number;
+    upstreamabilityScore?: number | null;
+    planner?: {
+      features?: Record<string, unknown>;
+      selectionSummary?: string;
+      attempts?: unknown[];
+    };
+  };
+}
+
+export async function runAcceptanceBenchmark(
+  options: AcceptanceBenchmarkOptions = {},
+): Promise<AcceptanceBenchmarkResult> {
+  const database = options.database ?? getDb();
+  const statements = createStatements(database);
+  const localCheckoutResolver = options.dependencies?.findLocalCheckout ?? findLocalCheckout;
+  const cloneRepo = options.dependencies?.cloneRepository ?? cloneCorpusRepository;
+  const scanRepo = options.dependencies?.scanRepository ?? scanRepository;
+  const entries = selectCorpusEntries(
+    options.entries ?? BENCHMARK_REPO_CORPUS,
+    options.onlyRepositories,
+    options.limit,
+  );
+  const workspaceDir = options.workspaceDir ? path.resolve(options.workspaceDir) : defaultWorkspaceDir();
+  const searchRoots = dedupePaths([...normalizeSearchRoots(options.searchRoots), workspaceDir]);
+  const scanWorktreesDir = options.scanWorktreesDir
+    ? path.resolve(options.scanWorktreesDir)
+    : path.join(workspaceDir, 'scan-worktrees');
+
+  const repositoryResults: AcceptanceBenchmarkRepositoryResult[] = [];
+  let repositoriesBenchmarked = 0;
+  let repositoriesCloned = 0;
+  let repositoriesSkipped = 0;
+  let totalCycles = 0;
+  let totalAcceptanceCases = 0;
+
+  for (const entry of entries) {
+    let repoPath = localCheckoutResolver(entry, searchRoots);
+    let status: AcceptanceBenchmarkRepositoryResult['status'] = 'benchmarked';
+
+    if (!repoPath) {
+      if (!options.cloneMissing) {
+        repositoriesSkipped += 1;
+        repositoryResults.push({
+          slug: entry.slug,
+          repoPath: null,
+          status: 'skipped',
+          reason: 'No local checkout matched the configured search roots',
+        });
+        continue;
+      }
+
+      try {
+        repoPath = await cloneRepo(entry, workspaceDir);
+        repositoriesCloned += 1;
+        status = 'cloned';
+      } catch (error) {
+        repositoriesSkipped += 1;
+        repositoryResults.push({
+          slug: entry.slug,
+          repoPath: null,
+          status: 'skipped',
+          reason: stringifyError(error),
+        });
+        continue;
+      }
+    }
+
+    try {
+      const scan = await scanRepo(repoPath, scanWorktreesDir);
+      const benchmarkedCases = snapshotAcceptanceBenchmark(database, entry.slug, repoPath, scan.scanId);
+      repositoriesBenchmarked += 1;
+      totalCycles += scan.cyclesFound;
+      totalAcceptanceCases += benchmarkedCases;
+      repositoryResults.push({
+        slug: entry.slug,
+        repoPath,
+        status,
+        scanId: scan.scanId,
+        cyclesFound: scan.cyclesFound,
+        benchmarkedCases,
+      });
+    } catch (error) {
+      repositoriesSkipped += 1;
+      repositoryResults.push({
+        slug: entry.slug,
+        repoPath,
+        status: 'skipped',
+        reason: stringifyError(error),
+      });
+    }
+  }
+
+  return {
+    corpusSize: entries.length,
+    repositoriesBenchmarked,
+    repositoriesCloned,
+    repositoriesSkipped,
+    totalCycles,
+    totalAcceptanceCases,
+    workspaceDir,
+    searchRoots,
+    repositoryResults,
+    acceptanceSummary: buildAcceptanceSummary(
+      statements.getAcceptanceSummaryByClassification.all() as AcceptanceBenchmarkSummaryQueryRow[],
+    ),
+  };
+}
+
+export function getAcceptanceBenchmarkReport(database: DatabaseType = getDb()): {
+  totalCases: number;
+  cases: AcceptanceBenchmarkCaseDTO[];
+  summary: AcceptanceBenchmarkSummaryRow[];
+} {
+  const statements = createStatements(database);
+  const cases = statements.getAcceptanceBenchmarkCases.all() as AcceptanceBenchmarkCaseDTO[];
+  const summaryRows = statements.getAcceptanceSummaryByClassification.all() as AcceptanceBenchmarkSummaryQueryRow[];
+
+  return {
+    totalCases: cases.length,
+    cases,
+    summary: buildAcceptanceSummary(summaryRows),
+  };
+}
+
+export function annotateAcceptanceBenchmarkCase(
+  id: number,
+  annotation: AcceptanceBenchmarkAnnotation,
+  database: DatabaseType = getDb(),
+): AcceptanceBenchmarkCaseDTO {
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new Error(`Acceptance benchmark case ID must be a positive integer. Received: ${id}`);
+  }
+
+  if (annotation.acceptability === 'rejected' && !annotation.rejectionReason) {
+    throw new Error('Rejected acceptance benchmark cases must include a rejection reason.');
+  }
+
+  const statements = createStatements(database);
+  const existingCase = statements.getAcceptanceBenchmarkCaseById.get(id) as AcceptanceBenchmarkCaseDTO | undefined;
+  if (!existingCase) {
+    throw new Error(`Acceptance benchmark case ${id} was not found.`);
+  }
+
+  statements.updateAcceptanceBenchmarkReview.run({
+    id,
+    acceptability: annotation.acceptability,
+    rejection_reason: annotation.acceptability === 'rejected' ? (annotation.rejectionReason ?? null) : null,
+    acceptability_note: annotation.note ?? null,
+  });
+
+  return statements.getAcceptanceBenchmarkCaseById.get(id) as AcceptanceBenchmarkCaseDTO;
+}
+
+function snapshotAcceptanceBenchmark(
+  database: DatabaseType,
+  repository: string,
+  repoPath: string,
+  scanId: number,
+): number {
+  const statements = createStatements(database);
+  const rows = database
+    .prepare(
+      `
+        SELECT
+          s.commit_sha,
+          c.id AS cycle_id,
+          c.normalized_path,
+          c.raw_payload,
+          fc.id AS fix_candidate_id,
+          fc.classification,
+          fc.confidence,
+          p.id AS patch_id,
+          p.validation_status,
+          p.validation_summary,
+          p.touched_files,
+          COALESCE(rd.decision, 'pending') AS review_status
+        FROM cycles c
+        INNER JOIN scans s ON s.id = c.scan_id
+        LEFT JOIN fix_candidates fc ON fc.cycle_id = c.id
+        LEFT JOIN patches p ON p.fix_candidate_id = fc.id
+        LEFT JOIN review_decisions rd ON rd.id = (
+          SELECT id
+          FROM review_decisions
+          WHERE patch_id = p.id
+          ORDER BY created_at DESC, id DESC
+          LIMIT 1
+        )
+        WHERE c.scan_id = ?
+        ORDER BY c.id ASC
+      `,
+    )
+    .all(scanId) as AcceptanceSnapshotRow[];
+
+  for (const row of rows) {
+    const rawPayload = parseRawPayload(row.raw_payload);
+    const planner = rawPayload?.analysis?.planner;
+    const acceptability = deriveAcceptability(row.review_status);
+
+    statements.upsertAcceptanceBenchmarkCase.run({
+      repository,
+      local_path: repoPath,
+      commit_sha: row.commit_sha,
+      scan_id: scanId,
+      cycle_id: row.cycle_id,
+      fix_candidate_id: row.fix_candidate_id,
+      patch_id: row.patch_id,
+      normalized_path: row.normalized_path,
+      classification: row.classification ?? rawPayload?.analysis?.classification ?? 'unsupported',
+      confidence: row.confidence ?? rawPayload?.analysis?.confidence ?? 0,
+      upstreamability_score: rawPayload?.analysis?.upstreamabilityScore ?? null,
+      validation_status: row.validation_status,
+      validation_summary: row.validation_summary,
+      review_status: row.review_status,
+      touched_files: row.touched_files,
+      feature_vector: JSON.stringify(planner?.features ?? {}),
+      planner_summary: planner?.selectionSummary ?? null,
+      planner_attempts: JSON.stringify(planner?.attempts ?? []),
+      acceptability,
+      rejection_reason: null,
+      acceptability_note: null,
+    });
+  }
+
+  return rows.length;
+}
+
+async function cloneCorpusRepository(entry: BenchmarkCorpusEntry, workspaceDir: string): Promise<string> {
+  const destination = path.join(workspaceDir, ...entry.slug.split('/'));
+  await mkdir(path.dirname(destination), { recursive: true });
+
+  if (isGitRepository(destination)) {
+    return destination;
+  }
+
+  if (existsSync(destination)) {
+    throw new Error(`Workspace path already exists but is not a git repository: ${destination}`);
+  }
+
+  const git = simpleGit();
+  await git.clone(`https://github.com/${entry.slug}.git`, destination, ['--depth', '1']);
+  return destination;
+}
+
+function buildAcceptanceSummary(rows: AcceptanceBenchmarkSummaryQueryRow[]): AcceptanceBenchmarkSummaryRow[] {
+  return rows.map((row) => {
+    const totalCases = Number(row.total_cases ?? 0);
+    const acceptedCases = Number(row.accepted_cases ?? 0);
+    const rejectedCases = Number(row.rejected_cases ?? 0);
+    const needsReviewCases = Number(row.needs_review_cases ?? 0);
+
+    return {
+      classification: String(row.classification ?? 'unknown'),
+      totalCases,
+      acceptedCases,
+      rejectedCases,
+      needsReviewCases,
+      acceptanceRate: totalCases === 0 ? 0 : Number((acceptedCases / totalCases).toFixed(2)),
+    };
+  });
+}
+
+function parseRawPayload(value: string | null): AcceptanceRawPayload | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as AcceptanceRawPayload;
+  } catch {
+    return null;
+  }
+}
+
+function deriveAcceptability(reviewStatus: string): AcceptanceBenchmarkDecision {
+  if (reviewStatus === 'approved' || reviewStatus === 'pr_candidate') {
+    return 'accepted';
+  }
+
+  if (reviewStatus === 'rejected') {
+    return 'rejected';
+  }
+
+  return 'needs_review';
+}
+
+function dedupePaths(paths: string[]): string[] {
+  return [...new Set(paths.map((candidate) => path.resolve(candidate)))];
+}
+
+function isGitRepository(candidatePath: string): boolean {
+  return existsSync(path.join(candidatePath, '.git'));
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -2,6 +2,11 @@ import { mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { analyzeRepository } from '../analyzer/analyzer.js';
+import {
+  annotateAcceptanceBenchmarkCase,
+  getAcceptanceBenchmarkReport,
+  runAcceptanceBenchmark,
+} from './acceptanceBenchmark.js';
 import { mineBenchmarkCasesFromCorpus } from './benchmarkCorpus.js';
 import { mineBenchmarkCasesFromRepo } from './benchmarkMiner.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
@@ -26,6 +31,120 @@ vi.mock('./benchmarkMiner.js', () => ({
     matchedCommits: 3,
     insertedCases: 2,
     matchedTerms: ['circular dependency', 'import type'],
+  }),
+}));
+
+vi.mock('./acceptanceBenchmark.js', () => ({
+  runAcceptanceBenchmark: vi.fn().mockResolvedValue({
+    corpusSize: 2,
+    repositoriesBenchmarked: 1,
+    repositoriesCloned: 0,
+    repositoriesSkipped: 1,
+    totalCycles: 4,
+    totalAcceptanceCases: 3,
+    workspaceDir: path.join(fixtureRoot, 'worktrees', 'acceptance-benchmark'),
+    searchRoots: [path.join(fixtureRoot, 'corpus')],
+    repositoryResults: [
+      {
+        slug: 'openclaw/openclaw',
+        repoPath: path.join(fixtureRoot, 'corpus', 'openclaw'),
+        status: 'benchmarked',
+        scanId: 42,
+        cyclesFound: 4,
+        benchmarkedCases: 3,
+      },
+      {
+        slug: 'microsoft/vscode',
+        repoPath: null,
+        status: 'skipped',
+        reason: 'No local checkout matched the configured search roots',
+      },
+    ],
+    acceptanceSummary: [
+      {
+        classification: 'autofix_import_type',
+        totalCases: 2,
+        acceptedCases: 1,
+        rejectedCases: 0,
+        needsReviewCases: 1,
+        acceptanceRate: 0.5,
+      },
+      {
+        classification: 'autofix_extract_shared',
+        totalCases: 1,
+        acceptedCases: 0,
+        rejectedCases: 1,
+        needsReviewCases: 0,
+        acceptanceRate: 0,
+      },
+    ],
+  }),
+  getAcceptanceBenchmarkReport: vi.fn().mockReturnValue({
+    totalCases: 3,
+    cases: [
+      {
+        id: 7,
+        repository: 'openclaw/openclaw',
+        local_path: path.join(fixtureRoot, 'corpus', 'openclaw'),
+        commit_sha: 'abc123',
+        scan_id: 42,
+        cycle_id: 9,
+        fix_candidate_id: 10,
+        patch_id: 11,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.93,
+        upstreamability_score: 0.89,
+        validation_status: 'passed',
+        validation_summary: 'passed',
+        review_status: 'approved',
+        touched_files: '["a.ts","b.ts"]',
+        feature_vector: '{"cycleSize":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[]',
+        acceptability: 'accepted',
+        rejection_reason: null,
+        acceptability_note: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    summary: [
+      {
+        classification: 'autofix_import_type',
+        totalCases: 2,
+        acceptedCases: 1,
+        rejectedCases: 0,
+        needsReviewCases: 1,
+        acceptanceRate: 0.5,
+      },
+    ],
+  }),
+  annotateAcceptanceBenchmarkCase: vi.fn().mockReturnValue({
+    id: 7,
+    repository: 'openclaw/openclaw',
+    local_path: path.join(fixtureRoot, 'corpus', 'openclaw'),
+    commit_sha: 'abc123',
+    scan_id: 42,
+    cycle_id: 9,
+    fix_candidate_id: 10,
+    patch_id: 11,
+    normalized_path: 'a.ts -> b.ts -> a.ts',
+    classification: 'autofix_import_type',
+    confidence: 0.93,
+    upstreamability_score: 0.89,
+    validation_status: 'passed',
+    validation_summary: 'passed',
+    review_status: 'approved',
+    touched_files: '["a.ts","b.ts"]',
+    feature_vector: '{"cycleSize":2}',
+    planner_summary: 'Selected import_type',
+    planner_attempts: '[]',
+    acceptability: 'rejected',
+    rejection_reason: 'semantic_wrong',
+    acceptability_note: 'Breaks runtime behavior',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
   }),
 }));
 
@@ -466,6 +585,89 @@ describe('CLI', () => {
     consoleSpy.mockRestore();
   });
 
+  it('benchmark:acceptance command logs JSON summary and calls the acceptance runner', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'benchmark:acceptance',
+      '--only',
+      'openclaw/openclaw',
+      '--search-root',
+      path.join(fixtureRoot, 'corpus'),
+      '--scan-worktrees-dir',
+      path.join(fixtureRoot, 'scan-worktrees'),
+    ]);
+
+    expect(vi.mocked(runAcceptanceBenchmark)).toHaveBeenCalledWith({
+      onlyRepositories: ['openclaw/openclaw'],
+      searchRoots: [path.join(fixtureRoot, 'corpus')],
+      workspaceDir: undefined,
+      cloneMissing: undefined,
+      limit: undefined,
+      scanWorktreesDir: path.join(fixtureRoot, 'scan-worktrees'),
+    });
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      repositoriesBenchmarked: 1,
+      totalAcceptanceCases: 3,
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('benchmark:acceptance:report prints the stored benchmark report', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'benchmark:acceptance:report']);
+
+    expect(vi.mocked(getAcceptanceBenchmarkReport)).toHaveBeenCalledWith();
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      totalCases: 3,
+      summary: [
+        expect.objectContaining({
+          classification: 'autofix_import_type',
+          totalCases: 2,
+        }),
+      ],
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('benchmark:acceptance:annotate updates a stored benchmark case', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'benchmark:acceptance:annotate',
+      '7',
+      '--acceptability',
+      'rejected',
+      '--rejection-reason',
+      'semantic_wrong',
+      '--note',
+      'Breaks runtime behavior',
+    ]);
+
+    expect(vi.mocked(annotateAcceptanceBenchmarkCase)).toHaveBeenCalledWith(7, {
+      acceptability: 'rejected',
+      rejectionReason: 'semantic_wrong',
+      note: 'Breaks runtime behavior',
+    });
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      id: 7,
+      acceptability: 'rejected',
+      rejection_reason: 'semantic_wrong',
+    });
+    consoleSpy.mockRestore();
+  });
+
   it('create:pr command exits on invalid issue number', async () => {
     const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
@@ -526,9 +728,27 @@ describe('CLI', () => {
     exitSpy.mockRestore();
   });
 
-  it('has all eight subcommands registered', () => {
+  it('benchmark:acceptance:annotate exits on invalid case id', async () => {
+    const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'benchmark:acceptance:annotate', 'nope', '--acceptability', 'accepted']);
+
+    expect(consoleErrSpy).toHaveBeenCalledWith('Invalid acceptance benchmark case ID: nope');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleErrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('has all eleven subcommands registered', () => {
     const program = createProgram();
     const commandNames = program.commands.map((cmd) => cmd.name());
+    expect(commandNames).toContain('benchmark:acceptance');
+    expect(commandNames).toContain('benchmark:acceptance:report');
+    expect(commandNames).toContain('benchmark:acceptance:annotate');
     expect(commandNames).toContain('scan');
     expect(commandNames).toContain('explain');
     expect(commandNames).toContain('mine:corpus');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,5 +1,10 @@
 import { Command } from 'commander';
 import { analyzeRepository } from '../analyzer/analyzer.js';
+import {
+  annotateAcceptanceBenchmarkCase,
+  getAcceptanceBenchmarkReport,
+  runAcceptanceBenchmark,
+} from './acceptanceBenchmark.js';
 import { mineBenchmarkCasesFromCorpus } from './benchmarkCorpus.js';
 import { mineBenchmarkCasesFromRepo } from './benchmarkMiner.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
@@ -25,6 +30,97 @@ export function createProgram(): Command {
         process.exit(1);
       }
     });
+
+  program
+    .command('benchmark:acceptance')
+    .description('Scan the benchmark corpus and snapshot acceptance-ready cycle candidates')
+    .option(
+      '--only <slug>',
+      'Restrict benchmarking to a specific corpus repository slug or repo name',
+      collectString,
+      [],
+    )
+    .option('--search-root <path>', 'Additional root path to search for local repository checkouts', collectString, [])
+    .option('--workspace <path>', 'Directory to clone missing repositories into before benchmarking')
+    .option('--clone-missing', 'Clone missing repositories into the workspace before benchmarking')
+    .option('--limit <count>', 'Limit how many corpus repositories are processed', parseInteger)
+    .option('--scan-worktrees-dir <path>', 'Directory to use for temporary scan worktrees')
+    .action(
+      async (options: {
+        only: string[];
+        searchRoot: string[];
+        workspace?: string;
+        cloneMissing?: boolean;
+        limit?: number;
+        scanWorktreesDir?: string;
+      }) => {
+        try {
+          const result = await runAcceptanceBenchmark({
+            onlyRepositories: options.only,
+            searchRoots: options.searchRoot,
+            workspaceDir: options.workspace,
+            cloneMissing: options.cloneMissing,
+            limit: options.limit,
+            scanWorktreesDir: options.scanWorktreesDir,
+          });
+          console.log(JSON.stringify(result, null, 2));
+        } catch (error) {
+          console.error('Failed to build the acceptance benchmark:', error);
+          process.exit(1);
+        }
+      },
+    );
+
+  program
+    .command('benchmark:acceptance:report')
+    .description('Print the stored acceptance benchmark cases and summary report')
+    .action(() => {
+      try {
+        const result = getAcceptanceBenchmarkReport();
+        console.log(JSON.stringify(result, null, 2));
+      } catch (error) {
+        console.error('Failed to load the acceptance benchmark report:', error);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('benchmark:acceptance:annotate <caseId>')
+    .description('Annotate an acceptance benchmark case with a review outcome')
+    .requiredOption('--acceptability <decision>', 'accepted, needs_review, or rejected')
+    .option(
+      '--rejection-reason <reason>',
+      'diff_noisy, validation_weak, semantic_wrong, repo_conventions_mismatch, or other',
+    )
+    .option('--note <note>', 'Optional note describing the review outcome')
+    .action(
+      async (
+        caseId: string,
+        options: {
+          acceptability: string;
+          rejectionReason?: string;
+          note?: string;
+        },
+      ) => {
+        const numericCaseId = Number(caseId);
+        if (!Number.isInteger(numericCaseId) || numericCaseId <= 0) {
+          console.error(`Invalid acceptance benchmark case ID: ${caseId}`);
+          process.exit(1);
+        }
+
+        try {
+          const result = annotateAcceptanceBenchmarkCase(numericCaseId, {
+            acceptability: parseAcceptanceDecision(options.acceptability),
+            rejectionReason: parseAcceptanceRejectionReason(options.rejectionReason),
+            note: options.note,
+          });
+          console.log(JSON.stringify(result, null, 2));
+        } catch (error) {
+          console.error(`Failed to annotate acceptance benchmark case ${caseId}:`, error);
+          process.exit(1);
+        }
+      },
+    );
 
   program
     .command('mine:corpus')
@@ -235,6 +331,36 @@ function parseScore(value: string): number {
 
 function collectString(value: string, previous: string[]): string[] {
   return [...previous, value];
+}
+
+function parseAcceptanceDecision(value: string): 'accepted' | 'needs_review' | 'rejected' {
+  if (value === 'accepted' || value === 'needs_review' || value === 'rejected') {
+    return value;
+  }
+
+  throw new Error(`Expected an acceptance decision of accepted, needs_review, or rejected. Received: ${value}`);
+}
+
+function parseAcceptanceRejectionReason(
+  value?: string,
+): 'diff_noisy' | 'other' | 'repo_conventions_mismatch' | 'semantic_wrong' | 'validation_weak' | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (
+    value === 'diff_noisy' ||
+    value === 'other' ||
+    value === 'repo_conventions_mismatch' ||
+    value === 'semantic_wrong' ||
+    value === 'validation_weak'
+  ) {
+    return value;
+  }
+
+  throw new Error(
+    `Expected a rejection reason of diff_noisy, validation_weak, semantic_wrong, repo_conventions_mismatch, or other. Received: ${value}`,
+  );
 }
 
 // Run when executed directly

--- a/db/index.test.ts
+++ b/db/index.test.ts
@@ -1,6 +1,7 @@
 import type { Database as DatabaseType } from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  type AcceptanceBenchmarkCaseDTO,
   type BenchmarkCaseDTO,
   type CycleDTO,
   createDatabase,
@@ -13,6 +14,9 @@ import {
   addRepository as defaultAddRepository,
   addReviewDecision as defaultAddReviewDecision,
   addScan as defaultAddScan,
+  getAcceptanceBenchmarkCaseById as defaultGetAcceptanceBenchmarkCaseById,
+  getAcceptanceBenchmarkCases as defaultGetAcceptanceBenchmarkCases,
+  getAcceptanceSummaryByClassification as defaultGetAcceptanceSummaryByClassification,
   getAllRepositories as defaultGetAllRepositories,
   getBenchmarkCases as defaultGetBenchmarkCases,
   getBenchmarkCasesByRepository as defaultGetBenchmarkCasesByRepository,
@@ -25,8 +29,10 @@ import {
   getRepositoryByOwnerName as defaultGetRepositoryByOwnerName,
   getReviewDecisionByPatchId as defaultGetReviewDecisionByPatchId,
   getScan as defaultGetScan,
+  updateAcceptanceBenchmarkReview as defaultUpdateAcceptanceBenchmarkReview,
   updateRepositoryStatus as defaultUpdateRepositoryStatus,
   updateScanStatus as defaultUpdateScanStatus,
+  upsertAcceptanceBenchmarkCase as defaultUpsertAcceptanceBenchmarkCase,
   type FixCandidateDTO,
   // Default production exports
   getDb as getDefaultDb,
@@ -38,6 +44,9 @@ import {
   type ReviewDecisionDTO,
   type ScanDTO,
 } from './index.js';
+
+// eslint-disable-next-line sonarjs/publicly-writable-directories
+const TEST_LOCAL_REPO_PATH = '/tmp/openclaw';
 
 describe('db module', () => {
   let db: DatabaseType;
@@ -77,6 +86,7 @@ describe('db module', () => {
       expect(tableNames).toContain('patch_replays');
       expect(tableNames).toContain('benchmark_cases');
       expect(tableNames).toContain('review_decisions');
+      expect(tableNames).toContain('acceptance_benchmark_cases');
     });
 
     it('creates expected indexes', () => {
@@ -100,6 +110,9 @@ describe('db module', () => {
       expect(indexNames).toContain('idx_benchmark_cases_source');
       expect(indexNames).toContain('idx_review_decisions_patch_id');
       expect(indexNames).toContain('idx_review_decisions_decision');
+      expect(indexNames).toContain('idx_acceptance_benchmark_repository');
+      expect(indexNames).toContain('idx_acceptance_benchmark_classification');
+      expect(indexNames).toContain('idx_acceptance_benchmark_acceptability');
     });
 
     it('is idempotent (safe to call multiple times)', () => {
@@ -668,6 +681,236 @@ describe('db module', () => {
       expect(decision).toBeUndefined();
     });
   });
+
+  describe('acceptance_benchmark_cases', () => {
+    it('upserts and retrieves acceptance benchmark cases', () => {
+      const insert = stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'openclaw/openclaw',
+        local_path: TEST_LOCAL_REPO_PATH,
+        commit_sha: 'abc123',
+        scan_id: 1,
+        cycle_id: 2,
+        fix_candidate_id: 3,
+        patch_id: 4,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.91,
+        upstreamability_score: 0.88,
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+        review_status: 'approved',
+        touched_files: '["a.ts","b.ts"]',
+        feature_vector: '{"cycleSize":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[{"strategy":"import_type"}]',
+        acceptability: 'accepted',
+        rejection_reason: null,
+        acceptability_note: null,
+      });
+
+      const acceptanceCase = stmts.getAcceptanceBenchmarkCaseById.get(
+        insert.lastInsertRowid,
+      ) as AcceptanceBenchmarkCaseDTO;
+      expect(acceptanceCase.repository).toBe('openclaw/openclaw');
+      expect(acceptanceCase.classification).toBe('autofix_import_type');
+      expect(acceptanceCase.acceptability).toBe('accepted');
+      expect(acceptanceCase.feature_vector).toBe('{"cycleSize":2}');
+    });
+
+    it('updates an existing acceptance benchmark case on conflict', () => {
+      stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'openclaw/openclaw',
+        local_path: TEST_LOCAL_REPO_PATH,
+        commit_sha: 'abc123',
+        scan_id: 1,
+        cycle_id: 2,
+        fix_candidate_id: 3,
+        patch_id: 4,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.91,
+        upstreamability_score: 0.88,
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+        review_status: 'approved',
+        touched_files: '["a.ts","b.ts"]',
+        feature_vector: '{"cycleSize":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[{"strategy":"import_type"}]',
+        acceptability: 'accepted',
+        rejection_reason: null,
+        acceptability_note: null,
+      });
+
+      stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'openclaw/openclaw',
+        local_path: TEST_LOCAL_REPO_PATH,
+        commit_sha: 'abc123',
+        scan_id: 11,
+        cycle_id: 12,
+        fix_candidate_id: 13,
+        patch_id: 14,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.72,
+        upstreamability_score: 0.64,
+        validation_status: 'failed',
+        validation_summary: 'Typecheck failed',
+        review_status: 'rejected',
+        touched_files: '["a.ts"]',
+        feature_vector: '{"cycleSize":2,"barrel":true}',
+        planner_summary: 'Selected import_type after review',
+        planner_attempts: '[{"strategy":"import_type","status":"candidate"}]',
+        acceptability: 'rejected',
+        rejection_reason: 'semantic_wrong',
+        acceptability_note: 'Rejected during benchmark review',
+      });
+
+      const rows = stmts.getAcceptanceBenchmarkCases.all() as AcceptanceBenchmarkCaseDTO[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        scan_id: 11,
+        cycle_id: 12,
+        fix_candidate_id: 13,
+        patch_id: 14,
+        confidence: 0.72,
+        upstreamability_score: 0.64,
+        validation_status: 'failed',
+        review_status: 'rejected',
+        acceptability: 'rejected',
+        rejection_reason: 'semantic_wrong',
+        acceptability_note: 'Rejected during benchmark review',
+      });
+    });
+
+    it('summarizes acceptance benchmark cases by classification', () => {
+      stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'openclaw/openclaw',
+        local_path: TEST_LOCAL_REPO_PATH,
+        commit_sha: 'abc123',
+        scan_id: 1,
+        cycle_id: 2,
+        fix_candidate_id: 3,
+        patch_id: 4,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.91,
+        upstreamability_score: 0.88,
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+        review_status: 'approved',
+        touched_files: '["a.ts","b.ts"]',
+        feature_vector: '{"cycleSize":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[{"strategy":"import_type"}]',
+        acceptability: 'accepted',
+        rejection_reason: null,
+        acceptability_note: null,
+      });
+      stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'openclaw/openclaw',
+        local_path: TEST_LOCAL_REPO_PATH,
+        commit_sha: 'def456',
+        scan_id: 5,
+        cycle_id: 6,
+        fix_candidate_id: 7,
+        patch_id: 8,
+        normalized_path: 'c.ts -> d.ts -> c.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.83,
+        upstreamability_score: 0.8,
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+        review_status: 'pending',
+        touched_files: '["c.ts","d.ts"]',
+        feature_vector: '{"cycleSize":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[{"strategy":"import_type"}]',
+        acceptability: 'needs_review',
+        rejection_reason: null,
+        acceptability_note: null,
+      });
+      stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'openclaw/openclaw',
+        local_path: TEST_LOCAL_REPO_PATH,
+        commit_sha: 'ghi789',
+        scan_id: 9,
+        cycle_id: 10,
+        fix_candidate_id: 11,
+        patch_id: 12,
+        normalized_path: 'e.ts -> f.ts -> e.ts',
+        classification: 'autofix_extract_shared',
+        confidence: 0.67,
+        upstreamability_score: 0.6,
+        validation_status: 'failed',
+        validation_summary: 'Typecheck failed',
+        review_status: 'rejected',
+        touched_files: '["e.ts","f.ts","shared.ts"]',
+        feature_vector: '{"cycleSize":2,"introducesNewFile":true}',
+        planner_summary: 'Selected extract_shared',
+        planner_attempts: '[{"strategy":"extract_shared"}]',
+        acceptability: 'rejected',
+        rejection_reason: 'repo_conventions_mismatch',
+        acceptability_note: 'Rejected by benchmark review',
+      });
+
+      const summaryRows = stmts.getAcceptanceSummaryByClassification.all() as Array<Record<string, unknown>>;
+      expect(summaryRows).toEqual([
+        {
+          classification: 'autofix_extract_shared',
+          total_cases: 1,
+          accepted_cases: 0,
+          rejected_cases: 1,
+          needs_review_cases: 0,
+        },
+        {
+          classification: 'autofix_import_type',
+          total_cases: 2,
+          accepted_cases: 1,
+          rejected_cases: 0,
+          needs_review_cases: 1,
+        },
+      ]);
+    });
+
+    it('updates review annotations for an acceptance benchmark case', () => {
+      const insert = stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'openclaw/openclaw',
+        local_path: TEST_LOCAL_REPO_PATH,
+        commit_sha: 'abc123',
+        scan_id: 1,
+        cycle_id: 2,
+        fix_candidate_id: 3,
+        patch_id: 4,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.91,
+        upstreamability_score: 0.88,
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+        review_status: 'approved',
+        touched_files: '["a.ts","b.ts"]',
+        feature_vector: '{"cycleSize":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[{"strategy":"import_type"}]',
+        acceptability: 'needs_review',
+        rejection_reason: null,
+        acceptability_note: null,
+      });
+
+      stmts.updateAcceptanceBenchmarkReview.run({
+        id: insert.lastInsertRowid,
+        acceptability: 'rejected',
+        rejection_reason: 'validation_weak',
+        acceptability_note: 'Needs repo-native validation',
+      });
+
+      const updated = stmts.getAcceptanceBenchmarkCaseById.get(insert.lastInsertRowid) as AcceptanceBenchmarkCaseDTO;
+      expect(updated.acceptability).toBe('rejected');
+      expect(updated.rejection_reason).toBe('validation_weak');
+      expect(updated.acceptability_note).toBe('Needs repo-native validation');
+    });
+  });
 });
 
 describe('default production exports', () => {
@@ -706,5 +949,10 @@ describe('default production exports', () => {
     expect(defaultGetBenchmarkCasesByRepository).toBeDefined();
     expect(defaultAddReviewDecision).toBeDefined();
     expect(defaultGetReviewDecisionByPatchId).toBeDefined();
+    expect(defaultUpsertAcceptanceBenchmarkCase).toBeDefined();
+    expect(defaultGetAcceptanceBenchmarkCases).toBeDefined();
+    expect(defaultGetAcceptanceBenchmarkCaseById).toBeDefined();
+    expect(defaultGetAcceptanceSummaryByClassification).toBeDefined();
+    expect(defaultUpdateAcceptanceBenchmarkReview).toBeDefined();
   });
 });

--- a/db/index.ts
+++ b/db/index.ts
@@ -90,6 +90,33 @@ export interface ReviewDecisionDTO {
   created_at: string;
 }
 
+export interface AcceptanceBenchmarkCaseDTO {
+  id: number;
+  repository: string;
+  local_path: string | null;
+  commit_sha: string;
+  scan_id: number | null;
+  cycle_id: number | null;
+  fix_candidate_id: number | null;
+  patch_id: number | null;
+  normalized_path: string;
+  classification: string;
+  confidence: number;
+  upstreamability_score: number | null;
+  validation_status: string | null;
+  validation_summary: string | null;
+  review_status: string | null;
+  touched_files: string | null;
+  feature_vector: string;
+  planner_summary: string | null;
+  planner_attempts: string;
+  acceptability: string | null;
+  rejection_reason: string | null;
+  acceptability_note: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export type RepositoryStatus =
   | 'queued'
   | 'scanning'
@@ -106,6 +133,13 @@ export type Classification =
   | 'suggest_manual'
   | 'unsupported';
 export type ReviewDecision = 'approved' | 'rejected' | 'ignored' | 'pr_candidate';
+export type AcceptanceBenchmarkDecision = 'accepted' | 'needs_review' | 'rejected';
+export type AcceptanceBenchmarkRejectionReason =
+  | 'diff_noisy'
+  | 'other'
+  | 'repo_conventions_mismatch'
+  | 'semantic_wrong'
+  | 'validation_weak';
 
 // Schema definition (shared between production and test databases)
 const SCHEMA_SQL = `
@@ -206,6 +240,34 @@ const SCHEMA_SQL = `
     UNIQUE(patch_id)
   );
 
+  CREATE TABLE IF NOT EXISTS acceptance_benchmark_cases (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repository TEXT NOT NULL,
+    local_path TEXT,
+    commit_sha TEXT NOT NULL,
+    scan_id INTEGER,
+    cycle_id INTEGER,
+    fix_candidate_id INTEGER,
+    patch_id INTEGER,
+    normalized_path TEXT NOT NULL,
+    classification TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    upstreamability_score REAL,
+    validation_status TEXT,
+    validation_summary TEXT,
+    review_status TEXT,
+    touched_files TEXT,
+    feature_vector TEXT NOT NULL,
+    planner_summary TEXT,
+    planner_attempts TEXT NOT NULL,
+    acceptability TEXT,
+    rejection_reason TEXT,
+    acceptability_note TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(repository, commit_sha, normalized_path, classification)
+  );
+
   -- Indexes
   CREATE INDEX IF NOT EXISTS idx_repositories_owner_name ON repositories(owner, name);
   CREATE INDEX IF NOT EXISTS idx_repositories_status ON repositories(status);
@@ -222,6 +284,9 @@ const SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_benchmark_cases_source ON benchmark_cases(source);
   CREATE INDEX IF NOT EXISTS idx_review_decisions_patch_id ON review_decisions(patch_id);
   CREATE INDEX IF NOT EXISTS idx_review_decisions_decision ON review_decisions(decision);
+  CREATE INDEX IF NOT EXISTS idx_acceptance_benchmark_repository ON acceptance_benchmark_cases(repository);
+  CREATE INDEX IF NOT EXISTS idx_acceptance_benchmark_classification ON acceptance_benchmark_cases(classification);
+  CREATE INDEX IF NOT EXISTS idx_acceptance_benchmark_acceptability ON acceptance_benchmark_cases(acceptability);
 `;
 
 /**
@@ -355,6 +420,67 @@ export function createStatements(database: DatabaseType) {
     getReviewDecisionByPatchId: database.prepare(`
       SELECT * FROM review_decisions WHERE patch_id = ?
     `),
+
+    // Acceptance benchmark cases
+    upsertAcceptanceBenchmarkCase: database.prepare(`
+      INSERT INTO acceptance_benchmark_cases (
+        repository, local_path, commit_sha, scan_id, cycle_id, fix_candidate_id, patch_id,
+        normalized_path, classification, confidence, upstreamability_score, validation_status,
+        validation_summary, review_status, touched_files, feature_vector, planner_summary,
+        planner_attempts, acceptability, rejection_reason, acceptability_note
+      )
+      VALUES (
+        @repository, @local_path, @commit_sha, @scan_id, @cycle_id, @fix_candidate_id, @patch_id,
+        @normalized_path, @classification, @confidence, @upstreamability_score, @validation_status,
+        @validation_summary, @review_status, @touched_files, @feature_vector, @planner_summary,
+        @planner_attempts, @acceptability, @rejection_reason, @acceptability_note
+      )
+      ON CONFLICT(repository, commit_sha, normalized_path, classification) DO UPDATE SET
+        local_path = excluded.local_path,
+        scan_id = excluded.scan_id,
+        cycle_id = excluded.cycle_id,
+        fix_candidate_id = excluded.fix_candidate_id,
+        patch_id = excluded.patch_id,
+        confidence = excluded.confidence,
+        upstreamability_score = excluded.upstreamability_score,
+        validation_status = excluded.validation_status,
+        validation_summary = excluded.validation_summary,
+        review_status = excluded.review_status,
+        touched_files = excluded.touched_files,
+        feature_vector = excluded.feature_vector,
+        planner_summary = excluded.planner_summary,
+        planner_attempts = excluded.planner_attempts,
+        acceptability = excluded.acceptability,
+        rejection_reason = excluded.rejection_reason,
+        acceptability_note = excluded.acceptability_note,
+        updated_at = CURRENT_TIMESTAMP
+    `),
+    getAcceptanceBenchmarkCases: database.prepare(`
+      SELECT * FROM acceptance_benchmark_cases ORDER BY updated_at DESC, id DESC
+    `),
+    getAcceptanceBenchmarkCaseById: database.prepare(`
+      SELECT * FROM acceptance_benchmark_cases WHERE id = ?
+    `),
+    getAcceptanceSummaryByClassification: database.prepare(`
+      SELECT
+        classification,
+        COUNT(*) AS total_cases,
+        SUM(CASE WHEN acceptability = 'accepted' THEN 1 ELSE 0 END) AS accepted_cases,
+        SUM(CASE WHEN acceptability = 'rejected' THEN 1 ELSE 0 END) AS rejected_cases,
+        SUM(CASE WHEN acceptability = 'needs_review' OR acceptability IS NULL THEN 1 ELSE 0 END) AS needs_review_cases
+      FROM acceptance_benchmark_cases
+      GROUP BY classification
+      ORDER BY classification
+    `),
+    updateAcceptanceBenchmarkReview: database.prepare(`
+      UPDATE acceptance_benchmark_cases
+      SET
+        acceptability = @acceptability,
+        rejection_reason = @rejection_reason,
+        acceptability_note = @acceptability_note,
+        updated_at = CURRENT_TIMESTAMP
+      WHERE id = @id
+    `),
   };
 }
 
@@ -486,5 +612,25 @@ export const addReviewDecision = {
 export const getReviewDecisionByPatchId = {
   get: (...args: Parameters<ReturnType<typeof createStatements>['getReviewDecisionByPatchId']['get']>) =>
     getStatements().getReviewDecisionByPatchId.get(...args),
+};
+export const upsertAcceptanceBenchmarkCase = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['upsertAcceptanceBenchmarkCase']['run']>) =>
+    getStatements().upsertAcceptanceBenchmarkCase.run(...args),
+};
+export const getAcceptanceBenchmarkCases = {
+  all: (...args: Parameters<ReturnType<typeof createStatements>['getAcceptanceBenchmarkCases']['all']>) =>
+    getStatements().getAcceptanceBenchmarkCases.all(...args),
+};
+export const getAcceptanceBenchmarkCaseById = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getAcceptanceBenchmarkCaseById']['get']>) =>
+    getStatements().getAcceptanceBenchmarkCaseById.get(...args),
+};
+export const getAcceptanceSummaryByClassification = {
+  all: (...args: Parameters<ReturnType<typeof createStatements>['getAcceptanceSummaryByClassification']['all']>) =>
+    getStatements().getAcceptanceSummaryByClassification.all(...args),
+};
+export const updateAcceptanceBenchmarkReview = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['updateAcceptanceBenchmarkReview']['run']>) =>
+    getStatements().updateAcceptanceBenchmarkReview.run(...args),
 };
 /* v8 ignore stop */


### PR DESCRIPTION
Closes #35

## Summary
- add an acceptance benchmark table and review annotations to persist real-repo autofix outcomes
- add `benchmark:acceptance`, `benchmark:acceptance:report`, and `benchmark:acceptance:annotate` CLI commands
- snapshot scan/planner output into acceptance benchmark cases and cover the workflow with DB and CLI tests

## Verification
- `../../node_modules/.bin/vitest run`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `../../node_modules/.bin/eslint cli/acceptanceBenchmark.ts cli/acceptanceBenchmark.test.ts cli/index.ts cli/index.test.ts db/index.ts db/index.test.ts`
- `../../node_modules/.bin/biome check cli/acceptanceBenchmark.ts cli/acceptanceBenchmark.test.ts cli/index.ts cli/index.test.ts db/index.ts db/index.test.ts`
- `../../node_modules/.bin/vite build`
- `git diff --check`