### PR TITLE
Add real-repo smoke harness

### DIFF
--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -14,6 +14,7 @@ import { exportApprovedPatches } from './exportPatches.js';
 import { createProgram } from './index.js';
 import { profileRepository } from './repoProfile.js';
 import { scanRepository } from './scanner.js';
+import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
 
 const fixtureRoot = vi.hoisted(() => `${process.cwd()}/.test-fixtures`);
 const exportedDir = vi.hoisted(() => `${process.cwd()}/.test-fixtures/patches`);
@@ -21,6 +22,36 @@ mkdirSync(fixtureRoot, { recursive: true });
 
 vi.mock('./scanner.js', () => ({
   scanRepository: vi.fn().mockResolvedValue({ scanId: 999, cyclesFound: 2 }),
+}));
+
+vi.mock('./smoke.js', () => ({
+  loadSmokeFixtures: vi.fn().mockResolvedValue([
+    {
+      name: 'openclaw',
+      target: '../openclaw',
+      expectations: { minCycles: 1 },
+    },
+  ]),
+  runSmokeSuite: vi.fn().mockResolvedValue({
+    results: [
+      {
+        name: 'openclaw',
+        target: '../openclaw',
+        status: 'passed',
+        scanId: 13,
+        cyclesFound: 4,
+        candidateCount: 2,
+        patchCount: 1,
+        classifications: {
+          autofix_extract_shared: 1,
+          unsupported: 1,
+        },
+      },
+    ],
+    passed: 1,
+    failed: 0,
+  }),
+  formatSmokeSuiteResult: vi.fn().mockReturnValue('PASS openclaw: 4 cycles, 2 candidates, 1 patches'),
 }));
 
 vi.mock('./benchmarkMiner.js', () => ({
@@ -345,6 +376,43 @@ describe('CLI', () => {
     consoleSpy.mockRestore();
   });
 
+  it('smoke command loads fixtures, runs the smoke suite, and prints the formatted result', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'smoke',
+      path.join(fixtureRoot, 'smoke.fixtures.json'),
+      '--worktrees-dir',
+      path.join(fixtureRoot, 'smoke-worktrees'),
+    ]);
+
+    expect(vi.mocked(loadSmokeFixtures)).toHaveBeenCalledWith(path.join(fixtureRoot, 'smoke.fixtures.json'));
+    expect(vi.mocked(runSmokeSuite)).toHaveBeenCalledWith(
+      [
+        {
+          name: 'openclaw',
+          target: '../openclaw',
+          expectations: { minCycles: 1 },
+        },
+      ],
+      {
+        worktreesDir: path.join(fixtureRoot, 'smoke-worktrees'),
+      },
+    );
+    expect(vi.mocked(formatSmokeSuiteResult)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        passed: 1,
+        failed: 0,
+      }),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith('PASS openclaw: 4 cycles, 2 candidates, 1 patches');
+    consoleSpy.mockRestore();
+  });
+
   it('mine:repo-history command logs repository path and calls miner', async () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const program = createProgram();
@@ -378,6 +446,40 @@ describe('CLI', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     consoleErrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('smoke command exits when the smoke suite reports failures', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
+    vi.mocked(runSmokeSuite).mockResolvedValueOnce({
+      results: [
+        {
+          name: 'dify',
+          target: 'https://github.com/langgenius/dify.git',
+          status: 'failed',
+          stage: 'expectation',
+          message: 'Expected at least 1 unsupported candidates, found 0.',
+        },
+      ],
+      passed: 0,
+      failed: 1,
+    });
+    vi.mocked(formatSmokeSuiteResult).mockReturnValueOnce(
+      'FAIL dify [expectation]: Expected at least 1 unsupported candidates, found 0.',
+    );
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'smoke']);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'FAIL dify [expectation]: Expected at least 1 unsupported candidates, found 0.',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
     exitSpy.mockRestore();
   });
 
