### PR TITLE
Clear remaining repo lint baseline failures

### DIFF
--- a/backend/server.test.ts
+++ b/backend/server.test.ts
@@ -1,8 +1,12 @@
+import path from 'node:path';
 import type { Database as DatabaseType } from 'better-sqlite3';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createDatabase, createStatements, initSchema } from '../db/index.js';
 import { buildApp } from './server.js';
+
+const fixtureRoot = path.join(process.cwd(), '.test-fixtures');
+const replayDetailPath = path.join(fixtureRoot, 'replay-detail');
 
 describe('backend API', () => {
   let app: FastifyInstance;
@@ -448,7 +452,7 @@ describe('backend API', () => {
         owner: 'replay-detail',
         name: 'repo',
         default_branch: 'main',
-        local_path: '/tmp/replay-detail',
+        local_path: replayDetailPath,
       });
       const scanInfo = stmts.addScan.run({
         repository_id: repoInfo.lastInsertRowid,
@@ -477,17 +481,17 @@ describe('backend API', () => {
       stmts.addPatchReplay.run({
         patch_id: patchInfo.lastInsertRowid,
         scan_id: scanInfo.lastInsertRowid,
-        source_target: '/tmp/replay-detail',
+        source_target: replayDetailPath,
         commit_sha: 'replay1',
         replay_bundle: JSON.stringify({
           scan_id: scanInfo.lastInsertRowid,
-          source_target: '/tmp/replay-detail',
+          source_target: replayDetailPath,
           commit_sha: 'replay1',
           repository: {
             owner: 'replay-detail',
             name: 'repo',
             default_branch: 'main',
-            local_path: '/tmp/replay-detail',
+            local_path: replayDetailPath,
           },
           cycle: {
             path: ['x.ts', 'y.ts'],
@@ -520,7 +524,7 @@ describe('backend API', () => {
       });
       expect(response.statusCode).toBe(200);
       const detail = response.json();
-      expect(detail.replay.source_target).toBe('/tmp/replay-detail');
+      expect(detail.replay.source_target).toBe(replayDetailPath);
       expect(detail.replay.commit_sha).toBe('replay1');
       expect(detail.replay.validation.summary).toBe('clean');
       expect(detail.replay.file_snapshots).toHaveLength(1);

--- a/src/routes/repositories.$id.cycles.$cycleId.tsx
+++ b/src/routes/repositories.$id.cycles.$cycleId.tsx
@@ -2,6 +2,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { fetchCycleDetail, type ReviewDecision, submitReviewDecision } from '../lib/api';
 
+type CycleDetailData = Awaited<ReturnType<typeof fetchCycleDetail>>;
+
 type ReplayBundle = {
   source_target?: string | null;
   commit_sha?: string | null;
@@ -62,11 +64,8 @@ function CycleDetail() {
   if (isLoading) return <div className="p-8">Loading cycle details...</div>;
   if (error) return <div className="p-8 text-red-600">Error loading cycle details</div>;
 
-  let statusColor = 'text-gray-800';
-  if (cycle?.validation_status === 'passed') statusColor = 'text-green-600';
-  if (cycle?.validation_status === 'failed') statusColor = 'text-red-600';
+  const statusColor = getValidationStatusColor(cycle?.validation_status);
   const replay = cycle?.replay as ReplayBundle | null | undefined;
-
   const canReview = Boolean(cycle?.patch_id);
 
   return (
@@ -80,143 +79,10 @@ function CycleDetail() {
 
       {cycle && (
         <div className="space-y-6">
-          <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
-            <h2 className="text-xl font-semibold mb-4">Details</h2>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <span className="text-gray-500 block text-sm">Classification</span>
-                <span className="font-medium bg-gray-100 px-2 py-1 rounded-md mt-1 inline-block">
-                  {String(cycle.classification || 'Unknown')}
-                </span>
-              </div>
-              <div>
-                <span className="text-gray-500 block text-sm">Confidence</span>
-                <span className="font-medium">
-                  {cycle.confidence ? `${(Number(cycle.confidence) * 100).toFixed(0)}%` : 'N/A'}
-                </span>
-              </div>
-              <div>
-                <span className="text-gray-500 block text-sm">Review Status</span>
-                <span className="font-medium bg-gray-100 px-2 py-1 rounded-md mt-1 inline-block">
-                  {String(cycle.review_status || 'pending')}
-                </span>
-                {cycle.review_notes && <p className="mt-2 text-sm text-gray-500">{cycle.review_notes}</p>}
-              </div>
-              <div className="col-span-2">
-                <span className="text-gray-500 block text-sm">Cycle Path</span>
-                <div className="bg-gray-50 p-3 rounded-md mt-1 font-mono text-sm break-all">
-                  {cycle.cycle_path ? (cycle.cycle_path as string[]).join(' → ') : 'No path available'}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
-            <h2 className="text-xl font-semibold mb-4">Dependency Summary</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="text-sm font-semibold text-gray-700 mb-2">Before (Original Cycle)</h3>
-                {cycle.raw_payload ? (
-                  <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 h-64 overflow-y-auto">
-                    <code>{JSON.stringify(cycle.raw_payload, null, 2)}</code>
-                  </pre>
-                ) : (
-                  <p className="text-gray-500 italic text-sm">No raw payload available.</p>
-                )}
-              </div>
-              <div>
-                <h3 className="text-sm font-semibold text-gray-700 mb-2">After (Validation)</h3>
-                <div className="mb-2">
-                  <span className="text-gray-500 text-sm">Status: </span>
-                  <span className={`font-medium ${statusColor}`}>{cycle.validation_status || 'Pending / N/A'}</span>
-                </div>
-                {cycle.validation_summary ? (
-                  <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 h-56 overflow-y-auto w-full">
-                    <code>{cycle.validation_summary}</code>
-                  </pre>
-                ) : (
-                  <p className="text-gray-500 italic text-sm mt-4">No validation summary available.</p>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
-            <h2 className="text-xl font-semibold mb-4">Replay Provenance</h2>
-            {replay ? (
-              <div className="space-y-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <span className="text-gray-500 block text-sm">Source Target</span>
-                    <span className="font-medium break-all">{replay.source_target || 'N/A'}</span>
-                  </div>
-                  <div>
-                    <span className="text-gray-500 block text-sm">Commit SHA</span>
-                    <span className="font-medium font-mono break-all">{replay.commit_sha || 'N/A'}</span>
-                  </div>
-                  <div>
-                    <span className="text-gray-500 block text-sm">Repository</span>
-                    <span className="font-medium">
-                      {replay.repository?.owner && replay.repository?.name
-                        ? `${replay.repository.owner}/${replay.repository.name}`
-                        : 'N/A'}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-gray-500 block text-sm">Repository Path</span>
-                    <span className="font-medium break-all">{replay.repository?.local_path || 'N/A'}</span>
-                  </div>
-                  <div>
-                    <span className="text-gray-500 block text-sm">Classification</span>
-                    <span className="font-medium">
-                      {replay.candidate?.classification || String(cycle.classification || 'Unknown')}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-gray-500 block text-sm">Validation</span>
-                    <span className={`font-medium ${statusColor}`}>
-                      {replay.validation?.status || cycle.validation_status || 'Pending / N/A'}
-                    </span>
-                  </div>
-                </div>
-
-                <div>
-                  <span className="text-gray-500 block text-sm mb-2">
-                    File Snapshots ({replay.file_snapshots?.length || 0})
-                  </span>
-                  {replay.file_snapshots?.length ? (
-                    <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 max-h-72 overflow-y-auto">
-                      <code>{JSON.stringify(replay.file_snapshots, null, 2)}</code>
-                    </pre>
-                  ) : (
-                    <p className="text-gray-500 italic text-sm">No file snapshots available.</p>
-                  )}
-                </div>
-
-                {replay.validation?.summary ? (
-                  <div>
-                    <span className="text-gray-500 block text-sm mb-2">Validation Summary</span>
-                    <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 max-h-56 overflow-y-auto">
-                      <code>{replay.validation.summary}</code>
-                    </pre>
-                  </div>
-                ) : null}
-              </div>
-            ) : (
-              <p className="text-gray-500 italic text-sm">No replay bundle stored for this patch yet.</p>
-            )}
-          </div>
-
-          <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
-            <h2 className="text-xl font-semibold mb-4">Proposed Patch</h2>
-            {cycle.patch ? (
-              <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-sm font-mono border border-gray-200">
-                <code>{cycle.patch}</code>
-              </pre>
-            ) : (
-              <p className="text-gray-500 italic">No patch available for this cycle.</p>
-            )}
-          </div>
+          <CycleDetailsSection cycle={cycle} />
+          <DependencySummarySection cycle={cycle} statusColor={statusColor} />
+          <ReplayProvenanceSection cycle={cycle} replay={replay} statusColor={statusColor} />
+          <PatchSection cycle={cycle} />
 
           <div className="flex gap-4 justify-end">
             <button
@@ -262,4 +128,184 @@ function CycleDetail() {
       )}
     </div>
   );
+}
+
+function CycleDetailsSection({ cycle }: { cycle: CycleDetailData }) {
+  const cyclePath = Array.isArray(cycle.cycle_path) ? cycle.cycle_path.join(' → ') : 'No path available';
+  const confidence = typeof cycle.confidence === 'number' ? `${(Number(cycle.confidence) * 100).toFixed(0)}%` : 'N/A';
+
+  return (
+    <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
+      <h2 className="text-xl font-semibold mb-4">Details</h2>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <span className="text-gray-500 block text-sm">Classification</span>
+          <span className="font-medium bg-gray-100 px-2 py-1 rounded-md mt-1 inline-block">
+            {String(cycle.classification || 'Unknown')}
+          </span>
+        </div>
+        <div>
+          <span className="text-gray-500 block text-sm">Confidence</span>
+          <span className="font-medium">{confidence}</span>
+        </div>
+        <div>
+          <span className="text-gray-500 block text-sm">Review Status</span>
+          <span className="font-medium bg-gray-100 px-2 py-1 rounded-md mt-1 inline-block">
+            {String(cycle.review_status || 'pending')}
+          </span>
+          {cycle.review_notes && <p className="mt-2 text-sm text-gray-500">{cycle.review_notes}</p>}
+        </div>
+        <div className="col-span-2">
+          <span className="text-gray-500 block text-sm">Cycle Path</span>
+          <div className="bg-gray-50 p-3 rounded-md mt-1 font-mono text-sm break-all">{cyclePath}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DependencySummarySection({ cycle, statusColor }: { cycle: CycleDetailData; statusColor: string }) {
+  return (
+    <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
+      <h2 className="text-xl font-semibold mb-4">Dependency Summary</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">Before (Original Cycle)</h3>
+          {cycle.raw_payload ? (
+            <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 h-64 overflow-y-auto">
+              <code>{JSON.stringify(cycle.raw_payload, null, 2)}</code>
+            </pre>
+          ) : (
+            <p className="text-gray-500 italic text-sm">No raw payload available.</p>
+          )}
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">After (Validation)</h3>
+          <div className="mb-2">
+            <span className="text-gray-500 text-sm">Status: </span>
+            <span className={`font-medium ${statusColor}`}>{cycle.validation_status || 'Pending / N/A'}</span>
+          </div>
+          {cycle.validation_summary ? (
+            <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 h-56 overflow-y-auto w-full">
+              <code>{cycle.validation_summary}</code>
+            </pre>
+          ) : (
+            <p className="text-gray-500 italic text-sm mt-4">No validation summary available.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReplayProvenanceSection({
+  cycle,
+  replay,
+  statusColor,
+}: {
+  cycle: CycleDetailData;
+  replay: ReplayBundle | null | undefined;
+  statusColor: string;
+}) {
+  const repositoryLabel =
+    replay?.repository?.owner && replay.repository.name
+      ? `${replay.repository.owner}/${replay.repository.name}`
+      : 'N/A';
+  const fileSnapshotCount = replay?.file_snapshots?.length || 0;
+
+  return (
+    <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
+      <h2 className="text-xl font-semibold mb-4">Replay Provenance</h2>
+      {replay ? (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <MetadataField label="Source Target" value={replay.source_target || 'N/A'} breakAll />
+            <MetadataField label="Commit SHA" value={replay.commit_sha || 'N/A'} mono breakAll />
+            <MetadataField label="Repository" value={repositoryLabel} />
+            <MetadataField label="Repository Path" value={replay.repository?.local_path || 'N/A'} breakAll />
+            <MetadataField
+              label="Classification"
+              value={replay.candidate?.classification || String(cycle.classification || 'Unknown')}
+            />
+            <div>
+              <span className="text-gray-500 block text-sm">Validation</span>
+              <span className={`font-medium ${statusColor}`}>
+                {replay.validation?.status || cycle.validation_status || 'Pending / N/A'}
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <span className="text-gray-500 block text-sm mb-2">File Snapshots ({fileSnapshotCount})</span>
+            {replay.file_snapshots?.length ? (
+              <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 max-h-72 overflow-y-auto">
+                <code>{JSON.stringify(replay.file_snapshots, null, 2)}</code>
+              </pre>
+            ) : (
+              <p className="text-gray-500 italic text-sm">No file snapshots available.</p>
+            )}
+          </div>
+
+          {replay.validation?.summary ? (
+            <div>
+              <span className="text-gray-500 block text-sm mb-2">Validation Summary</span>
+              <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 max-h-56 overflow-y-auto">
+                <code>{replay.validation.summary}</code>
+              </pre>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-gray-500 italic text-sm">No replay bundle stored for this patch yet.</p>
+      )}
+    </div>
+  );
+}
+
+function PatchSection({ cycle }: { cycle: CycleDetailData }) {
+  return (
+    <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
+      <h2 className="text-xl font-semibold mb-4">Proposed Patch</h2>
+      {cycle.patch ? (
+        <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-sm font-mono border border-gray-200">
+          <code>{cycle.patch}</code>
+        </pre>
+      ) : (
+        <p className="text-gray-500 italic">No patch available for this cycle.</p>
+      )}
+    </div>
+  );
+}
+
+function MetadataField({
+  label,
+  value,
+  mono = false,
+  breakAll = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  breakAll?: boolean;
+}) {
+  const className = ['font-medium', mono ? 'font-mono' : '', breakAll ? 'break-all' : ''].filter(Boolean).join(' ');
+
+  return (
+    <div>
+      <span className="text-gray-500 block text-sm">{label}</span>
+      <span className={className}>{value}</span>
+    </div>
+  );
+}
+
+function getValidationStatusColor(validationStatus: string | null | undefined): string {
+  if (validationStatus === 'passed') {
+    return 'text-green-600';
+  }
+
+  if (validationStatus === 'failed') {
+    return 'text-red-600';
+  }
+
+  return 'text-gray-800';
 }


### PR DESCRIPTION
## Summary
- replace repo-local test fixture path literals that were tripping the public writable directory lint rule
- split the cycle detail route into smaller render helpers so it stays under the repo's complexity cap
- restore a clean `eslint .` baseline on `main`

## Verification
- `../../node_modules/.bin/eslint .`
- `../../node_modules/.bin/biome check .`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `../../node_modules/.bin/vitest run --config vitest.config.ts`
- `../../node_modules/.bin/vitest run --config vitest.config.ts backend/server.test.ts`
- `../../node_modules/.bin/vite build`

Closes #57
