### PR TITLE
Calibrate planner scoring with acceptance evidence

### DIFF
--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -238,6 +238,7 @@ describe('SemanticAnalyzer', () => {
       },
       historicalEvidence: {
         totalBenchmarkCases: 6,
+        totalAcceptanceBenchmarkCases: 2,
         totalReviewedPatches: 4,
         totalValidatedPatches: 4,
         strategies: {
@@ -250,6 +251,19 @@ describe('SemanticAnalyzer', () => {
             ignoredReviews: 0,
             passedValidations: 0,
             failedValidations: 0,
+            acceptedBenchmarks: 0,
+            rejectedBenchmarks: 0,
+            needsReviewBenchmarks: 0,
+            acceptanceProfileMatches: 0,
+            semanticWrongRejections: 0,
+            repoConventionsMismatchRejections: 0,
+            diffNoisyRejections: 0,
+            validationWeakRejections: 0,
+            otherRejections: 0,
+            originalCyclePersistedFailures: 0,
+            newCyclesIntroducedFailures: 0,
+            repoValidationFailures: 0,
+            typecheckFailures: 0,
           },
           direct_import: {
             benchmarkMatches: 4,
@@ -260,6 +274,19 @@ describe('SemanticAnalyzer', () => {
             ignoredReviews: 0,
             passedValidations: 4,
             failedValidations: 0,
+            acceptedBenchmarks: 2,
+            rejectedBenchmarks: 0,
+            needsReviewBenchmarks: 0,
+            acceptanceProfileMatches: 2,
+            semanticWrongRejections: 0,
+            repoConventionsMismatchRejections: 0,
+            diffNoisyRejections: 0,
+            validationWeakRejections: 0,
+            otherRejections: 0,
+            originalCyclePersistedFailures: 0,
+            newCyclesIntroducedFailures: 0,
+            repoValidationFailures: 0,
+            typecheckFailures: 0,
           },
           extract_shared: {
             benchmarkMatches: 0,
@@ -270,6 +297,19 @@ describe('SemanticAnalyzer', () => {
             ignoredReviews: 0,
             passedValidations: 0,
             failedValidations: 0,
+            acceptedBenchmarks: 0,
+            rejectedBenchmarks: 0,
+            needsReviewBenchmarks: 0,
+            acceptanceProfileMatches: 0,
+            semanticWrongRejections: 0,
+            repoConventionsMismatchRejections: 0,
+            diffNoisyRejections: 0,
+            validationWeakRejections: 0,
+            otherRejections: 0,
+            originalCyclePersistedFailures: 0,
+            newCyclesIntroducedFailures: 0,
+            repoValidationFailures: 0,
+            typecheckFailures: 0,
           },
           host_state_update: {
             benchmarkMatches: 0,
@@ -280,6 +320,19 @@ describe('SemanticAnalyzer', () => {
             ignoredReviews: 0,
             passedValidations: 0,
             failedValidations: 0,
+            acceptedBenchmarks: 0,
+            rejectedBenchmarks: 0,
+            needsReviewBenchmarks: 0,
+            acceptanceProfileMatches: 0,
+            semanticWrongRejections: 0,
+            repoConventionsMismatchRejections: 0,
+            diffNoisyRejections: 0,
+            validationWeakRejections: 0,
+            otherRejections: 0,
+            originalCyclePersistedFailures: 0,
+            newCyclesIntroducedFailures: 0,
+            repoValidationFailures: 0,
+            typecheckFailures: 0,
           },
         },
       },
@@ -323,14 +376,117 @@ describe('SemanticAnalyzer', () => {
     expect(result.planner?.rankedCandidates[0]?.signals).toMatchObject({
       historicalBenchmarkMatches: 4,
       historicalProfileMatches: 2,
+      historicalAcceptanceBenchmarks: 2,
       historicalReviewedPatches: 4,
       historicalValidatedPatches: 4,
     });
     expect(result.planner?.rankedCandidates[0]?.scoreBreakdown).toEqual(
       expect.arrayContaining([
         expect.stringContaining('matching benchmark case'),
+        expect.stringContaining('acceptance benchmark outcomes'),
         expect.stringContaining('review outcomes'),
         expect.stringContaining('validation history'),
+      ]),
+    );
+  });
+
+  it('penalizes extract_shared when acceptance and replay evidence show fragile outcomes', () => {
+    analyzer = new SemanticAnalyzer('/dummy/repo', {
+      repositoryProfile: {
+        packageManager: 'pnpm',
+        workspaceMode: 'workspace',
+        validationCommandCount: 5,
+      },
+      historicalEvidence: {
+        totalBenchmarkCases: 0,
+        totalAcceptanceBenchmarkCases: 5,
+        totalReviewedPatches: 2,
+        totalValidatedPatches: 3,
+        strategies: {
+          import_type: {
+            benchmarkMatches: 0,
+            profileMatches: 0,
+            approvedReviews: 0,
+            rejectedReviews: 0,
+            prCandidates: 0,
+            ignoredReviews: 0,
+            passedValidations: 0,
+            failedValidations: 0,
+          },
+          direct_import: {
+            benchmarkMatches: 0,
+            profileMatches: 0,
+            approvedReviews: 0,
+            rejectedReviews: 0,
+            prCandidates: 0,
+            ignoredReviews: 0,
+            passedValidations: 0,
+            failedValidations: 0,
+          },
+          extract_shared: {
+            benchmarkMatches: 0,
+            profileMatches: 0,
+            approvedReviews: 0,
+            rejectedReviews: 2,
+            prCandidates: 0,
+            ignoredReviews: 0,
+            passedValidations: 1,
+            failedValidations: 2,
+            rejectedBenchmarks: 3,
+            acceptedBenchmarks: 0,
+            needsReviewBenchmarks: 0,
+            acceptanceProfileMatches: 2,
+            diffNoisyRejections: 1,
+            repoConventionsMismatchRejections: 1,
+            semanticWrongRejections: 1,
+            validationWeakRejections: 1,
+            newCyclesIntroducedFailures: 1,
+            repoValidationFailures: 1,
+            originalCyclePersistedFailures: 0,
+            typecheckFailures: 0,
+            otherRejections: 0,
+          },
+          host_state_update: {
+            benchmarkMatches: 0,
+            profileMatches: 0,
+            approvedReviews: 0,
+            rejectedReviews: 0,
+            prCandidates: 0,
+            ignoredReviews: 0,
+            passedValidations: 0,
+            failedValidations: 0,
+          },
+        },
+      },
+    });
+
+    analyzer.project.createSourceFile(
+      '/dummy/repo/a.ts',
+      `
+      import { helperB } from './b';
+      export const mainA = () => helperB();
+    `,
+    );
+    analyzer.project.createSourceFile(
+      '/dummy/repo/b.ts',
+      `
+      import { mainA } from './a';
+      export const helperB = () => console.log("B");
+      export const sideEffectB = () => mainA();
+    `,
+    );
+
+    const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
+
+    expect(result.classification).toBe('autofix_extract_shared');
+    expect(result.upstreamabilityScore).toBeLessThan(0.75);
+    expect(result.planner?.rankedCandidates[0]?.scoreBreakdown).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('acceptance benchmark outcomes'),
+        expect.stringContaining('semantically wrong'),
+        expect.stringContaining('noisy diffs'),
+        expect.stringContaining('preserved or introduced cycles'),
+        expect.stringContaining('repo validation or typecheck failed'),
       ]),
     );
   });

--- a/analyzer/semantic/evidence.test.ts
+++ b/analyzer/semantic/evidence.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const evidenceFixtures = vi.hoisted(() => ({
+  benchmarkCases: [] as Array<Record<string, unknown>>,
+  acceptanceBenchmarkCases: [] as Array<Record<string, unknown>>,
+  reviewRows: [] as Array<Record<string, unknown>>,
+  replayRows: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('../../db/index.js', () => ({
+  getBenchmarkCases: {
+    all: vi.fn(() => evidenceFixtures.benchmarkCases),
+  },
+  getAcceptanceBenchmarkCases: {
+    all: vi.fn(() => evidenceFixtures.acceptanceBenchmarkCases),
+  },
+  getDb: () => ({
+    prepare: (query: string) => ({
+      all: vi.fn(() => (query.includes('patch_replays') ? evidenceFixtures.replayRows : evidenceFixtures.reviewRows)),
+    }),
+  }),
+}));
+
+import { loadHistoricalEvidence } from './evidence.js';
+
+describe('historical evidence loading', () => {
+  beforeEach(() => {
+    evidenceFixtures.benchmarkCases = [];
+    evidenceFixtures.acceptanceBenchmarkCases = [];
+    evidenceFixtures.reviewRows = [];
+    evidenceFixtures.replayRows = [];
+  });
+
+  it('hydrates acceptance benchmark outcomes and replay failure categories into strategy evidence', () => {
+    evidenceFixtures.benchmarkCases = [
+      {
+        strategy_labels: JSON.stringify(['direct_import']),
+        validation_signals: JSON.stringify({
+          repository_profile: {
+            package_manager: 'pnpm',
+            workspace_mode: 'workspace',
+          },
+        }),
+      },
+    ];
+    evidenceFixtures.acceptanceBenchmarkCases = [
+      {
+        classification: 'autofix_import_type',
+        acceptability: 'accepted',
+        rejection_reason: null,
+        feature_vector: JSON.stringify({
+          packageManager: 'pnpm',
+          workspaceMode: 'workspace',
+        }),
+      },
+      {
+        classification: 'autofix_extract_shared',
+        acceptability: 'rejected',
+        rejection_reason: 'semantic_wrong',
+        feature_vector: JSON.stringify({
+          packageManager: 'pnpm',
+          workspaceMode: 'workspace',
+        }),
+      },
+      {
+        classification: 'autofix_extract_shared',
+        acceptability: 'rejected',
+        rejection_reason: 'diff_noisy',
+        feature_vector: JSON.stringify({
+          packageManager: 'npm',
+          workspaceMode: 'single-package',
+        }),
+      },
+    ];
+    evidenceFixtures.reviewRows = [
+      {
+        classification: 'autofix_direct_import',
+        validation_status: 'passed',
+        decision: 'approved',
+      },
+      {
+        classification: 'autofix_extract_shared',
+        validation_status: 'failed',
+        decision: 'rejected',
+      },
+    ];
+    evidenceFixtures.replayRows = [
+      {
+        classification: 'autofix_extract_shared',
+        replay_bundle: JSON.stringify({
+          validation: {
+            failureCategory: 'new_cycles_introduced',
+          },
+        }),
+      },
+      {
+        classification: 'autofix_extract_shared',
+        replay_bundle: JSON.stringify({
+          validation: {
+            failureCategory: 'repo_validation_failed',
+          },
+        }),
+      },
+    ];
+
+    const snapshot = loadHistoricalEvidence({
+      packageManager: 'pnpm',
+      workspaceMode: 'workspace',
+      validationCommandCount: 3,
+    });
+
+    expect(snapshot.totalBenchmarkCases).toBe(1);
+    expect(snapshot.totalAcceptanceBenchmarkCases).toBe(3);
+    expect(snapshot.totalReviewedPatches).toBe(2);
+    expect(snapshot.totalValidatedPatches).toBe(2);
+    expect(snapshot.strategies.direct_import).toMatchObject({
+      benchmarkMatches: 1,
+      profileMatches: 2,
+      approvedReviews: 1,
+      passedValidations: 1,
+    });
+    expect(snapshot.strategies.import_type).toMatchObject({
+      acceptedBenchmarks: 1,
+      acceptanceProfileMatches: 2,
+    });
+    expect(snapshot.strategies.extract_shared).toMatchObject({
+      rejectedBenchmarks: 2,
+      semanticWrongRejections: 1,
+      diffNoisyRejections: 1,
+      rejectedReviews: 1,
+      failedValidations: 1,
+      newCyclesIntroducedFailures: 1,
+      repoValidationFailures: 1,
+    });
+  });
+});

--- a/analyzer/semantic/evidence.ts
+++ b/analyzer/semantic/evidence.ts
@@ -1,5 +1,5 @@
-import type { BenchmarkCaseDTO } from '../../db/index.js';
-import { getBenchmarkCases, getDb } from '../../db/index.js';
+import type { AcceptanceBenchmarkCaseDTO, BenchmarkCaseDTO } from '../../db/index.js';
+import { getAcceptanceBenchmarkCases, getBenchmarkCases, getDb } from '../../db/index.js';
 import type {
   HistoricalEvidenceSnapshot,
   PlannerRepositoryProfile,
@@ -29,6 +29,11 @@ interface ReviewEvidenceRow {
   decision: string | null;
 }
 
+interface ReplayEvidenceRow {
+  classification: string;
+  replay_bundle: string | null;
+}
+
 interface BenchmarkSignalsShape {
   repository_profile?: {
     package_manager?: PlannerRepositoryProfile['packageManager'];
@@ -36,9 +41,21 @@ interface BenchmarkSignalsShape {
   };
 }
 
+interface AcceptanceFeatureVectorShape {
+  packageManager?: PlannerRepositoryProfile['packageManager'];
+  workspaceMode?: PlannerRepositoryProfile['workspaceMode'];
+}
+
+interface ReplayBundleShape {
+  validation?: {
+    failureCategory?: string | null;
+  };
+}
+
 export function createEmptyHistoricalEvidenceSnapshot(): HistoricalEvidenceSnapshot {
   return {
     totalBenchmarkCases: 0,
+    totalAcceptanceBenchmarkCases: 0,
     totalReviewedPatches: 0,
     totalValidatedPatches: 0,
     strategies: {
@@ -59,61 +76,14 @@ export function loadHistoricalEvidence(repositoryProfile?: PlannerRepositoryProf
     applyBenchmarkCase(snapshot, benchmarkCase, repositoryProfile);
   }
 
-  const reviewRows = getDb()
-    .prepare(
-      `
-        SELECT
-          fc.classification,
-          p.validation_status,
-          rd.decision
-        FROM fix_candidates fc
-        LEFT JOIN patches p ON p.fix_candidate_id = fc.id
-        LEFT JOIN review_decisions rd ON rd.patch_id = p.id
-      `,
-    )
-    .all() as ReviewEvidenceRow[];
-
-  for (const row of reviewRows) {
-    const strategy = CLASSIFICATION_TO_STRATEGY[row.classification];
-    if (!strategy) {
-      continue;
-    }
-
-    const evidence = snapshot.strategies[strategy];
-    if (row.validation_status === 'passed') {
-      evidence.passedValidations += 1;
-      snapshot.totalValidatedPatches += 1;
-    } else if (row.validation_status === 'failed') {
-      evidence.failedValidations += 1;
-      snapshot.totalValidatedPatches += 1;
-    }
-
-    switch (row.decision) {
-      case 'approved': {
-        evidence.approvedReviews += 1;
-        snapshot.totalReviewedPatches += 1;
-        break;
-      }
-      case 'rejected': {
-        evidence.rejectedReviews += 1;
-        snapshot.totalReviewedPatches += 1;
-        break;
-      }
-      case 'pr_candidate': {
-        evidence.prCandidates += 1;
-        snapshot.totalReviewedPatches += 1;
-        break;
-      }
-      case 'ignored': {
-        evidence.ignoredReviews += 1;
-        snapshot.totalReviewedPatches += 1;
-        break;
-      }
-      default: {
-        break;
-      }
-    }
+  const acceptanceBenchmarkCases = getAcceptanceBenchmarkCases.all() as AcceptanceBenchmarkCaseDTO[];
+  snapshot.totalAcceptanceBenchmarkCases = acceptanceBenchmarkCases.length;
+  for (const acceptanceCase of acceptanceBenchmarkCases) {
+    applyAcceptanceBenchmarkCase(snapshot, acceptanceCase, repositoryProfile);
   }
+
+  applyReviewEvidence(snapshot, loadReviewEvidenceRows());
+  applyReplayEvidence(snapshot, loadReplayEvidenceRows());
 
   return snapshot;
 }
@@ -145,6 +115,73 @@ function applyBenchmarkCase(
   }
 }
 
+function applyAcceptanceBenchmarkCase(
+  snapshot: HistoricalEvidenceSnapshot,
+  benchmarkCase: AcceptanceBenchmarkCaseDTO,
+  repositoryProfile?: PlannerRepositoryProfile,
+): void {
+  const strategy = CLASSIFICATION_TO_STRATEGY[benchmarkCase.classification];
+  if (!strategy) {
+    return;
+  }
+
+  const evidence = snapshot.strategies[strategy];
+  const featureVector = parseAcceptanceFeatureVector(benchmarkCase.feature_vector);
+
+  if (repositoryProfile) {
+    let profileMatches = 0;
+    if (featureVector.packageManager === repositoryProfile.packageManager) {
+      profileMatches += 1;
+    }
+    if (featureVector.workspaceMode === repositoryProfile.workspaceMode) {
+      profileMatches += 1;
+    }
+    evidence.acceptanceProfileMatches = (evidence.acceptanceProfileMatches ?? 0) + profileMatches;
+  }
+
+  switch (benchmarkCase.acceptability) {
+    case 'accepted': {
+      evidence.acceptedBenchmarks = (evidence.acceptedBenchmarks ?? 0) + 1;
+      break;
+    }
+    case 'rejected': {
+      evidence.rejectedBenchmarks = (evidence.rejectedBenchmarks ?? 0) + 1;
+
+      switch (benchmarkCase.rejection_reason) {
+        case 'diff_noisy': {
+          evidence.diffNoisyRejections = (evidence.diffNoisyRejections ?? 0) + 1;
+          break;
+        }
+        case 'repo_conventions_mismatch': {
+          evidence.repoConventionsMismatchRejections = (evidence.repoConventionsMismatchRejections ?? 0) + 1;
+          break;
+        }
+        case 'semantic_wrong': {
+          evidence.semanticWrongRejections = (evidence.semanticWrongRejections ?? 0) + 1;
+          break;
+        }
+        case 'validation_weak': {
+          evidence.validationWeakRejections = (evidence.validationWeakRejections ?? 0) + 1;
+          break;
+        }
+        default: {
+          evidence.otherRejections = (evidence.otherRejections ?? 0) + 1;
+          break;
+        }
+      }
+      break;
+    }
+    case 'needs_review': {
+      evidence.needsReviewBenchmarks = (evidence.needsReviewBenchmarks ?? 0) + 1;
+      break;
+    }
+    default: {
+      evidence.needsReviewBenchmarks = (evidence.needsReviewBenchmarks ?? 0) + 1;
+      break;
+    }
+  }
+}
+
 function createEmptyStrategyEvidence(): StrategyHistoricalEvidence {
   return {
     benchmarkMatches: 0,
@@ -155,6 +192,19 @@ function createEmptyStrategyEvidence(): StrategyHistoricalEvidence {
     ignoredReviews: 0,
     passedValidations: 0,
     failedValidations: 0,
+    acceptedBenchmarks: 0,
+    rejectedBenchmarks: 0,
+    needsReviewBenchmarks: 0,
+    acceptanceProfileMatches: 0,
+    semanticWrongRejections: 0,
+    repoConventionsMismatchRejections: 0,
+    diffNoisyRejections: 0,
+    validationWeakRejections: 0,
+    otherRejections: 0,
+    originalCyclePersistedFailures: 0,
+    newCyclesIntroducedFailures: 0,
+    repoValidationFailures: 0,
+    typecheckFailures: 0,
   };
 }
 
@@ -173,5 +223,145 @@ function parseBenchmarkSignals(value: string): BenchmarkSignalsShape {
     return parsed && typeof parsed === 'object' ? parsed : {};
   } catch {
     return {};
+  }
+}
+
+function parseAcceptanceFeatureVector(value: string): AcceptanceFeatureVectorShape {
+  try {
+    const parsed = JSON.parse(value) as AcceptanceFeatureVectorShape;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseReplayFailureCategory(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as ReplayBundleShape;
+    return typeof parsed.validation?.failureCategory === 'string' ? parsed.validation.failureCategory : null;
+  } catch {
+    return null;
+  }
+}
+
+function loadReviewEvidenceRows(): ReviewEvidenceRow[] {
+  return getDb()
+    .prepare(
+      `
+        SELECT
+          fc.classification,
+          p.validation_status,
+          rd.decision
+        FROM fix_candidates fc
+        LEFT JOIN patches p ON p.fix_candidate_id = fc.id
+        LEFT JOIN review_decisions rd ON rd.patch_id = p.id
+      `,
+    )
+    .all() as ReviewEvidenceRow[];
+}
+
+function applyReviewEvidence(snapshot: HistoricalEvidenceSnapshot, reviewRows: ReviewEvidenceRow[]): void {
+  for (const row of reviewRows) {
+    const strategy = CLASSIFICATION_TO_STRATEGY[row.classification];
+    if (!strategy) {
+      continue;
+    }
+
+    const evidence = snapshot.strategies[strategy];
+    if (row.validation_status === 'passed') {
+      evidence.passedValidations += 1;
+      snapshot.totalValidatedPatches += 1;
+    } else if (row.validation_status === 'failed') {
+      evidence.failedValidations += 1;
+      snapshot.totalValidatedPatches += 1;
+    }
+
+    const reviewed = applyReviewDecision(evidence, row.decision);
+    if (reviewed) {
+      snapshot.totalReviewedPatches += 1;
+    }
+  }
+}
+
+function applyReviewDecision(evidence: StrategyHistoricalEvidence, decision: string | null): boolean {
+  switch (decision) {
+    case 'approved': {
+      evidence.approvedReviews += 1;
+      return true;
+    }
+    case 'rejected': {
+      evidence.rejectedReviews += 1;
+      return true;
+    }
+    case 'pr_candidate': {
+      evidence.prCandidates += 1;
+      return true;
+    }
+    case 'ignored': {
+      evidence.ignoredReviews += 1;
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function loadReplayEvidenceRows(): ReplayEvidenceRow[] {
+  return getDb()
+    .prepare(
+      `
+        SELECT
+          fc.classification,
+          pr.replay_bundle
+        FROM fix_candidates fc
+        INNER JOIN patches p ON p.fix_candidate_id = fc.id
+        INNER JOIN patch_replays pr ON pr.patch_id = p.id
+      `,
+    )
+    .all() as ReplayEvidenceRow[];
+}
+
+function applyReplayEvidence(snapshot: HistoricalEvidenceSnapshot, replayRows: ReplayEvidenceRow[]): void {
+  for (const row of replayRows) {
+    const strategy = CLASSIFICATION_TO_STRATEGY[row.classification];
+    if (!strategy) {
+      continue;
+    }
+
+    const failureCategory = parseReplayFailureCategory(row.replay_bundle);
+    if (!failureCategory) {
+      continue;
+    }
+
+    incrementReplayFailure(snapshot.strategies[strategy], failureCategory);
+  }
+}
+
+function incrementReplayFailure(evidence: StrategyHistoricalEvidence, failureCategory: string): void {
+  switch (failureCategory) {
+    case 'new_cycles_introduced': {
+      evidence.newCyclesIntroducedFailures = (evidence.newCyclesIntroducedFailures ?? 0) + 1;
+      break;
+    }
+    case 'original_cycle_persisted': {
+      evidence.originalCyclePersistedFailures = (evidence.originalCyclePersistedFailures ?? 0) + 1;
+      break;
+    }
+    case 'repo_validation_failed': {
+      evidence.repoValidationFailures = (evidence.repoValidationFailures ?? 0) + 1;
+      break;
+    }
+    case 'typecheck_failed': {
+      evidence.typecheckFailures = (evidence.typecheckFailures ?? 0) + 1;
+      break;
+    }
+    default: {
+      break;
+    }
   }
 }

--- a/analyzer/semantic/scoring.ts
+++ b/analyzer/semantic/scoring.ts
@@ -152,67 +152,216 @@ export function applyHistoricalEvidence(
     return attempt;
   }
 
-  let adjustedScore = attempt.score ?? 0;
-  const breakdown = [...(attempt.scoreBreakdown ?? [])];
-
-  if (evidence.benchmarkMatches > 0) {
-    const benchmarkBonus = Math.min(0.03, evidence.benchmarkMatches * 0.005);
-    adjustedScore += benchmarkBonus;
-    breakdown.push(`+${benchmarkBonus.toFixed(2)} from ${evidence.benchmarkMatches} matching benchmark case(s)`);
-  }
-
-  if (evidence.profileMatches > 0) {
-    const profileBonus = Math.min(0.02, evidence.profileMatches * 0.01);
-    adjustedScore += profileBonus;
-    breakdown.push(`+${profileBonus.toFixed(2)} from repository-profile matches in historical cases`);
-  }
-
   const reviewedCount =
     evidence.approvedReviews + evidence.rejectedReviews + evidence.prCandidates + evidence.ignoredReviews;
-  if (reviewedCount > 0) {
-    const positiveReviewWeight = evidence.approvedReviews + evidence.prCandidates * 0.5;
-    const approvalRatio = positiveReviewWeight / reviewedCount;
-    const reviewDelta = clampSignedAdjustment((approvalRatio - 0.5) * 0.08, 0.04);
-    if (reviewDelta !== 0) {
-      adjustedScore += reviewDelta;
-      breakdown.push(`${formatSignedScore(reviewDelta)} from review outcomes (${reviewedCount} reviewed patch(es))`);
-    }
-  }
-
   const validatedCount = evidence.passedValidations + evidence.failedValidations;
-  if (validatedCount > 0) {
-    const validationRatio = evidence.passedValidations / validatedCount;
-    const validationDelta = clampSignedAdjustment((validationRatio - 0.5) * 0.06, 0.03);
-    if (validationDelta !== 0) {
-      adjustedScore += validationDelta;
-      breakdown.push(
-        `${formatSignedScore(validationDelta)} from validation history (${evidence.passedValidations}/${validatedCount} passed)`,
-      );
-    }
-  }
+  const acceptanceReviewedCount = (evidence.acceptedBenchmarks ?? 0) + (evidence.rejectedBenchmarks ?? 0);
+  const semanticWrongPenalty = Math.min(0.05, (evidence.semanticWrongRejections ?? 0) * 0.02);
+  const noisyDiffRejections = (evidence.diffNoisyRejections ?? 0) + (evidence.repoConventionsMismatchRejections ?? 0);
+  const structuralFailureCount =
+    (evidence.originalCyclePersistedFailures ?? 0) + (evidence.newCyclesIntroducedFailures ?? 0);
+  const validationFailureCount = (evidence.repoValidationFailures ?? 0) + (evidence.typecheckFailures ?? 0);
+  const accumulator = {
+    score: attempt.score ?? 0,
+    breakdown: [...(attempt.scoreBreakdown ?? [])],
+  };
 
-  if (attempt.strategy === 'direct_import' && features.hasBarrelFile) {
-    adjustedScore += 0.01;
-    breakdown.push('+0.01 because the cycle already contains a barrel entrypoint');
-  }
-
-  if (attempt.strategy === 'extract_shared' && features.validationCommandCount > 2) {
-    adjustedScore -= 0.01;
-    breakdown.push('-0.01 because new shared modules are more fragile under heavier repo validation');
-  }
+  applyBenchmarkEvidence(accumulator, evidence);
+  applyReviewEvidence(accumulator, evidence, reviewedCount);
+  applyValidationEvidence(accumulator, evidence, validatedCount);
+  applyAcceptanceEvidence(accumulator, evidence, acceptanceReviewedCount);
+  applyPenaltyEvidence(accumulator, attempt, features, {
+    semanticWrongPenalty,
+    noisyDiffRejections,
+    structuralFailureCount,
+    validationFailureCount,
+    validationWeakRejections: evidence.validationWeakRejections ?? 0,
+  });
+  applyFeatureBiases(accumulator, attempt, features);
 
   return {
     ...attempt,
-    score: clampScore(adjustedScore),
-    scoreBreakdown: breakdown,
+    score: clampScore(accumulator.score),
+    scoreBreakdown: accumulator.breakdown,
     signals: {
       ...attempt.signals,
       historicalBenchmarkMatches: evidence.benchmarkMatches,
       historicalProfileMatches: evidence.profileMatches,
+      historicalAcceptanceBenchmarks:
+        (evidence.acceptedBenchmarks ?? 0) + (evidence.rejectedBenchmarks ?? 0) + (evidence.needsReviewBenchmarks ?? 0),
       historicalReviewedPatches: reviewedCount,
       historicalValidatedPatches: validatedCount,
+      historicalStructuralFailures: structuralFailureCount,
+      historicalValidationFailures: validationFailureCount,
     },
   };
+}
+
+interface ScoreAccumulator {
+  score: number;
+  breakdown: string[];
+}
+
+function applyBenchmarkEvidence(
+  accumulator: ScoreAccumulator,
+  evidence: HistoricalEvidenceSnapshot['strategies'][PlanningStrategy],
+): void {
+  if (evidence.benchmarkMatches > 0) {
+    const benchmarkBonus = Math.min(0.03, evidence.benchmarkMatches * 0.005);
+    accumulator.score += benchmarkBonus;
+    accumulator.breakdown.push(
+      `+${benchmarkBonus.toFixed(2)} from ${evidence.benchmarkMatches} matching benchmark case(s)`,
+    );
+  }
+
+  if (evidence.profileMatches > 0) {
+    const profileBonus = Math.min(0.02, evidence.profileMatches * 0.01);
+    accumulator.score += profileBonus;
+    accumulator.breakdown.push(`+${profileBonus.toFixed(2)} from repository-profile matches in historical cases`);
+  }
+
+  if ((evidence.acceptanceProfileMatches ?? 0) > 0) {
+    const acceptanceProfileBonus = Math.min(0.02, (evidence.acceptanceProfileMatches ?? 0) * 0.005);
+    accumulator.score += acceptanceProfileBonus;
+    accumulator.breakdown.push(
+      `+${acceptanceProfileBonus.toFixed(2)} from acceptance benchmark cases with matching repo profiles`,
+    );
+  }
+}
+
+function applyReviewEvidence(
+  accumulator: ScoreAccumulator,
+  evidence: HistoricalEvidenceSnapshot['strategies'][PlanningStrategy],
+  reviewedCount: number,
+): void {
+  if (reviewedCount === 0) {
+    return;
+  }
+
+  const positiveReviewWeight = evidence.approvedReviews + evidence.prCandidates * 0.5;
+  const approvalRatio = positiveReviewWeight / reviewedCount;
+  const reviewDelta = clampSignedAdjustment((approvalRatio - 0.5) * 0.08, 0.04);
+  if (reviewDelta === 0) {
+    return;
+  }
+
+  accumulator.score += reviewDelta;
+  accumulator.breakdown.push(
+    `${formatSignedScore(reviewDelta)} from review outcomes (${reviewedCount} reviewed patch(es))`,
+  );
+}
+
+function applyValidationEvidence(
+  accumulator: ScoreAccumulator,
+  evidence: HistoricalEvidenceSnapshot['strategies'][PlanningStrategy],
+  validatedCount: number,
+): void {
+  if (validatedCount === 0) {
+    return;
+  }
+
+  const validationRatio = evidence.passedValidations / validatedCount;
+  const validationDelta = clampSignedAdjustment((validationRatio - 0.5) * 0.06, 0.03);
+  if (validationDelta === 0) {
+    return;
+  }
+
+  accumulator.score += validationDelta;
+  accumulator.breakdown.push(
+    `${formatSignedScore(validationDelta)} from validation history (${evidence.passedValidations}/${validatedCount} passed)`,
+  );
+}
+
+function applyAcceptanceEvidence(
+  accumulator: ScoreAccumulator,
+  evidence: HistoricalEvidenceSnapshot['strategies'][PlanningStrategy],
+  acceptanceReviewedCount: number,
+): void {
+  if (acceptanceReviewedCount === 0) {
+    return;
+  }
+
+  const acceptanceRatio = (evidence.acceptedBenchmarks ?? 0) / acceptanceReviewedCount;
+  const acceptanceDelta = clampSignedAdjustment((acceptanceRatio - 0.5) * 0.12, 0.06);
+  if (acceptanceDelta === 0) {
+    return;
+  }
+
+  accumulator.score += acceptanceDelta;
+  accumulator.breakdown.push(
+    `${formatSignedScore(acceptanceDelta)} from acceptance benchmark outcomes (${evidence.acceptedBenchmarks ?? 0}/${acceptanceReviewedCount} accepted)`,
+  );
+}
+
+function applyPenaltyEvidence(
+  accumulator: ScoreAccumulator,
+  attempt: StrategyAttempt,
+  features: CycleFeatureVector,
+  penalties: {
+    semanticWrongPenalty: number;
+    noisyDiffRejections: number;
+    structuralFailureCount: number;
+    validationFailureCount: number;
+    validationWeakRejections: number;
+  },
+): void {
+  if (penalties.semanticWrongPenalty > 0) {
+    accumulator.score -= penalties.semanticWrongPenalty;
+    accumulator.breakdown.push(
+      `-${penalties.semanticWrongPenalty.toFixed(2)} because similar fixes were marked semantically wrong`,
+    );
+  }
+
+  if (
+    (attempt.signals.introducesNewFile === true || attempt.strategy === 'extract_shared') &&
+    penalties.noisyDiffRejections > 0
+  ) {
+    const noisyDiffPenalty = Math.min(0.03, penalties.noisyDiffRejections * 0.01);
+    accumulator.score -= noisyDiffPenalty;
+    accumulator.breakdown.push(
+      `-${noisyDiffPenalty.toFixed(2)} because similar rewrites were rejected for noisy diffs or repo-convention mismatch`,
+    );
+  }
+
+  if (penalties.validationWeakRejections > 0 && features.validationCommandCount > 0) {
+    const validationWeakPenalty = Math.min(0.02, penalties.validationWeakRejections * 0.01);
+    accumulator.score -= validationWeakPenalty;
+    accumulator.breakdown.push(
+      `-${validationWeakPenalty.toFixed(2)} because similar candidates were rejected for weak validation coverage`,
+    );
+  }
+
+  if (penalties.structuralFailureCount > 0) {
+    const structuralFailurePenalty = Math.min(0.04, penalties.structuralFailureCount * 0.01);
+    accumulator.score -= structuralFailurePenalty;
+    accumulator.breakdown.push(
+      `-${structuralFailurePenalty.toFixed(2)} from replay history where the rewrite preserved or introduced cycles`,
+    );
+  }
+
+  if (penalties.validationFailureCount > 0) {
+    const validationFailurePenalty = Math.min(0.03, penalties.validationFailureCount * 0.01);
+    accumulator.score -= validationFailurePenalty;
+    accumulator.breakdown.push(
+      `-${validationFailurePenalty.toFixed(2)} from replay history where repo validation or typecheck failed`,
+    );
+  }
+}
+
+function applyFeatureBiases(
+  accumulator: ScoreAccumulator,
+  attempt: StrategyAttempt,
+  features: CycleFeatureVector,
+): void {
+  if (attempt.strategy === 'direct_import' && features.hasBarrelFile) {
+    accumulator.score += 0.01;
+    accumulator.breakdown.push('+0.01 because the cycle already contains a barrel entrypoint');
+  }
+
+  if (attempt.strategy === 'extract_shared' && features.validationCommandCount > 2) {
+    accumulator.score -= 0.01;
+    accumulator.breakdown.push('-0.01 because new shared modules are more fragile under heavier repo validation');
+  }
 }
 
 export function createNotApplicableAttempt(

--- a/analyzer/semantic/types.ts
+++ b/analyzer/semantic/types.ts
@@ -75,10 +75,24 @@ export interface StrategyHistoricalEvidence {
   ignoredReviews: number;
   passedValidations: number;
   failedValidations: number;
+  acceptedBenchmarks?: number;
+  rejectedBenchmarks?: number;
+  needsReviewBenchmarks?: number;
+  acceptanceProfileMatches?: number;
+  semanticWrongRejections?: number;
+  repoConventionsMismatchRejections?: number;
+  diffNoisyRejections?: number;
+  validationWeakRejections?: number;
+  otherRejections?: number;
+  originalCyclePersistedFailures?: number;
+  newCyclesIntroducedFailures?: number;
+  repoValidationFailures?: number;
+  typecheckFailures?: number;
 }
 
 export interface HistoricalEvidenceSnapshot {
   totalBenchmarkCases: number;
+  totalAcceptanceBenchmarkCases: number;
   totalReviewedPatches: number;
   totalValidatedPatches: number;
   strategies: Record<PlanningStrategy, StrategyHistoricalEvidence>;


### PR DESCRIPTION
## Summary
- fold acceptance benchmark outcomes and rejection reasons into strategy evidence
- parse replay bundle validation failure categories and expose them to planner scoring
- add tests for evidence ingestion and score-breakdown adjustments

## Verification
- ../../node_modules/.bin/vitest run --config vitest.config.ts
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/eslint .
- ../../node_modules/.bin/biome check .
- ../../node_modules/.bin/vite build

Closes #61