@@ -743,9 +845,10 @@ describe('CLI', () => {
     exitSpy.mockRestore();
   });
 
-  it('has all eleven subcommands registered', () => {
+  it('has all twelve subcommands registered', () => {
     const program = createProgram();
     const commandNames = program.commands.map((cmd) => cmd.name());
+    expect(commandNames).toContain('smoke');
     expect(commandNames).toContain('benchmark:acceptance');
     expect(commandNames).toContain('benchmark:acceptance:report');
     expect(commandNames).toContain('benchmark:acceptance:annotate');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -11,6 +11,7 @@ import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
 import { profileRepository } from './repoProfile.js';
 import { scanRepository } from './scanner.js';
+import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -27,6 +28,27 @@ export function createProgram(): Command {
         console.log(`Scan completed successfully (Scan ID: ${result.scanId}). Found ${result.cyclesFound} cycles.`);
       } catch (error) {
         console.error(`Failed to scan repository ${repo}:`, error);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('smoke [fixturesPath]')
+    .description('Run the real-repo smoke suite from a fixture list')
+    .option('--worktrees-dir <path>', 'Directory to use for smoke suite worktrees')
+    .action(async (fixturesPath = 'smoke.fixtures.json', options: { worktreesDir?: string }) => {
+      try {
+        const fixtures = await loadSmokeFixtures(fixturesPath);
+        const result = await runSmokeSuite(fixtures, {
+          worktreesDir: options.worktreesDir,
+        });
+        console.log(formatSmokeSuiteResult(result));
+
+        if (result.failed > 0) {
+          process.exit(1);
+        }
+      } catch (error) {
+        console.error(`Failed to run smoke suite from ${fixturesPath}:`, error);
         process.exit(1);
       }
     });

--- a/cli/smoke.test.ts
+++ b/cli/smoke.test.ts
@@ -1,0 +1,290 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
+
+const tempDirs: string[] = [];
+// eslint-disable-next-line sonarjs/publicly-writable-directories
+const TEST_REPO_ONE_PATH = '/tmp/repo-one';
+// eslint-disable-next-line sonarjs/publicly-writable-directories
+const TEST_REPO_THREE_PATH = '/tmp/repo-three';
+// eslint-disable-next-line sonarjs/publicly-writable-directories
+const TEST_REPO_FOUR_PATH = '/tmp/repo-four';
+
+interface ExpectationFailureCase {
+  name: string;
+  expectations: {
+    exactCycles?: number;
+    minCycles?: number;
+    maxCycles?: number;
+    minClassifications?: Record<string, number>;
+    minPatches?: number;
+  };
+  cycles: Array<{ id: number }>;
+  candidatesByCycle: Record<number, Array<{ id: number; classification: string }>>;
+  patchesByCandidate: Record<number, Array<{ id: number }>>;
+  messageFragment: string;
+}
+
+async function createFixturesFile(contents: unknown): Promise<string> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'smoke-fixtures-'));
+  tempDirs.push(tempDir);
+  const fixturePath = path.join(tempDir, 'fixtures.json');
+  await fs.writeFile(fixturePath, JSON.stringify(contents), 'utf8');
+  return fixturePath;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((candidate) => fs.rm(candidate, { recursive: true, force: true })));
+});
+
+describe('smoke suite', () => {
+  it('loads smoke fixtures from JSON', async () => {
+    const fixturePath = await createFixturesFile([
+      {
+        name: 'openclaw',
+        target: '../openclaw',
+        expectations: {
+          minCycles: 1,
+        },
+      },
+    ]);
+
+    const fixtures = await loadSmokeFixtures(fixturePath);
+    expect(fixtures).toEqual([
+      {
+        name: 'openclaw',
+        target: '../openclaw',
+        expectations: {
+          minCycles: 1,
+          exactCycles: undefined,
+          maxCycles: undefined,
+          minClassifications: undefined,
+          minPatches: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('rejects invalid fixture files', async () => {
+    const fixturePath = await createFixturesFile({ name: 'broken' });
+    await expect(loadSmokeFixtures(fixturePath)).rejects.toThrow('must contain an array');
+  });
+
+  it('rejects invalid fixture entries and expectation blocks', async () => {
+    const fixturePath = await createFixturesFile([
+      null,
+      {
+        name: 'broken',
+        target: '../broken',
+        expectations: 42,
+      },
+    ]);
+
+    await expect(loadSmokeFixtures(fixturePath)).rejects.toThrow('must be an object');
+  });
+
+  it('runs the smoke suite and reports pass/fail results with stage information', async () => {
+    const scanRepository = vi
+      .fn()
+      .mockResolvedValueOnce({
+        scanId: 1,
+        repoPath: TEST_REPO_ONE_PATH,
+        cyclesFound: 2,
+      })
+      .mockRejectedValueOnce(new Error('Validation failed: the original cycle is still present.'));
+
+    const report = await runSmokeSuite(
+      [
+        {
+          name: 'repo-one',
+          target: '../repo-one',
+          expectations: {
+            minCycles: 2,
+            minClassifications: {
+              autofix_extract_shared: 2,
+            },
+            minPatches: 1,
+          },
+        },
+        {
+          name: 'repo-two',
+          target: 'https://github.com/org/repo-two.git',
+        },
+      ],
+      {
+        worktreesDir: './worktrees/smoke',
+        dependencies: {
+          scanRepository,
+          getCyclesByScanId: (scanId) => (scanId === 1 ? [{ id: 11 }, { id: 12 }] : []),
+          getFixCandidatesByCycleId: (cycleId) =>
+            ({
+              11: [
+                { id: 111, classification: 'autofix_extract_shared' },
+                { id: 112, classification: 'unsupported' },
+              ],
+              12: [{ id: 121, classification: 'autofix_extract_shared' }],
+            })[cycleId] ?? [],
+          getPatchesByFixCandidateId: (candidateId) =>
+            ({
+              111: [{ id: 1 }],
+            })[candidateId] ?? [],
+        },
+      },
+    );
+
+    expect(report).toMatchObject({
+      passed: 1,
+      failed: 1,
+      results: [
+        {
+          name: 'repo-one',
+          status: 'passed',
+          cyclesFound: 2,
+          candidateCount: 3,
+          patchCount: 1,
+        },
+        {
+          name: 'repo-two',
+          status: 'failed',
+          stage: 'validation',
+          message: 'Validation failed: the original cycle is still present.',
+        },
+      ],
+    });
+    expect(formatSmokeSuiteResult(report)).toContain('PASS repo-one');
+    expect(formatSmokeSuiteResult(report)).toContain('FAIL repo-two [validation]');
+  });
+
+  it.each<ExpectationFailureCase>([
+    {
+      name: 'exact cycle expectations',
+      expectations: { exactCycles: 2 },
+      cycles: [{ id: 11 }],
+      candidatesByCycle: { 11: [] },
+      patchesByCandidate: {},
+      messageFragment: 'Expected exactly 2 cycles',
+    },
+    {
+      name: 'minimum cycle expectations',
+      expectations: { minCycles: 1 },
+      cycles: [],
+      candidatesByCycle: {},
+      patchesByCandidate: {},
+      messageFragment: 'Expected at least 1 cycles',
+    },
+    {
+      name: 'maximum cycle expectations',
+      expectations: { maxCycles: 1 },
+      cycles: [{ id: 11 }, { id: 12 }],
+      candidatesByCycle: { 11: [], 12: [] },
+      patchesByCandidate: {},
+      messageFragment: 'Expected at most 1 cycles',
+    },
+    {
+      name: 'classification expectations',
+      expectations: { minClassifications: { autofix_extract_shared: 1 } },
+      cycles: [{ id: 11 }],
+      candidatesByCycle: { 11: [{ id: 111, classification: 'unsupported' }] },
+      patchesByCandidate: { 111: [] },
+      messageFragment: 'Expected at least 1 autofix_extract_shared candidates',
+    },
+    {
+      name: 'patch expectations',
+      expectations: { minPatches: 1 },
+      cycles: [{ id: 11 }],
+      candidatesByCycle: { 11: [{ id: 111, classification: 'autofix_extract_shared' }] },
+      patchesByCandidate: { 111: [] },
+      messageFragment: 'Expected at least 1 generated patches',
+    },
+  ])('reports expectation failures for $name', async ({
+    expectations,
+    cycles,
+    candidatesByCycle,
+    patchesByCandidate,
+    messageFragment,
+  }) => {
+    const report = await runSmokeSuite(
+      [
+        {
+          name: 'repo-four',
+          target: '../repo-four',
+          expectations,
+        },
+      ],
+      {
+        dependencies: {
+          scanRepository: vi.fn().mockResolvedValue({
+            scanId: 1,
+            repoPath: TEST_REPO_FOUR_PATH,
+            cyclesFound: cycles.length,
+          }),
+          getCyclesByScanId: () => cycles,
+          getFixCandidatesByCycleId: (cycleId) => candidatesByCycle[cycleId] ?? [],
+          getPatchesByFixCandidateId: (candidateId) => patchesByCandidate[candidateId] ?? [],
+        },
+      },
+    );
+
+    expect(report.results[0]).toMatchObject({
+      status: 'failed',
+      stage: 'expectation',
+    });
+    expect(report.results[0].message).toContain(messageFragment);
+  });
+
+  it('classifies clone failures as clone-stage failures', async () => {
+    const report = await runSmokeSuite(
+      [
+        {
+          name: 'dify',
+          target: 'https://github.com/langgenius/dify.git',
+        },
+      ],
+      {
+        dependencies: {
+          scanRepository: vi.fn().mockRejectedValue(new Error('Clone error')),
+        },
+      },
+    );
+
+    expect(report.results[0]).toMatchObject({
+      status: 'failed',
+      stage: 'clone',
+      message: 'Clone error',
+    });
+  });
+
+  it('passes fixtures without explicit expectations', async () => {
+    const report = await runSmokeSuite(
+      [
+        {
+          name: 'repo-three',
+          target: '../repo-three',
+        },
+      ],
+      {
+        dependencies: {
+          scanRepository: vi.fn().mockResolvedValue({
+            scanId: 1,
+            repoPath: TEST_REPO_THREE_PATH,
+            cyclesFound: 1,
+          }),
+          getCyclesByScanId: () => [{ id: 11 }],
+          getFixCandidatesByCycleId: () => [{ id: 111, classification: 'unsupported' }],
+          getPatchesByFixCandidateId: () => [],
+        },
+      },
+    );
+
+    expect(report.results[0]).toMatchObject({
+      status: 'passed',
+      scanId: 1,
+      cyclesFound: 1,
+      candidateCount: 1,
+      patchCount: 0,
+    });
+  });
+});

--- a/cli/smoke.ts
+++ b/cli/smoke.ts
@@ -1,0 +1,312 @@
+import fs from 'node:fs/promises';
+import { getCyclesByScanId, getFixCandidatesByCycleId, getPatchesByFixCandidateId } from '../db/index.js';
+import { scanRepository } from './scanner.js';
+
+export interface SmokeFixtureExpectations {
+  exactCycles?: number;
+  minCycles?: number;
+  maxCycles?: number;
+  minClassifications?: Record<string, number>;
+  minPatches?: number;
+}
+
+export interface SmokeFixture {
+  name: string;
+  target: string;
+  expectations?: SmokeFixtureExpectations;
+}
+
+export type SmokeStage = 'clone' | 'scan' | 'validation' | 'expectation';
+
+export interface SmokeFixtureResult {
+  name: string;
+  target: string;
+  status: 'passed' | 'failed';
+  stage?: SmokeStage;
+  message?: string;
+  scanId?: number;
+  cyclesFound?: number;
+  candidateCount?: number;
+  patchCount?: number;
+  classifications?: Record<string, number>;
+}
+
+export interface SmokeSuiteResult {
+  results: SmokeFixtureResult[];
+  passed: number;
+  failed: number;
+}
+
+export interface SmokeSuiteOptions {
+  worktreesDir?: string;
+  dependencies?: SmokeSuiteDependencies;
+}
+
+export interface SmokeSuiteDependencies {
+  scanRepository?: typeof scanRepository;
+  getCyclesByScanId?: (scanId: number) => Array<{ id: number }>;
+  getFixCandidatesByCycleId?: (cycleId: number) => Array<{ id: number; classification: string }>;
+  getPatchesByFixCandidateId?: (candidateId: number) => Array<unknown>;
+}
+
+interface SmokeMetrics {
+  cyclesFound: number;
+  candidateCount: number;
+  patchCount: number;
+  classifications: Record<string, number>;
+}
+
+export async function loadSmokeFixtures(fixturesPath: string): Promise<SmokeFixture[]> {
+  const contents = await fs.readFile(fixturesPath, 'utf8');
+  const parsed = JSON.parse(contents) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(`Smoke fixture file must contain an array: ${fixturesPath}`);
+  }
+
+  return parsed.map((item, index) => normalizeSmokeFixture(item, fixturesPath, index));
+}
+
+export async function runSmokeSuite(
+  fixtures: SmokeFixture[],
+  options: SmokeSuiteOptions = {},
+): Promise<SmokeSuiteResult> {
+  const worktreesDir = options.worktreesDir ?? './worktrees/smoke';
+  const dependencies = options.dependencies;
+  const results: SmokeFixtureResult[] = [];
+
+  for (const fixture of fixtures) {
+    results.push(await runSmokeFixture(fixture, worktreesDir, dependencies));
+  }
+
+  return {
+    results,
+    passed: results.filter((result) => result.status === 'passed').length,
+    failed: results.filter((result) => result.status === 'failed').length,
+  };
+}
+
+export function formatSmokeSuiteResult(result: SmokeSuiteResult): string {
+  const lines = result.results.map((fixtureResult) => {
+    if (fixtureResult.status === 'passed') {
+      const summary = [
+        `${fixtureResult.cyclesFound ?? 0} cycles`,
+        `${fixtureResult.candidateCount ?? 0} candidates`,
+        `${fixtureResult.patchCount ?? 0} patches`,
+      ].join(', ');
+      const classifications = formatClassificationCounts(fixtureResult.classifications);
+      const classificationSuffix = classifications ? ` (${classifications})` : '';
+      return `PASS ${fixtureResult.name}: ${summary}${classificationSuffix}`;
+    }
+
+    return `FAIL ${fixtureResult.name} [${fixtureResult.stage ?? 'scan'}]: ${fixtureResult.message ?? 'Unknown failure'}`;
+  });
+
+  lines.push(`Smoke suite complete: ${result.passed} passed, ${result.failed} failed.`);
+  return lines.join('\n');
+}
+
+async function runSmokeFixture(
+  fixture: SmokeFixture,
+  worktreesDir: string,
+  dependencies: SmokeSuiteDependencies | undefined,
+): Promise<SmokeFixtureResult> {
+  const runScan = dependencies?.scanRepository ?? scanRepository;
+
+  try {
+    const scanResult = await runScan(fixture.target, worktreesDir);
+    const metrics = collectSmokeMetrics(scanResult.scanId, dependencies);
+    const failureMessage = evaluateSmokeExpectations(fixture.expectations, metrics);
+
+    if (failureMessage) {
+      return {
+        name: fixture.name,
+        target: fixture.target,
+        status: 'failed',
+        stage: 'expectation',
+        message: failureMessage,
+        scanId: scanResult.scanId,
+        ...metrics,
+      };
+    }
+
+    return {
+      name: fixture.name,
+      target: fixture.target,
+      status: 'passed',
+      scanId: scanResult.scanId,
+      ...metrics,
+    };
+  } catch (error) {
+    return {
+      name: fixture.name,
+      target: fixture.target,
+      status: 'failed',
+      stage: inferFailureStage(error),
+      message: getErrorMessage(error),
+    };
+  }
+}
+
+function collectSmokeMetrics(scanId: number, dependencies: SmokeSuiteDependencies | undefined): SmokeMetrics {
+  const listCycles =
+    dependencies?.getCyclesByScanId ??
+    ((currentScanId: number) => getCyclesByScanId.all(currentScanId) as Array<{ id: number }>);
+  const listCandidates =
+    dependencies?.getFixCandidatesByCycleId ??
+    ((cycleId: number) => getFixCandidatesByCycleId.all(cycleId) as Array<{ id: number; classification: string }>);
+  const listPatches =
+    dependencies?.getPatchesByFixCandidateId ??
+    ((candidateId: number) => getPatchesByFixCandidateId.all(candidateId) as Array<unknown>);
+
+  const cycles = listCycles(scanId);
+  const classifications: Record<string, number> = {};
+  let candidateCount = 0;
+  let patchCount = 0;
+
+  for (const cycle of cycles) {
+    const candidates = listCandidates(cycle.id);
+    candidateCount += candidates.length;
+
+    for (const candidate of candidates) {
+      classifications[candidate.classification] = (classifications[candidate.classification] ?? 0) + 1;
+      patchCount += listPatches(candidate.id).length;
+    }
+  }
+
+  return {
+    cyclesFound: cycles.length,
+    candidateCount,
+    patchCount,
+    classifications,
+  };
+}
+
+function evaluateSmokeExpectations(
+  expectations: SmokeFixtureExpectations | undefined,
+  metrics: SmokeMetrics,
+): string | null {
+  if (!expectations) {
+    return null;
+  }
+
+  if (typeof expectations.exactCycles === 'number' && metrics.cyclesFound !== expectations.exactCycles) {
+    return `Expected exactly ${expectations.exactCycles} cycles, found ${metrics.cyclesFound}.`;
+  }
+
+  if (typeof expectations.minCycles === 'number' && metrics.cyclesFound < expectations.minCycles) {
+    return `Expected at least ${expectations.minCycles} cycles, found ${metrics.cyclesFound}.`;
+  }
+
+  if (typeof expectations.maxCycles === 'number' && metrics.cyclesFound > expectations.maxCycles) {
+    return `Expected at most ${expectations.maxCycles} cycles, found ${metrics.cyclesFound}.`;
+  }
+
+  if (expectations.minClassifications) {
+    for (const [classification, minimum] of Object.entries(expectations.minClassifications)) {
+      const found = metrics.classifications[classification] ?? 0;
+      if (found < minimum) {
+        return `Expected at least ${minimum} ${classification} candidates, found ${found}.`;
+      }
+    }
+  }
+
+  if (typeof expectations.minPatches === 'number' && metrics.patchCount < expectations.minPatches) {
+    return `Expected at least ${expectations.minPatches} generated patches, found ${metrics.patchCount}.`;
+  }
+
+  return null;
+}
+
+function inferFailureStage(error: unknown): SmokeStage {
+  const message = getErrorMessage(error).toLowerCase();
+
+  if (message.includes('validation') || message.includes('typescript') || message.includes('tsc')) {
+    return 'validation';
+  }
+
+  if (message.includes('clone') || message.includes('fetch') || message.includes('download')) {
+    return 'clone';
+  }
+
+  return 'scan';
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return typeof error === 'string' ? error : 'Unknown smoke suite failure';
+}
+
+function normalizeSmokeFixture(item: unknown, fixturesPath: string, index: number): SmokeFixture {
+  if (!item || typeof item !== 'object') {
+    throw new TypeError(`Smoke fixture ${index + 1} in ${fixturesPath} must be an object.`);
+  }
+
+  const fixture = item as Record<string, unknown>;
+  if (typeof fixture.name !== 'string' || typeof fixture.target !== 'string') {
+    throw new TypeError(`Smoke fixture ${index + 1} in ${fixturesPath} must include string name and target fields.`);
+  }
+
+  return {
+    name: fixture.name,
+    target: fixture.target,
+    expectations: normalizeExpectations(fixture.expectations, fixturesPath, index),
+  };
+}
+
+function normalizeExpectations(
+  value: unknown,
+  fixturesPath: string,
+  index: number,
+): SmokeFixtureExpectations | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== 'object') {
+    throw new TypeError(`Smoke fixture ${index + 1} in ${fixturesPath} has an invalid expectations block.`);
+  }
+
+  const expectations = value as Record<string, unknown>;
+  const minClassifications = expectations.minClassifications;
+  if (minClassifications !== undefined && (!minClassifications || typeof minClassifications !== 'object')) {
+    throw new TypeError(`Smoke fixture ${index + 1} in ${fixturesPath} has invalid minClassifications.`);
+  }
+
+  return {
+    exactCycles: asOptionalNumber(expectations.exactCycles),
+    minCycles: asOptionalNumber(expectations.minCycles),
+    maxCycles: asOptionalNumber(expectations.maxCycles),
+    minClassifications: minClassifications as Record<string, number> | undefined,
+    minPatches: asOptionalNumber(expectations.minPatches),
+  };
+}
+
+function asOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function formatClassificationCounts(classifications: Record<string, number> | undefined): string {
+  if (!classifications || Object.keys(classifications).length === 0) {
+    return '';
+  }
+
+  const sortedEntries: Array<[string, number]> = [];
+  for (const entry of Object.entries(classifications)) {
+    const insertionIndex = sortedEntries.findIndex(([existingClassification]) => {
+      return entry[0].localeCompare(existingClassification) < 0;
+    });
+
+    if (insertionIndex === -1) {
+      sortedEntries.push(entry);
+      continue;
+    }
+
+    sortedEntries.splice(insertionIndex, 0, entry);
+  }
+
+  return sortedEntries.map(([classification, count]) => `${classification}:${count}`).join(', ');
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "biome format --write .",
     "check": "biome check --write . && eslint --fix . && pnpm run test:coverage",
     "scan": "tsx cli/index.ts scan",
+    "smoke": "tsx cli/index.ts smoke",
     "explain": "tsx cli/index.ts explain",
     "profile:repo": "tsx cli/index.ts profile:repo",
     "mine:corpus": "tsx cli/index.ts mine:corpus",

--- a/smoke.fixtures.json
+++ b/smoke.fixtures.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "openclaw",
+    "target": "../openclaw",
+    "expectations": {
+      "minCycles": 1,
+      "minClassifications": {
+        "autofix_extract_shared": 1
+      }
+    }
+  },
+  {
+    "name": "dify",
+    "target": "https://github.com/langgenius/dify.git",
+    "expectations": {
+      "minCycles": 1,
+      "minClassifications": {
+        "unsupported": 1
+      }
+    }
+  },
+  {
+    "name": "jan",
+    "target": "https://github.com/janhq/jan.git",
+    "expectations": {
+      "maxCycles": 0
+    }
+  }
+]


### PR DESCRIPTION
Closes #22

## Summary
- add a fixture-driven smoke harness for real repository scans and expectation checks
- add a `smoke` CLI command and default `smoke.fixtures.json` seed file
- cover fixture loading, stage-level failures, and CLI behavior with targeted tests

## Verification
- `../../node_modules/.bin/vitest run`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `../../node_modules/.bin/eslint cli/smoke.ts cli/smoke.test.ts cli/index.ts cli/index.test.ts`
- `../../node_modules/.bin/biome check cli/smoke.ts cli/smoke.test.ts cli/index.ts cli/index.test.ts package.json smoke.fixtures.json`
- `../../node_modules/.bin/vite build`
- `git diff --check`