### PR TITLE
Persist and review ranked candidate shortlists

### DIFF
--- a/backend/server.test.ts
+++ b/backend/server.test.ts
@@ -250,6 +250,56 @@ describe('backend API', () => {
       expect(findings[0].cycle_path).toEqual(['a.ts', 'b.ts']);
     });
 
+    it('GET /api/repositories/:id/findings only returns the primary ranked candidate', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'ranked-findings',
+        name: 'repo',
+        default_branch: null,
+        local_path: null,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'ranked1',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        participating_files: JSON.stringify(['a.ts', 'b.ts', 'a.ts']),
+        raw_payload: null,
+      });
+      stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        strategy: 'extract_shared',
+        planner_rank: 2,
+        classification: 'autofix_extract_shared',
+        confidence: 0.82,
+        reasons: JSON.stringify(['secondary']),
+      });
+      stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        strategy: 'import_type',
+        planner_rank: 1,
+        classification: 'autofix_import_type',
+        confidence: 0.94,
+        reasons: JSON.stringify(['primary']),
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/repositories/${repoInfo.lastInsertRowid}/findings`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual([
+        expect.objectContaining({
+          classification: 'autofix_import_type',
+          confidence: 0.94,
+        }),
+      ]);
+    });
+
     it('GET /api/findings filters by repository, classification, validation, review, cycle size, and search', async () => {
       const stmts = createStatements(testDb);
       const repoInfo = stmts.addRepository.run({
@@ -444,6 +494,109 @@ describe('backend API', () => {
       expect(detail.patch).toContain('--- a/p.ts');
       expect(detail.patch_id).toBeDefined();
       expect(detail.review_status).toBe('approved');
+      expect(detail.candidates).toHaveLength(1);
+    });
+
+    it('GET /api/repositories/:id/cycles/:cycleId returns ranked candidate alternatives', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'candidate-detail',
+        name: 'repo',
+        default_branch: null,
+        local_path: null,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'candidate1',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        participating_files: JSON.stringify(['a.ts', 'b.ts', 'a.ts']),
+        raw_payload: JSON.stringify({
+          analysis: {
+            planner: {
+              selectionSummary: 'Selected import_type after ranking two candidates.',
+            },
+          },
+        }),
+      });
+      const primaryCandidate = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        strategy: 'import_type',
+        planner_rank: 1,
+        classification: 'autofix_import_type',
+        confidence: 0.93,
+        upstreamability_score: 0.96,
+        reasons: JSON.stringify(['primary']),
+        summary: 'Most upstreamable option.',
+        score_breakdown: JSON.stringify(['base 0.97']),
+        signals: JSON.stringify({ introducesNewFile: false }),
+      });
+      const secondaryCandidate = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        strategy: 'extract_shared',
+        planner_rank: 2,
+        classification: 'autofix_extract_shared',
+        confidence: 0.81,
+        upstreamability_score: 0.76,
+        reasons: JSON.stringify(['secondary']),
+        summary: 'Fallback shared extraction.',
+        score_breakdown: JSON.stringify(['base 0.68']),
+        signals: JSON.stringify({ introducesNewFile: true }),
+      });
+      const secondaryPatch = stmts.addPatch.run({
+        fix_candidate_id: secondaryCandidate.lastInsertRowid,
+        patch_text: '--- a/a.ts\n+++ b/a.ts',
+        touched_files: JSON.stringify(['a.ts', 'helper.shared.ts']),
+        validation_status: 'failed',
+        validation_summary: 'Introduced a new cycle.',
+      });
+      stmts.addReviewDecision.run({
+        patch_id: secondaryPatch.lastInsertRowid,
+        decision: 'rejected',
+        notes: 'Too invasive',
+      });
+      const primaryPatch = stmts.addPatch.run({
+        fix_candidate_id: primaryCandidate.lastInsertRowid,
+        patch_text: '--- a/a.ts\n+++ b/a.ts',
+        touched_files: JSON.stringify(['a.ts']),
+        validation_status: 'passed',
+        validation_summary: 'Validation passed.',
+      });
+      stmts.addReviewDecision.run({
+        patch_id: primaryPatch.lastInsertRowid,
+        decision: 'approved',
+        notes: 'Ship it',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/repositories/${repoInfo.lastInsertRowid}/cycles/${cycleInfo.lastInsertRowid}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const detail = response.json();
+      expect(detail.classification).toBe('autofix_import_type');
+      expect(detail.candidates).toHaveLength(2);
+      expect(detail.candidates.map((candidate: { planner_rank: number }) => candidate.planner_rank)).toEqual([1, 2]);
+      expect(detail.candidates[0]).toEqual(
+        expect.objectContaining({
+          classification: 'autofix_import_type',
+          upstreamability_score: 0.96,
+          patch_id: primaryPatch.lastInsertRowid,
+          review_status: 'approved',
+        }),
+      );
+      expect(detail.candidates[1]).toEqual(
+        expect.objectContaining({
+          classification: 'autofix_extract_shared',
+          patch_id: secondaryPatch.lastInsertRowid,
+          validation_status: 'failed',
+          review_status: 'rejected',
+        }),
+      );
     });
 
     it('GET /api/repositories/:id/cycles/:cycleId returns replay provenance when available', async () => {

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -4,15 +4,11 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import {
   type CycleDTO,
   createStatements,
-  type FixCandidateDTO,
   getDb,
   initSchema,
-  type PatchDTO,
-  type PatchReplayDTO,
   type RepositoryDTO,
   type RepositoryStatus,
   type ReviewDecision,
-  type ReviewDecisionDTO,
 } from '../db/index.js';
 
 interface FindingsFilters {
@@ -47,6 +43,31 @@ interface FindingsQueryRow {
   cycle_size: number;
 }
 
+interface CycleDetailCandidateRow {
+  id: number;
+  cycle_id: number;
+  strategy: string | null;
+  planner_rank: number;
+  classification: string;
+  confidence: number;
+  upstreamability_score: number | null;
+  reasons: string | null;
+  summary: string | null;
+  score_breakdown: string | null;
+  signals: string | null;
+  patch_id: number | null;
+  patch_text: string | null;
+  touched_files: string | null;
+  validation_status: string | null;
+  validation_summary: string | null;
+  replay_bundle: string | null;
+  replay_scan_id: number | null;
+  replay_source_target: string | null;
+  replay_commit_sha: string | null;
+  review_status: string | null;
+  review_notes: string | null;
+}
+
 function parseJsonArray(value: string | null): string[] {
   if (!value) {
     return [];
@@ -78,6 +99,40 @@ function parseReplayBundle(value: string): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+function parseFixCandidate(row: CycleDetailCandidateRow) {
+  const replay = row.replay_bundle ? parseReplayBundle(row.replay_bundle) : null;
+
+  return {
+    id: row.id,
+    cycle_id: row.cycle_id,
+    strategy: row.strategy,
+    planner_rank: row.planner_rank,
+    classification: row.classification,
+    confidence: row.confidence,
+    upstreamability_score: row.upstreamability_score,
+    reasons: parseJsonValue(row.reasons, null as string[] | null),
+    summary: row.summary,
+    score_breakdown: parseJsonValue(row.score_breakdown, [] as string[]) ?? [],
+    signals: parseJsonValue(row.signals, {} as Record<string, unknown>) ?? {},
+    patch_id: row.patch_id,
+    patch: row.patch_text,
+    touched_files: parseJsonArray(row.touched_files),
+    validation_status: row.validation_status ?? 'pending',
+    validation_summary: row.validation_summary,
+    replay: replay
+      ? {
+          patch_id: row.patch_id,
+          scan_id: row.replay_scan_id,
+          source_target: row.replay_source_target,
+          commit_sha: row.replay_commit_sha,
+          ...replay,
+        }
+      : null,
+    review_status: row.review_status ?? 'pending',
+    review_notes: row.review_notes ?? null,
+  };
 }
 
 function toOptionalNumber(value: string | undefined): number | undefined {
@@ -119,8 +174,20 @@ function buildFindingsQuery(filters: FindingsFilters): { query: string; params: 
     FROM cycles c
     INNER JOIN scans s ON s.id = c.scan_id
     INNER JOIN repositories r ON r.id = s.repository_id
-    LEFT JOIN fix_candidates fc ON fc.cycle_id = c.id
-    LEFT JOIN patches p ON p.fix_candidate_id = fc.id
+    LEFT JOIN fix_candidates fc ON fc.id = (
+      SELECT id
+      FROM fix_candidates
+      WHERE cycle_id = c.id
+      ORDER BY planner_rank ASC, id ASC
+      LIMIT 1
+    )
+    LEFT JOIN patches p ON p.id = (
+      SELECT id
+      FROM patches
+      WHERE fix_candidate_id = fc.id
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    )
     LEFT JOIN review_decisions rd ON rd.id = (
       SELECT id
       FROM review_decisions
@@ -414,51 +481,62 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
       return { error: 'Cycle not found' };
     }
 
-    const fixCandidate = db.prepare('SELECT * FROM fix_candidates WHERE cycle_id = ? LIMIT 1').get(cycleId) as
-      | FixCandidateDTO
-      | undefined;
+    const candidateRows = db
+      .prepare(
+        `
+          SELECT
+            fc.*,
+            p.id AS patch_id,
+            p.patch_text,
+            p.touched_files,
+            p.validation_status,
+            p.validation_summary,
+            pr.replay_bundle,
+            pr.scan_id AS replay_scan_id,
+            pr.source_target AS replay_source_target,
+            pr.commit_sha AS replay_commit_sha,
+            rd.decision AS review_status,
+            rd.notes AS review_notes
+          FROM fix_candidates fc
+          LEFT JOIN patches p ON p.id = (
+            SELECT id
+            FROM patches
+            WHERE fix_candidate_id = fc.id
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+          )
+          LEFT JOIN patch_replays pr ON pr.patch_id = p.id
+          LEFT JOIN review_decisions rd ON rd.id = (
+            SELECT id
+            FROM review_decisions
+            WHERE patch_id = p.id
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+          )
+          WHERE fc.cycle_id = ?
+          ORDER BY fc.planner_rank ASC, fc.id ASC
+        `,
+      )
+      .all(cycleId) as CycleDetailCandidateRow[];
 
-    let patch: PatchDTO | undefined;
-    let patchReplay: PatchReplayDTO | undefined;
-    let reviewDecision: ReviewDecisionDTO | undefined;
-
-    if (fixCandidate) {
-      patch = db.prepare('SELECT * FROM patches WHERE fix_candidate_id = ? LIMIT 1').get(fixCandidate.id) as
-        | PatchDTO
-        | undefined;
-
-      if (patch) {
-        patchReplay = db.prepare('SELECT * FROM patch_replays WHERE patch_id = ? LIMIT 1').get(patch.id) as
-          | PatchReplayDTO
-          | undefined;
-        reviewDecision = stmts.getReviewDecisionByPatchId.get(patch.id) as ReviewDecisionDTO | undefined;
-      }
-    }
-
-    const replay = patchReplay ? parseReplayBundle(patchReplay.replay_bundle) : null;
+    const candidates = candidateRows.map((candidateRow) => parseFixCandidate(candidateRow));
+    const primaryCandidate = candidates[0];
 
     return {
       ...cycle,
-      patch_id: patch?.id ?? null,
       cycle_path: parseJsonArray(cycle.participating_files),
       raw_payload: parseJsonValue(cycle.raw_payload, null),
-      classification: fixCandidate?.classification ?? null,
-      confidence: fixCandidate?.confidence ?? null,
-      reasons: parseJsonValue(fixCandidate?.reasons ?? null, null),
-      patch: patch?.patch_text ?? null,
-      validation_status: patch?.validation_status ?? null,
-      validation_summary: patch?.validation_summary ?? null,
-      replay: replay
-        ? {
-            patch_id: patchReplay?.patch_id ?? null,
-            scan_id: patchReplay?.scan_id ?? null,
-            source_target: patchReplay?.source_target ?? null,
-            commit_sha: patchReplay?.commit_sha ?? null,
-            ...replay,
-          }
-        : null,
-      review_status: reviewDecision?.decision ?? 'pending',
-      review_notes: reviewDecision?.notes ?? null,
+      patch_id: primaryCandidate?.patch_id ?? null,
+      classification: primaryCandidate?.classification ?? null,
+      confidence: primaryCandidate?.confidence ?? null,
+      reasons: primaryCandidate?.reasons ?? null,
+      patch: primaryCandidate?.patch ?? null,
+      validation_status: primaryCandidate?.validation_status ?? 'pending',
+      validation_summary: primaryCandidate?.validation_summary ?? null,
+      replay: primaryCandidate?.replay ?? null,
+      review_status: primaryCandidate?.review_status ?? 'pending',
+      review_notes: primaryCandidate?.review_notes ?? null,
+      candidates,
     };
   });
 

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -311,6 +311,129 @@ describe('Scanner Worker', () => {
     expect(candidates[0].confidence).toBe(0.9);
   });
 
+  it('persists ranked planner candidates and validates executable shortlist entries', async () => {
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(analyzeRepository).mockResolvedValue([
+      {
+        type: 'circular',
+        path: ['a.ts', 'b.ts', 'a.ts'],
+        analysis: {
+          classification: 'autofix_import_type',
+          confidence: 0.93,
+          reasons: ['selected import type candidate'],
+          upstreamabilityScore: 0.96,
+          plan: {
+            kind: 'import_type',
+            imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+          },
+          planner: {
+            cycleFiles: ['a.ts', 'b.ts', 'a.ts'],
+            cycleSize: 2,
+            cycleShape: 'two_file',
+            cycleSignals: { explicitImportEdges: 2, loadedFiles: 2, missingFiles: 0 },
+            features: {
+              cycleSize: 2,
+              cycleShape: 'two_file',
+              explicitImportEdges: 2,
+              loadedFiles: 2,
+              missingFiles: 0,
+              hasBarrelFile: false,
+              hasSharedModuleFile: false,
+              typescriptFileCount: 2,
+              tsxFileCount: 0,
+              packageManager: 'pnpm',
+              workspaceMode: 'workspace',
+              validationCommandCount: 2,
+            },
+            fallbackClassification: 'autofix_import_type',
+            fallbackConfidence: 0.93,
+            fallbackReasons: ['selected import type candidate'],
+            selectedStrategy: 'import_type',
+            selectedClassification: 'autofix_import_type',
+            selectedScore: 0.96,
+            selectionSummary: 'Selected import_type after ranking two candidates.',
+            rankedCandidates: [
+              {
+                strategy: 'import_type',
+                status: 'candidate',
+                summary: 'Least invasive option.',
+                reasons: ['selected import type candidate'],
+                signals: { introducesNewFile: false },
+                classification: 'autofix_import_type',
+                confidence: 0.93,
+                plan: {
+                  kind: 'import_type',
+                  imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+                },
+                score: 0.96,
+                scoreBreakdown: ['base 0.97'],
+              },
+              {
+                strategy: 'extract_shared',
+                status: 'candidate',
+                summary: 'Fallback shared extraction.',
+                reasons: ['secondary extraction candidate'],
+                signals: { introducesNewFile: true },
+                classification: 'autofix_extract_shared',
+                confidence: 0.84,
+                plan: {
+                  kind: 'extract_shared',
+                  sourceFile: 'b.ts',
+                  targetFile: 'a.ts',
+                  symbols: ['helperB'],
+                  sharedFile: 'helperB.shared.ts',
+                  preserveSourceExports: true,
+                },
+                score: 0.81,
+                scoreBreakdown: ['base 0.68'],
+              },
+            ],
+            attempts: [],
+          },
+        },
+      },
+    ]);
+    vi.mocked(generatePatchForCycle).mockImplementation(async (_repoPath, _cycle, analysis) => ({
+      patchText: `patch for ${analysis.classification}`,
+      touchedFiles: analysis.plan?.kind === 'extract_shared' ? ['a.ts', 'helperB.shared.ts'] : ['a.ts'],
+      validationStatus: 'pending',
+      validationSummary: 'Generated candidate patch. Validation has not run yet.',
+      fileSnapshots: [
+        {
+          path: 'a.ts',
+          before: 'before',
+          after: `after ${analysis.classification}`,
+        },
+      ],
+    }));
+
+    const result = await scanRepository('org/ranked');
+    const cycles = dbModule.getCyclesByScanId.all(result.scanId) as Array<{ id: number }>;
+    const candidates = dbModule.getFixCandidatesByCycleId.all(cycles[0].id) as Array<{
+      id: number;
+      planner_rank: number;
+      classification: string;
+      strategy: string | null;
+      upstreamability_score: number | null;
+    }>;
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates.map((candidate) => candidate.planner_rank)).toEqual([1, 2]);
+    expect(candidates.map((candidate) => candidate.classification)).toEqual([
+      'autofix_import_type',
+      'autofix_extract_shared',
+    ]);
+    expect(candidates[0].strategy).toBe('import_type');
+    expect(candidates[1].upstreamability_score).toBe(0.81);
+
+    const primaryPatches = dbModule.getPatchesByFixCandidateId.all(candidates[0].id);
+    const secondaryPatches = dbModule.getPatchesByFixCandidateId.all(candidates[1].id);
+
+    expect(primaryPatches).toHaveLength(1);
+    expect(secondaryPatches).toHaveLength(1);
+    expect(vi.mocked(generatePatchForCycle)).toHaveBeenCalledTimes(2);
+  });
+
   it('persists generated patches for executable fix plans', async () => {
     vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
     vi.mocked(analyzeRepository).mockResolvedValue([

--- a/cli/scanner/persistence.ts
+++ b/cli/scanner/persistence.ts
@@ -1,6 +1,6 @@
 import type { SimpleGit } from 'simple-git';
 import { canonicalizeCyclePath, normalizeCyclePath } from '../../analyzer/cycleNormalization.js';
-import type { SemanticAnalysisResult } from '../../analyzer/semantic.js';
+import type { SemanticAnalysisResult, StrategyAttempt } from '../../analyzer/semantic.js';
 import type { GeneratedPatch } from '../../codemod/generatePatch.js';
 import { generatePatchForCycle } from '../../codemod/generatePatch.js';
 import type { RepositoryDTO } from '../../db/index.js';
@@ -19,6 +19,19 @@ import { shouldPromotePatchCandidate } from '../promotionPolicy.js';
 import type { ValidationResult } from '../validation.js';
 import { validateGeneratedPatch } from '../validation.js';
 import type { PatchReplayBundle, ScannedCycle } from './types.js';
+
+interface PersistedCandidate {
+  strategy: string | null;
+  plannerRank: number;
+  classification: SemanticAnalysisResult['classification'];
+  confidence: number;
+  reasons: string[];
+  plan: SemanticAnalysisResult['plan'];
+  upstreamabilityScore: number | null;
+  summary: string | null;
+  scoreBreakdown: string[] | null;
+  signals: Record<string, unknown> | null;
+}
 
 export async function getLatestCommitSha(gitRepo: Pick<SimpleGit, 'log'>): Promise<string> {
   try {
@@ -116,108 +129,123 @@ export async function persistCycle(
     return;
   }
 
-  const fixCandidateInfo = addFixCandidate.run({
-    cycle_id: cycleId,
-    classification: persistedCycle.analysis.classification,
-    confidence: persistedCycle.analysis.confidence,
-    reasons: JSON.stringify(persistedCycle.analysis.reasons),
-  });
-  const fixCandidateId = fixCandidateInfo.lastInsertRowid as number;
-  const candidateLogger = cycleLogger.child({
-    fixCandidateId,
-    classification: persistedCycle.analysis.classification,
-  });
-  candidateLogger.info('cycle.classified', {
-    confidence: persistedCycle.analysis.confidence,
-    upstreamabilityScore: persistedCycle.analysis.upstreamabilityScore ?? null,
-  });
+  const candidates = extractPersistedCandidates(persistedCycle.analysis);
 
-  if (!shouldGeneratePatch(persistedCycle.analysis)) {
-    candidateLogger.info('patch.skipped', {
-      reason: 'Candidate did not clear the promotion policy thresholds.',
-      confidence: persistedCycle.analysis.confidence,
-      upstreamabilityScore: persistedCycle.analysis.upstreamabilityScore ?? null,
+  for (const candidate of candidates) {
+    const fixCandidateInfo = addFixCandidate.run({
+      cycle_id: cycleId,
+      strategy: candidate.strategy,
+      planner_rank: candidate.plannerRank,
+      classification: candidate.classification,
+      confidence: candidate.confidence,
+      upstreamability_score: candidate.upstreamabilityScore,
+      reasons: JSON.stringify(candidate.reasons),
+      summary: candidate.summary,
+      score_breakdown: candidate.scoreBreakdown ? JSON.stringify(candidate.scoreBreakdown) : null,
+      signals: candidate.signals ? JSON.stringify(candidate.signals) : null,
     });
-    return;
-  }
-
-  candidateLogger.info('patch.generation.started', {
-    repoPath,
-  });
-
-  let generatedPatch: GeneratedPatch | null;
-  try {
-    generatedPatch = await generatePatchForCycle(repoPath, persistedCycle, persistedCycle.analysis);
-  } catch (error) {
-    candidateLogger.error('patch.generation.failed', {
-      ...serializeError(error),
+    const fixCandidateId = fixCandidateInfo.lastInsertRowid as number;
+    const candidateLogger = cycleLogger.child({
+      fixCandidateId,
+      plannerRank: candidate.plannerRank,
+      strategy: candidate.strategy,
+      classification: candidate.classification,
     });
-    throw error;
-  }
-
-  if (!generatedPatch) {
-    candidateLogger.warn('patch.generation.skipped', {
-      reason: 'No executable patch could be generated for the selected plan.',
+    candidateLogger.info('cycle.candidate.persisted', {
+      confidence: candidate.confidence,
+      upstreamabilityScore: candidate.upstreamabilityScore ?? null,
     });
-    return;
-  }
 
-  candidateLogger.info('patch.generated', {
-    touchedFiles: generatedPatch.touchedFiles.length,
-  });
+    const candidateAnalysis = buildCandidateAnalysis(persistedCycle.analysis, candidate);
 
-  candidateLogger.info('validation.started', {
-    queued: Boolean(options.validationLimiter),
-  });
-  const validationLogger = candidateLogger.child({
-    touchedFiles: generatedPatch.touchedFiles.length,
-  });
-  const validation = options.validationLimiter
-    ? await options.validationLimiter.run(async () =>
-        validateGeneratedPatch(repoPath, persistedCycle, generatedPatch, {
-          logger: validationLogger,
-        }),
-      )
-    : await validateGeneratedPatch(repoPath, persistedCycle, generatedPatch, {
-        logger: validationLogger,
+    if (!shouldGeneratePatch(candidateAnalysis)) {
+      candidateLogger.info('patch.skipped', {
+        reason: 'Candidate did not clear the promotion policy thresholds.',
+        confidence: candidate.confidence,
+        upstreamabilityScore: candidate.upstreamabilityScore ?? null,
       });
-  candidateLogger.info('validation.completed', {
-    status: validation.status,
-    failureCategory: validation.failureCategory ?? null,
-  });
+      continue;
+    }
 
-  const patchPayload = {
-    fix_candidate_id: fixCandidateId,
-    patch_text: generatedPatch.patchText,
-    touched_files: JSON.stringify(generatedPatch.touchedFiles),
-    validation_status: validation.status,
-    validation_summary: validation.summary,
-  };
-  const replayBundle = buildPatchReplayBundle({
-    scanId,
-    sourceTarget,
-    commitSha,
-    remoteUrl,
-    repository,
-    cycle: persistedCycle,
-    generatedPatch,
-    validation,
-  });
+    candidateLogger.info('patch.generation.started', {
+      repoPath,
+    });
 
-  getDb().transaction((patchRow: typeof patchPayload, replayBundleJson: string) => {
-    const patchInfo = addPatch.run(patchRow);
-    candidateLogger.info('patch.persisted', {
-      patchId: patchInfo.lastInsertRowid as number,
-      validationStatus: validation.status,
+    let generatedPatch: GeneratedPatch | null;
+    try {
+      generatedPatch = await generatePatchForCycle(repoPath, persistedCycle, candidateAnalysis);
+    } catch (error) {
+      candidateLogger.error('patch.generation.failed', {
+        ...serializeError(error),
+      });
+      throw error;
+    }
+
+    if (!generatedPatch) {
+      candidateLogger.warn('patch.generation.skipped', {
+        reason: 'No executable patch could be generated for the selected candidate plan.',
+      });
+      continue;
+    }
+
+    candidateLogger.info('patch.generated', {
+      touchedFiles: generatedPatch.touchedFiles.length,
     });
-    addPatchReplay.run({
-      patch_id: patchInfo.lastInsertRowid as number,
-      scan_id: scanId,
-      source_target: sourceTarget,
-      commit_sha: commitSha,
-      replay_bundle: replayBundleJson,
+
+    candidateLogger.info('validation.started', {
+      queued: Boolean(options.validationLimiter),
     });
-  })(patchPayload, JSON.stringify(replayBundle));
+    const validationLogger = candidateLogger.child({
+      touchedFiles: generatedPatch.touchedFiles.length,
+    });
+    const validation = options.validationLimiter
+      ? await options.validationLimiter.run(async () =>
+          validateGeneratedPatch(repoPath, persistedCycle, generatedPatch, {
+            logger: validationLogger,
+          }),
+        )
+      : await validateGeneratedPatch(repoPath, persistedCycle, generatedPatch, {
+          logger: validationLogger,
+        });
+    candidateLogger.info('validation.completed', {
+      status: validation.status,
+      failureCategory: validation.failureCategory ?? null,
+    });
+
+    const patchPayload = {
+      fix_candidate_id: fixCandidateId,
+      patch_text: generatedPatch.patchText,
+      touched_files: JSON.stringify(generatedPatch.touchedFiles),
+      validation_status: validation.status,
+      validation_summary: validation.summary,
+    };
+    const replayBundle = buildPatchReplayBundle({
+      scanId,
+      sourceTarget,
+      commitSha,
+      remoteUrl,
+      repository,
+      cycle: persistedCycle,
+      candidate: candidateAnalysis,
+      generatedPatch,
+      validation,
+    });
+
+    getDb().transaction((patchRow: typeof patchPayload, replayBundleJson: string) => {
+      const patchInfo = addPatch.run(patchRow);
+      candidateLogger.info('patch.persisted', {
+        patchId: patchInfo.lastInsertRowid as number,
+        validationStatus: validation.status,
+      });
+      addPatchReplay.run({
+        patch_id: patchInfo.lastInsertRowid as number,
+        scan_id: scanId,
+        source_target: sourceTarget,
+        commit_sha: commitSha,
+        replay_bundle: replayBundleJson,
+      });
+    })(patchPayload, JSON.stringify(replayBundle));
+  }
 }
 
 function shouldGeneratePatch(analysis: SemanticAnalysisResult): boolean {
@@ -229,6 +257,81 @@ function shouldGeneratePatch(analysis: SemanticAnalysisResult): boolean {
   });
 }
 
+function extractPersistedCandidates(analysis: SemanticAnalysisResult): PersistedCandidate[] {
+  const rankedCandidates = analysis.planner?.rankedCandidates ?? [];
+  if (rankedCandidates.length > 0) {
+    return rankedCandidates.map((candidate, index) => toPersistedCandidate(candidate, index + 1, analysis));
+  }
+
+  return [
+    {
+      strategy: analysis.planner?.selectedStrategy ?? classifyStrategy(analysis.classification),
+      plannerRank: 1,
+      classification: analysis.classification,
+      confidence: analysis.confidence,
+      reasons: analysis.reasons,
+      plan: analysis.plan,
+      upstreamabilityScore: analysis.upstreamabilityScore ?? null,
+      summary: analysis.planner?.selectionSummary ?? null,
+      scoreBreakdown: null,
+      signals: null,
+    },
+  ];
+}
+
+function toPersistedCandidate(
+  attempt: StrategyAttempt,
+  plannerRank: number,
+  analysis: SemanticAnalysisResult,
+): PersistedCandidate {
+  return {
+    strategy: attempt.strategy,
+    plannerRank,
+    classification: attempt.classification ?? analysis.classification,
+    confidence: attempt.confidence ?? analysis.confidence,
+    reasons: attempt.reasons,
+    plan: attempt.plan,
+    upstreamabilityScore: attempt.score ?? null,
+    summary: attempt.summary,
+    scoreBreakdown: attempt.scoreBreakdown ?? null,
+    signals: attempt.signals,
+  };
+}
+
+function buildCandidateAnalysis(
+  analysis: SemanticAnalysisResult,
+  candidate: PersistedCandidate,
+): SemanticAnalysisResult {
+  return {
+    classification: candidate.classification,
+    confidence: candidate.confidence,
+    reasons: candidate.reasons,
+    plan: candidate.plan,
+    upstreamabilityScore: candidate.upstreamabilityScore ?? undefined,
+    planner: analysis.planner,
+  };
+}
+
+function classifyStrategy(classification: SemanticAnalysisResult['classification']): string | null {
+  switch (classification) {
+    case 'autofix_import_type': {
+      return 'import_type';
+    }
+    case 'autofix_direct_import': {
+      return 'direct_import';
+    }
+    case 'autofix_extract_shared': {
+      return 'extract_shared';
+    }
+    case 'autofix_host_state_update': {
+      return 'host_state_update';
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
 function buildPatchReplayBundle(args: {
   scanId: number;
   sourceTarget: string;
@@ -236,6 +339,7 @@ function buildPatchReplayBundle(args: {
   remoteUrl: string | null;
   repository: RepositoryDTO;
   cycle: ScannedCycle;
+  candidate: SemanticAnalysisResult;
   generatedPatch: GeneratedPatch;
   validation: ValidationResult;
 }): PatchReplayBundle {
@@ -261,10 +365,10 @@ function buildPatchReplayBundle(args: {
       },
     },
     candidate: {
-      classification: args.cycle.analysis?.classification ?? 'unsupported',
-      confidence: args.cycle.analysis?.confidence ?? 0,
-      upstreamabilityScore: args.cycle.analysis?.upstreamabilityScore,
-      reasons: args.cycle.analysis?.reasons ?? null,
+      classification: args.candidate.classification,
+      confidence: args.candidate.confidence,
+      upstreamabilityScore: args.candidate.upstreamabilityScore,
+      reasons: args.candidate.reasons ?? null,
     },
     validation: args.validation,
     file_snapshots: args.generatedPatch.fileSnapshots,

--- a/db/index.test.ts
+++ b/db/index.test.ts
@@ -119,6 +119,49 @@ describe('db module', () => {
       expect(() => initSchema(db)).not.toThrow();
       expect(() => initSchema(db)).not.toThrow();
     });
+
+    it('adds ranked-candidate columns to legacy fix_candidates tables', () => {
+      const legacyDb = createDatabase(':memory:');
+      legacyDb.exec(`
+        CREATE TABLE fix_candidates (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          cycle_id INTEGER NOT NULL,
+          classification TEXT NOT NULL,
+          confidence REAL NOT NULL,
+          reasons TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO fix_candidates (cycle_id, classification, confidence, reasons)
+        VALUES (1, 'autofix_import_type', 0.9, NULL);
+      `);
+
+      initSchema(legacyDb);
+
+      const columns = legacyDb.prepare('PRAGMA table_info(fix_candidates)').all() as Array<{ name: string }>;
+      const candidate = legacyDb
+        .prepare('SELECT strategy, planner_rank, upstreamability_score FROM fix_candidates LIMIT 1')
+        .get() as {
+        strategy: string | null;
+        planner_rank: number;
+        upstreamability_score: number | null;
+      };
+
+      expect(columns.map((column) => column.name)).toEqual(
+        expect.arrayContaining([
+          'strategy',
+          'planner_rank',
+          'upstreamability_score',
+          'summary',
+          'score_breakdown',
+          'signals',
+        ]),
+      );
+      expect(candidate.strategy).toBe('import_type');
+      expect(candidate.planner_rank).toBe(1);
+      expect(candidate.upstreamability_score).toBeNull();
+
+      legacyDb.close();
+    });
   });
 
   describe('repositories', () => {
@@ -355,6 +398,41 @@ describe('db module', () => {
     it('returns empty array when no candidates exist', () => {
       const candidates = stmts.getFixCandidatesByCycleId.all(cycleId);
       expect(candidates).toEqual([]);
+    });
+
+    it('orders ranked candidates by planner rank and persists scoring metadata', () => {
+      stmts.addFixCandidate.run({
+        cycle_id: cycleId,
+        strategy: 'extract_shared',
+        planner_rank: 2,
+        classification: 'autofix_extract_shared',
+        confidence: 0.81,
+        upstreamability_score: 0.74,
+        reasons: JSON.stringify(['extract helper']),
+        summary: 'Introduces a shared helper file.',
+        score_breakdown: JSON.stringify(['base 0.68']),
+        signals: JSON.stringify({ introducesNewFile: true }),
+      });
+      stmts.addFixCandidate.run({
+        cycle_id: cycleId,
+        strategy: 'import_type',
+        planner_rank: 1,
+        classification: 'autofix_import_type',
+        confidence: 0.94,
+        upstreamability_score: 0.95,
+        reasons: JSON.stringify(['type-only edge']),
+        summary: 'Converts runtime imports to import type.',
+        score_breakdown: JSON.stringify(['base 0.97']),
+        signals: JSON.stringify({ introducesNewFile: false }),
+      });
+
+      const candidates = stmts.getFixCandidatesByCycleId.all(cycleId) as FixCandidateDTO[];
+
+      expect(candidates).toHaveLength(2);
+      expect(candidates.map((candidate) => candidate.planner_rank)).toEqual([1, 2]);
+      expect(candidates[0].strategy).toBe('import_type');
+      expect(candidates[0].upstreamability_score).toBe(0.95);
+      expect(candidates[0].summary).toContain('import type');
     });
   });
 

--- a/db/index.ts
+++ b/db/index.ts
@@ -38,9 +38,15 @@ export interface CycleDTO {
 export interface FixCandidateDTO {
   id: number;
   cycle_id: number;
+  strategy: string | null;
+  planner_rank: number;
   classification: string;
   confidence: number;
+  upstreamability_score: number | null;
   reasons: string | null;
+  summary: string | null;
+  score_breakdown: string | null;
+  signals: string | null;
   created_at: string;
 }
 
@@ -184,9 +190,15 @@ const SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS fix_candidates (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     cycle_id INTEGER NOT NULL,
+    strategy TEXT,
+    planner_rank INTEGER NOT NULL DEFAULT 1,
     classification TEXT NOT NULL,
     confidence REAL NOT NULL,
+    upstreamability_score REAL,
     reasons TEXT, -- JSON string
+    summary TEXT,
+    score_breakdown TEXT, -- JSON string
+    signals TEXT, -- JSON string
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (cycle_id) REFERENCES cycles(id)
   );
@@ -308,12 +320,88 @@ export function createDatabase(dbPath?: string): DatabaseType {
  */
 export function initSchema(database: DatabaseType): void {
   database.exec(SCHEMA_SQL);
+  ensureFixCandidateSchema(database);
+}
+
+interface TableColumnInfo {
+  name: string;
+}
+
+function ensureFixCandidateSchema(database: DatabaseType): void {
+  const existingColumns = new Set(
+    (database.prepare('PRAGMA table_info(fix_candidates)').all() as TableColumnInfo[]).map((column) => column.name),
+  );
+
+  const requiredColumns = [
+    ['strategy', 'TEXT'],
+    ['planner_rank', 'INTEGER NOT NULL DEFAULT 1'],
+    ['upstreamability_score', 'REAL'],
+    ['summary', 'TEXT'],
+    ['score_breakdown', 'TEXT'],
+    ['signals', 'TEXT'],
+  ] as const;
+
+  for (const [columnName, columnDefinition] of requiredColumns) {
+    if (existingColumns.has(columnName)) {
+      continue;
+    }
+
+    database.exec(`ALTER TABLE fix_candidates ADD COLUMN ${columnName} ${columnDefinition}`);
+  }
+
+  database.exec(`
+    UPDATE fix_candidates
+    SET planner_rank = COALESCE(planner_rank, 1)
+    WHERE planner_rank IS NULL
+  `);
+  database.exec(`
+    UPDATE fix_candidates
+    SET strategy = CASE classification
+      WHEN 'autofix_import_type' THEN 'import_type'
+      WHEN 'autofix_direct_import' THEN 'direct_import'
+      WHEN 'autofix_extract_shared' THEN 'extract_shared'
+      WHEN 'autofix_host_state_update' THEN 'host_state_update'
+      ELSE strategy
+    END
+    WHERE strategy IS NULL
+  `);
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_fix_candidates_cycle_rank
+    ON fix_candidates(cycle_id, planner_rank, id)
+  `);
 }
 
 /**
  * Create all prepared statements for a given database instance.
  */
 export function createStatements(database: DatabaseType) {
+  const addFixCandidateStatement = database.prepare(`
+    INSERT INTO fix_candidates (
+      cycle_id,
+      strategy,
+      planner_rank,
+      classification,
+      confidence,
+      upstreamability_score,
+      reasons,
+      summary,
+      score_breakdown,
+      signals
+    )
+    VALUES (
+      @cycle_id,
+      @strategy,
+      @planner_rank,
+      @classification,
+      @confidence,
+      @upstreamability_score,
+      @reasons,
+      @summary,
+      @score_breakdown,
+      @signals
+    )
+  `);
+
   return {
     // Repositories
     addRepository: database.prepare(`
@@ -364,12 +452,32 @@ export function createStatements(database: DatabaseType) {
     `),
 
     // Fix Candidates
-    addFixCandidate: database.prepare(`
-      INSERT INTO fix_candidates (cycle_id, classification, confidence, reasons)
-      VALUES (@cycle_id, @classification, @confidence, @reasons)
-    `),
+    addFixCandidate: {
+      run: (params: {
+        cycle_id: number | bigint;
+        strategy?: string | null;
+        planner_rank?: number;
+        classification: string;
+        confidence: number;
+        upstreamability_score?: number | null;
+        reasons?: string | null;
+        summary?: string | null;
+        score_breakdown?: string | null;
+        signals?: string | null;
+      }) =>
+        addFixCandidateStatement.run({
+          strategy: null,
+          planner_rank: 1,
+          upstreamability_score: null,
+          reasons: null,
+          summary: null,
+          score_breakdown: null,
+          signals: null,
+          ...params,
+        }),
+    },
     getFixCandidatesByCycleId: database.prepare(`
-      SELECT * FROM fix_candidates WHERE cycle_id = ?
+      SELECT * FROM fix_candidates WHERE cycle_id = ? ORDER BY planner_rank ASC, id ASC
     `),
 
     // Patches

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,6 +38,75 @@ export interface FindingRecord {
   status?: string;
 }
 
+export interface ReplayBundleRecord {
+  patch_id?: number | null;
+  scan_id?: number | null;
+  source_target?: string | null;
+  commit_sha?: string | null;
+  repository?: {
+    owner?: string;
+    name?: string;
+    local_path?: string | null;
+  };
+  candidate?: {
+    classification?: string;
+    confidence?: number;
+    reasons?: string[] | null;
+  };
+  validation?: {
+    status?: string;
+    summary?: string;
+  };
+  file_snapshots?: Array<{
+    path: string;
+    before: string;
+    after: string;
+  }>;
+}
+
+export interface CycleDetailCandidateRecord {
+  id: number;
+  cycle_id: number;
+  strategy: string | null;
+  planner_rank: number;
+  classification: string;
+  confidence: number;
+  upstreamability_score: number | null;
+  reasons: string[] | null;
+  summary: string | null;
+  score_breakdown: string[];
+  signals: Record<string, unknown>;
+  patch_id: number | null;
+  patch: string | null;
+  touched_files: string[];
+  validation_status: string;
+  validation_summary: string | null;
+  replay: ReplayBundleRecord | null;
+  review_status: string;
+  review_notes: string | null;
+}
+
+export interface CycleDetailRecord {
+  id: number;
+  scan_id: number;
+  normalized_path: string;
+  participating_files: string;
+  raw_payload: unknown;
+  created_at: string;
+  patch_id: number | null;
+  cycle_path: string[];
+  classification: string | null;
+  confidence: number | null;
+  reasons: string[] | null;
+  patch: string | null;
+  validation_status: string;
+  validation_summary: string | null;
+  replay: ReplayBundleRecord | null;
+  review_status: string;
+  review_notes: string | null;
+  candidates: CycleDetailCandidateRecord[];
+}
+
 function toSearchParams(filters?: FindingsFilters) {
   const searchParams = new URLSearchParams();
 
@@ -90,7 +159,7 @@ export async function fetchRepositoryFindings(
   });
 }
 
-export async function fetchCycleDetail(repoId: string, cycleId: string) {
+export async function fetchCycleDetail(repoId: string, cycleId: string): Promise<CycleDetailRecord> {
   const response = await fetch(`${API_BASE_URL}/repositories/${repoId}/cycles/${cycleId}`);
   if (!response.ok) {
     throw new Error(NETWORK_ERROR);

--- a/src/routes/repositories.$id.cycles.$cycleId.tsx
+++ b/src/routes/repositories.$id.cycles.$cycleId.tsx
@@ -1,32 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { fetchCycleDetail, type ReviewDecision, submitReviewDecision } from '../lib/api';
+import { useEffect, useState } from 'react';
+import {
+  type CycleDetailCandidateRecord,
+  fetchCycleDetail,
+  type ReviewDecision,
+  submitReviewDecision,
+} from '../lib/api';
 
 type CycleDetailData = Awaited<ReturnType<typeof fetchCycleDetail>>;
-
-type ReplayBundle = {
-  source_target?: string | null;
-  commit_sha?: string | null;
-  repository?: {
-    owner?: string;
-    name?: string;
-    local_path?: string | null;
-  };
-  candidate?: {
-    classification?: string;
-    confidence?: number;
-    reasons?: string[] | null;
-  };
-  validation?: {
-    status?: string;
-    summary?: string;
-  };
-  file_snapshots?: Array<{
-    path: string;
-    before: string;
-    after: string;
-  }>;
-};
 
 export const Route = createFileRoute('/repositories/$id/cycles/$cycleId')({
   component: CycleDetail,
@@ -35,6 +17,7 @@ export const Route = createFileRoute('/repositories/$id/cycles/$cycleId')({
 function CycleDetail() {
   const { id, cycleId } = Route.useParams();
   const queryClient = useQueryClient();
+  const [selectedCandidateId, setSelectedCandidateId] = useState<number | null>(null);
 
   const {
     data: cycle,
@@ -45,13 +28,29 @@ function CycleDetail() {
     queryFn: () => fetchCycleDetail(id, cycleId),
   });
 
+  useEffect(() => {
+    if (!cycle?.candidates?.length) {
+      setSelectedCandidateId(null);
+      return;
+    }
+
+    if (selectedCandidateId && cycle.candidates.some((candidate) => candidate.id === selectedCandidateId)) {
+      return;
+    }
+
+    setSelectedCandidateId(cycle.candidates[0].id);
+  }, [cycle?.candidates, selectedCandidateId]);
+
+  const selectedCandidate =
+    cycle?.candidates.find((candidate) => candidate.id === selectedCandidateId) ?? cycle?.candidates[0] ?? null;
+
   const reviewMutation = useMutation({
     mutationFn: (decision: ReviewDecision) => {
-      if (!cycle?.patch_id) {
+      if (!selectedCandidate?.patch_id) {
         throw new Error('No patch is available for this cycle.');
       }
 
-      return submitReviewDecision(String(cycle.patch_id), decision);
+      return submitReviewDecision(String(selectedCandidate.patch_id), decision);
     },
     onSuccess: async () => {
       await Promise.all([
@@ -64,9 +63,8 @@ function CycleDetail() {
   if (isLoading) return <div className="p-8">Loading cycle details...</div>;
   if (error) return <div className="p-8 text-red-600">Error loading cycle details</div>;
 
-  const statusColor = getValidationStatusColor(cycle?.validation_status);
-  const replay = cycle?.replay as ReplayBundle | null | undefined;
-  const canReview = Boolean(cycle?.patch_id);
+  const statusColor = getValidationStatusColor(selectedCandidate?.validation_status ?? cycle?.validation_status);
+  const canReview = Boolean(selectedCandidate?.patch_id);
 
   return (
     <div className="p-8 max-w-6xl mx-auto">
@@ -80,9 +78,17 @@ function CycleDetail() {
       {cycle && (
         <div className="space-y-6">
           <CycleDetailsSection cycle={cycle} />
-          <DependencySummarySection cycle={cycle} statusColor={statusColor} />
-          <ReplayProvenanceSection cycle={cycle} replay={replay} statusColor={statusColor} />
-          <PatchSection cycle={cycle} />
+          {cycle.candidates.length > 1 ? (
+            <CandidateSelectorSection
+              candidates={cycle.candidates}
+              selectedCandidateId={selectedCandidate?.id ?? null}
+              onSelect={setSelectedCandidateId}
+            />
+          ) : null}
+          <CandidateAnalysisSection candidate={selectedCandidate} />
+          <DependencySummarySection cycle={cycle} candidate={selectedCandidate} statusColor={statusColor} />
+          <ReplayProvenanceSection candidate={selectedCandidate} statusColor={statusColor} />
+          <PatchSection candidate={selectedCandidate} />
 
           <div className="flex gap-4 justify-end">
             <button
@@ -133,23 +139,28 @@ function CycleDetail() {
 function CycleDetailsSection({ cycle }: { cycle: CycleDetailData }) {
   const cyclePath = Array.isArray(cycle.cycle_path) ? cycle.cycle_path.join(' → ') : 'No path available';
   const confidence = typeof cycle.confidence === 'number' ? `${(Number(cycle.confidence) * 100).toFixed(0)}%` : 'N/A';
+  const totalCandidates = cycle.candidates.length;
 
   return (
     <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
       <h2 className="text-xl font-semibold mb-4">Details</h2>
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <span className="text-gray-500 block text-sm">Classification</span>
+          <span className="text-gray-500 block text-sm">Primary classification</span>
           <span className="font-medium bg-gray-100 px-2 py-1 rounded-md mt-1 inline-block">
             {String(cycle.classification || 'Unknown')}
           </span>
         </div>
         <div>
-          <span className="text-gray-500 block text-sm">Confidence</span>
+          <span className="text-gray-500 block text-sm">Primary confidence</span>
           <span className="font-medium">{confidence}</span>
         </div>
         <div>
-          <span className="text-gray-500 block text-sm">Review Status</span>
+          <span className="text-gray-500 block text-sm">Candidate count</span>
+          <span className="font-medium">{totalCandidates}</span>
+        </div>
+        <div>
+          <span className="text-gray-500 block text-sm">Primary review status</span>
           <span className="font-medium bg-gray-100 px-2 py-1 rounded-md mt-1 inline-block">
             {String(cycle.review_status || 'pending')}
           </span>
@@ -164,7 +175,120 @@ function CycleDetailsSection({ cycle }: { cycle: CycleDetailData }) {
   );
 }
 
-function DependencySummarySection({ cycle, statusColor }: { cycle: CycleDetailData; statusColor: string }) {
+function CandidateSelectorSection({
+  candidates,
+  selectedCandidateId,
+  onSelect,
+}: {
+  candidates: CycleDetailCandidateRecord[];
+  selectedCandidateId: number | null;
+  onSelect: (candidateId: number) => void;
+}) {
+  return (
+    <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
+      <h2 className="text-xl font-semibold mb-4">Candidate Shortlist</h2>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {candidates.map((candidate) => {
+          const isSelected = candidate.id === selectedCandidateId;
+          const upstreamability =
+            typeof candidate.upstreamability_score === 'number'
+              ? `${Math.round(candidate.upstreamability_score * 100)}%`
+              : 'N/A';
+
+          return (
+            <button
+              key={candidate.id}
+              type="button"
+              onClick={() => onSelect(candidate.id)}
+              className={`rounded-lg border p-4 text-left transition ${
+                isSelected ? 'border-blue-500 bg-blue-50 shadow-sm' : 'border-gray-200 hover:border-gray-300'
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Rank {candidate.planner_rank}
+                  </p>
+                  <p className="mt-1 font-medium text-gray-900">{candidate.classification}</p>
+                </div>
+                <span className="rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
+                  {upstreamability}
+                </span>
+              </div>
+              <div className="mt-3 space-y-1 text-sm text-gray-600">
+                <p>Strategy: {candidate.strategy || 'fallback'}</p>
+                <p>Confidence: {Math.round(candidate.confidence * 100)}%</p>
+                <p>Validation: {candidate.validation_status || 'pending'}</p>
+                <p>Review: {candidate.review_status || 'pending'}</p>
+              </div>
+              {candidate.summary ? <p className="mt-3 text-sm text-gray-500">{candidate.summary}</p> : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CandidateAnalysisSection({ candidate }: { candidate: CycleDetailCandidateRecord | null }) {
+  const upstreamability =
+    typeof candidate?.upstreamability_score === 'number'
+      ? `${Math.round(candidate.upstreamability_score * 100)}%`
+      : 'N/A';
+
+  return (
+    <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
+      <h2 className="text-xl font-semibold mb-4">Selected Candidate</h2>
+      {candidate ? (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <MetadataField label="Strategy" value={candidate.strategy || 'fallback'} />
+            <MetadataField label="Planner rank" value={String(candidate.planner_rank)} />
+            <MetadataField label="Upstreamability" value={upstreamability} />
+          </div>
+
+          <div>
+            <span className="text-gray-500 block text-sm mb-2">Reasons</span>
+            {candidate.reasons && candidate.reasons.length > 0 ? (
+              <ul className="list-disc pl-5 text-sm text-gray-700 space-y-1">
+                {candidate.reasons.map((reason) => (
+                  <li key={reason}>{reason}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-gray-500 italic">No candidate reasons were recorded.</p>
+            )}
+          </div>
+
+          <div>
+            <span className="text-gray-500 block text-sm mb-2">Score breakdown</span>
+            {candidate.score_breakdown.length > 0 ? (
+              <ul className="list-disc pl-5 text-sm text-gray-700 space-y-1">
+                {candidate.score_breakdown.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-gray-500 italic">No score breakdown was recorded.</p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500 italic">No persisted candidate is available for this cycle yet.</p>
+      )}
+    </div>
+  );
+}
+
+function DependencySummarySection({
+  cycle,
+  candidate,
+  statusColor,
+}: {
+  cycle: CycleDetailData;
+  candidate: CycleDetailCandidateRecord | null;
+  statusColor: string;
+}) {
   return (
     <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
       <h2 className="text-xl font-semibold mb-4">Dependency Summary</h2>
@@ -183,11 +307,11 @@ function DependencySummarySection({ cycle, statusColor }: { cycle: CycleDetailDa
           <h3 className="text-sm font-semibold text-gray-700 mb-2">After (Validation)</h3>
           <div className="mb-2">
             <span className="text-gray-500 text-sm">Status: </span>
-            <span className={`font-medium ${statusColor}`}>{cycle.validation_status || 'Pending / N/A'}</span>
+            <span className={`font-medium ${statusColor}`}>{candidate?.validation_status || 'Pending / N/A'}</span>
           </div>
-          {cycle.validation_summary ? (
+          {candidate?.validation_summary ? (
             <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-xs font-mono border border-gray-200 h-56 overflow-y-auto w-full">
-              <code>{cycle.validation_summary}</code>
+              <code>{candidate.validation_summary}</code>
             </pre>
           ) : (
             <p className="text-gray-500 italic text-sm mt-4">No validation summary available.</p>
@@ -199,14 +323,13 @@ function DependencySummarySection({ cycle, statusColor }: { cycle: CycleDetailDa
 }
 
 function ReplayProvenanceSection({
-  cycle,
-  replay,
+  candidate,
   statusColor,
 }: {
-  cycle: CycleDetailData;
-  replay: ReplayBundle | null | undefined;
+  candidate: CycleDetailCandidateRecord | null;
   statusColor: string;
 }) {
+  const replay = candidate?.replay;
   const repositoryLabel =
     replay?.repository?.owner && replay.repository.name
       ? `${replay.repository.owner}/${replay.repository.name}`
@@ -223,15 +346,10 @@ function ReplayProvenanceSection({
             <MetadataField label="Commit SHA" value={replay.commit_sha || 'N/A'} mono breakAll />
             <MetadataField label="Repository" value={repositoryLabel} />
             <MetadataField label="Repository Path" value={replay.repository?.local_path || 'N/A'} breakAll />
-            <MetadataField
-              label="Classification"
-              value={replay.candidate?.classification || String(cycle.classification || 'Unknown')}
-            />
+            <MetadataField label="Classification" value={replay.candidate?.classification || 'Unknown'} />
             <div>
               <span className="text-gray-500 block text-sm">Validation</span>
-              <span className={`font-medium ${statusColor}`}>
-                {replay.validation?.status || cycle.validation_status || 'Pending / N/A'}
-              </span>
+              <span className={`font-medium ${statusColor}`}>{replay.validation?.status || 'Pending / N/A'}</span>
             </div>
           </div>
 
@@ -262,13 +380,13 @@ function ReplayProvenanceSection({
   );
 }
 
-function PatchSection({ cycle }: { cycle: CycleDetailData }) {
+function PatchSection({ candidate }: { candidate: CycleDetailCandidateRecord | null }) {
   return (
     <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
       <h2 className="text-xl font-semibold mb-4">Proposed Patch</h2>
-      {cycle.patch ? (
+      {candidate?.patch ? (
         <pre className="bg-gray-50 p-4 rounded-md overflow-x-auto text-sm font-mono border border-gray-200">
-          <code>{cycle.patch}</code>
+          <code>{candidate.patch}</code>
         </pre>
       ) : (
         <p className="text-gray-500 italic">No patch available for this cycle.</p>


### PR DESCRIPTION
## Summary
- persist ranked fix candidates with planner rank, strategy, score, and summary metadata
- keep findings queues pinned to the primary candidate while exposing full candidate shortlists on cycle detail
- let the review UI switch between candidates and review the selected patch with candidate-specific provenance

## Verification
- ../../node_modules/.bin/vitest run --config vitest.config.ts
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/eslint .
- ../../node_modules/.bin/biome check .
- ../../node_modules/.bin/vite build

Closes #59
