### PR TITLE
Implement data-first observations and graph core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,44 +1,107 @@
 # AGENTS.md - Circular Dependency Autofix Bot
 
+## Project Goal
+
+This repository is building a data-first cycle analysis and autofix platform for JavaScript and TypeScript repositories.
+
+The target workflow is:
+
+`detect -> extract features -> rank against historical evidence -> generate candidates -> validate -> review -> learn`
+
+The project should keep moving toward:
+
+- reusable observations for every cycle, including unsupported cases
+- graph-aware planning instead of only file-level heuristics
+- ranking informed by benchmark, validation, and review history
+- automation of patterns that repeatedly validate and survive human review
+
 ## Tech Stack
-- **Runtime:** Node.js 25 (pinned via mise.toml)
-- **Package Manager:** pnpm 10 (pinned via mise.toml)
-- **UI Framework:** TanStack Start (Vite 7 + React 19 + file-based routing)
-- **Language:** TypeScript (strict mode)
-- **Backend API:** Fastify 5 (port 3001, serves `/api/*`)
+
+- **Runtime:** Node.js 25
+- **Package Manager:** pnpm 10
+- **Frontend:** TanStack Start, React 19, Tailwind CSS 4
+- **Backend API:** Fastify 5
 - **Database:** SQLite via better-sqlite3
-- **Dependency Analysis:** dependency-cruiser
-- **AST & Semantic Analysis:** ts-morph (TypeScript Compiler API)
-- **Codemod Engine:** jscodeshift + recast
+- **Cycle Detection:** dependency-cruiser
+- **Semantic Analysis:** ts-morph
+- **Codemods:** jscodeshift + recast
 - **Git Operations:** simple-git
-- **Styling:** Tailwind CSS 4
+- **Testing:** Vitest
 
 ## Project Structure
-- `/src` — TanStack Start frontend (React, file-based routes in `/src/routes`)
-- `/backend` — Fastify API server (port 3001, imports from `/db`)
-- `/analyzer` — Core logic: dependency-cruiser cycle detection, ts-morph semantic analysis, classification
-- `/codemod` — jscodeshift rewrite scripts for safe symbol extraction (not yet implemented)
-- `/cli` — Commander-based CLI for scan, retry, and export commands
-- `/db` — SQLite schema, DTOs, and prepared-statement data access layer
-- `/worktrees` — Isolated, temporary local repository clones for safe patch generation (gitignored)
 
-## Development
-- `npm run dev` — Starts both Fastify backend (port 3001) and TanStack Start frontend (port 3000) via concurrently
-- `npm run dev:frontend` — Frontend only
-- `npm run dev:backend` — Backend only
-- `npm run test` — Run vitest
+- `/src` — review UI and application routes
+- `/backend` — Fastify API surface
+- `/analyzer` — cycle detection, feature extraction, planner logic
+- `/codemod` — candidate rewrite and patch generation
+- `/cli` — scan, retry, export, and future report/rescore commands
+- `/db` — SQLite schema and data access layer
+- `/worktrees` — isolated repository clones and temp workspaces
+
+## Development Commands
+
+- `pnpm run dev`
+- `pnpm run dev:frontend`
+- `pnpm run dev:backend`
+- `pnpm run test`
+- `pnpm run scan <repo-url-or-path>`
+- `pnpm run scan:all`
+- `pnpm run retry:failed`
+- `pnpm run export:patches`
+
+## Engineering Rules
+
+### 1. Data capture is a product feature
+
+Every new feature should improve the evidence loop, not bypass it.
+
+Prefer designs that persist:
+
+- cycle identity
+- feature vectors
+- strategy attempts
+- ranking signals
+- validation outcomes
+- review outcomes
+- benchmark labels
+
+Unsupported cases are still useful data.
+
+### 2. Correctness and ranking are separate
+
+- Safety and correctness come from structural analysis and validation.
+- Ranking decides which already-safe candidates are most promising.
+- ML, if added later, is only a ranking aid and must not replace correctness checks.
+
+### 3. Prefer reusable graph/search layers over one-off heuristics
+
+When adding new strategies:
+
+- prefer shared graph features over strategy-local AST hacks
+- prefer reusable export/import reasoning over bespoke barrel handling
+- prefer explicit candidate generation and ranking over direct single-choice classification
+
+### 4. Keep the system conservative
+
+- Default to no patch when evidence is weak.
+- Preserve public APIs when possible.
+- Avoid introducing new files unless the evidence supports it.
+- Minimize diff noise and touched files.
 
 ## Coding Conventions
-- **Conservative Autofix:** Auto-fix only narrow, safe cases (top-level named functions, consts, type aliases, interfaces). No classes, default exports, or modules with side-effects in v1.
-- **Layered Architecture:** Keep detection, classification, rewrite, and validation strictly separated.
-- **Deterministic Classification:** Every cycle must be classified clearly (`autofix_extract_shared`, `autofix_direct_import`, `autofix_import_type`, `suggest_manual`, or `unsupported`) with explainable reasons.
-- **Formatting Preservation:** jscodeshift uses recast to minimize diff noise and preserve the target repository's formatting.
-- **Strict Validation:** A patch is only valid if re-running dependency-cruiser shows no new cycles and `tsc --noEmit` succeeds.
-- **Type Safety:** All TypeScript strict mode. Use DTOs from `/db/index.ts` for data shapes.
 
-## Commands
-- `pnpm run dev` — Start both Fastify backend and TanStack Start frontend
-- `pnpm run scan <repo-url-or-path>` — Run the dependency analyzer and classifier on a target repository
-- `pnpm run scan:all` — Scan all tracked repositories in the SQLite database
-- `pnpm run retry:failed` — Retry failed patch candidates
-- `pnpm run export:patches` — Export approved patch files for PR generation
+- **Type Safety:** strict TypeScript throughout
+- **Explainability:** every classification or rank should be explainable
+- **Replayability:** store enough information to rescore and replay decisions later
+- **Formatting Preservation:** prefer low-noise diffs via recast/jscodeshift
+- **Validation Boundary:** a candidate is only trustworthy if cycle and validation checks pass
+
+## Implementation Priorities
+
+1. observation and evidence capture
+2. graph-analysis core
+3. search-based candidate generation
+4. benchmark-driven ranking
+5. broader automation only after the above are solid
+
+If a change adds a new fix path without improving the evidence pipeline, it is probably the wrong next change.

--- a/DEPS.md
+++ b/DEPS.md
@@ -1,8 +1,17 @@
 # Dependencies
 
-## Tool Versioning (mise.toml)
+## Why This Stack Exists
 
-All tool versions are pinned via [mise-en-place](https://mise.jdx.dev/):
+This repository is now aimed at a data-first, graph-aware autofix platform. The dependency stack is chosen to support four responsibilities:
+
+- detect real dependency cycles in JS and TS repositories
+- extract graph, semantic, and validation features that can be stored as training data
+- generate and validate candidate rewrites with low diff noise
+- expose enough operational and review surface to learn which strategies actually work
+
+## Runtime Tooling
+
+All core tools are pinned via `mise.toml`:
 
 ```toml
 [tools]
@@ -13,58 +22,139 @@ pnpm = "10"
 ## System Dependencies
 
 ### macOS
+
 ```bash
 brew install mise
 mise install
 ```
 
 ### Linux (Debian/Ubuntu)
+
 ```bash
 sudo apt update
 sudo apt install -y git curl jq unzip sqlite3 build-essential python3 ca-certificates
-# Install mise: https://mise.jdx.dev/getting-started.html
 mise install
 ```
 
-## Node Dependencies (managed by pnpm)
+## Current Node Dependencies
 
-### Core Pipeline
-| Package | Purpose |
-|---|---|
-| `dependency-cruiser` | Circular dependency detection via structured JSON output |
-| `ts-morph` | TypeScript Compiler API wrapper for semantic analysis |
-| `jscodeshift` | Codemod engine for safe AST rewrites |
-| `recast` | Formatting-preserving code printer (used by jscodeshift) |
-| `simple-git` | Git operations for cloning, worktrees, and patch generation |
+### Cycle detection and semantic analysis
 
-### Backend
-| Package | Purpose |
+| Package | Role in the roadmap |
 |---|---|
-| `fastify` | API server for the review UI |
-| `@fastify/cors` | CORS support for frontend ↔ backend dev |
-| `better-sqlite3` | SQLite access layer |
+| `dependency-cruiser` | File-level dependency graph and circular dependency detection |
+| `ts-morph` | AST inspection, import/export analysis, semantic feature extraction |
 
-### Frontend
-| Package | Purpose |
+### Rewrite and patch generation
+
+| Package | Role in the roadmap |
 |---|---|
-| `@tanstack/react-start` | Full-stack React framework (SSR + routing) |
+| `jscodeshift` | Rewrite engine for candidate fixes |
+| `recast` | Low-noise patch printing and formatting preservation |
+
+### Repository and workflow control
+
+| Package | Role in the roadmap |
+|---|---|
+| `simple-git` | Clone, fetch, branch, and patch export workflows |
+| `commander` | CLI surface for scan, retry, export, and future reporting commands |
+
+### Data and API surface
+
+| Package | Role in the roadmap |
+|---|---|
+| `better-sqlite3` | Local evidence store for scans, candidates, validations, reviews, and benchmarks |
+| `fastify` | API surface for findings, cycle detail, review, and future reporting endpoints |
+| `@fastify/cors` | Local frontend-backend development support |
+
+### Review UI
+
+| Package | Role in the roadmap |
+|---|---|
+| `@tanstack/react-start` | App shell for the review and benchmark UI |
 | `@tanstack/react-router` | File-based routing |
-| `@tanstack/react-query` | Data fetching and cache management |
-| `react` / `react-dom` | UI library |
-| `tailwindcss` | Utility-first CSS |
+| `@tanstack/react-query` | Data fetching and cache coordination |
+| `react` / `react-dom` | UI layer |
+| `tailwindcss` | Styling |
 | `lucide-react` | Icons |
 
-### Dev Tools
-| Package | Purpose |
-|---|---|
-| `typescript` | Type checking |
-| `vite` | Build tool and dev server |
-| `vitest` | Test runner |
-| `tsx` | TypeScript execution for CLI and backend |
-| `concurrently` | Run frontend + backend in parallel |
+### Quality and development tools
 
-## Quality Tools (planned)
-- ESLint
-- Biome
-- Playwright (e2e)
-- Knip (dead code detection)
+| Package | Role in the roadmap |
+|---|---|
+| `typescript` | Type checking and compiler-backed validation |
+| `vite` | Frontend build and dev workflow |
+| `vitest` | Unit and integration testing |
+| `tsx` | TypeScript execution for CLI and backend |
+| `concurrently` | Local dev orchestration |
+| `eslint` | Static analysis |
+| `@biomejs/biome` | Formatting and additional checks |
+
+## Dependency Direction by Project Goal
+
+### 1. Data collection
+
+The system must store not only successful patches, but also:
+
+- unsupported cycles
+- rejected strategies
+- validation failures
+- review outcomes
+- benchmark labels
+
+Current stack support:
+
+- `better-sqlite3`
+- `fastify`
+- `commander`
+
+### 2. Graph and search infrastructure
+
+The current stack is sufficient to build the first reusable graph/search layer without committing to a separate graph library yet.
+
+Current stack support:
+
+- `dependency-cruiser` for file graph input
+- `ts-morph` for symbol and AST data
+
+Planned capability, not yet a fixed dependency:
+
+- explicit symbol graph construction
+- SCC decomposition
+- weighted edge scoring
+- def-use slicing
+- cluster and partition search
+
+### 3. Ranking and learning
+
+The current codebase should export model-ready datasets before adding a dedicated ML dependency.
+
+This means:
+
+- keep heuristic scoring as the baseline
+- store versioned features and outcomes
+- add offline dataset export first
+- only add model tooling when benchmark data is stable enough to justify it
+
+No ML framework is a required dependency yet by design.
+
+## Planned Additions
+
+These are planned capability areas, not locked package choices:
+
+- offline dataset export for ranking experiments
+- reporting commands and API endpoints for failure clusters and strategy performance
+- optional model training and inference tooling after the evidence pipeline is stable
+- richer repo-profile and validation inference
+
+## Quality Expectations
+
+New dependencies should help one of these goals:
+
+- improve cycle understanding
+- improve candidate generation
+- improve evidence capture
+- improve ranking quality
+- improve replay, validation, or reviewability
+
+If a new dependency does not clearly strengthen one of those, it probably does not belong here.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,377 +1,208 @@
-# Circular Dependency Autofix Bot MVP Plan
+# Circular Dependency Autofix Bot
+## Data-First Completion Plan
 
 ## Summary
 
-This application will scan JavaScript and TypeScript repositories for circular dependencies, classify which cycles are likely safe to fix automatically, generate patch files for those fixes, store the findings and patches in a database, and provide a simple review UI so a human can inspect candidates and choose which fixes should become pull requests.
-
-The first release should focus on high-confidence, low-risk fixes in JS, JSX, TS, and TSX files. It should not try to solve every circular dependency. Its value comes from being conservative, repeatable, and useful across many repositories.
-
-The operating model is:
-
-1. Pull or update repository heads on a cheap server.
-2. Run dependency analysis against each repo.
-3. Detect circular dependencies and normalize them into distinct issues.
-4. Classify each issue into fixable now, suggest-only, or ignore.
-5. Generate patch files for high-confidence cases.
-6. Store repo metadata, findings, patch files, validation results, and review state in a database.
-7. Present a small UI for triage, review, and PR decisions.
-
----
-
-## Tech stack decisions
-
-### Runtime and tooling
-- **Node.js 25** — Latest LTS runtime, pinned via `mise.toml`
-- **pnpm 10** — Package manager, pinned via `mise.toml`
-- **TypeScript** — Strict mode throughout
-
-### Frontend
-- **TanStack Start** — Full-stack React framework with SSR, built on Vite 7
-- **TanStack Router** — File-based routing in `/src/routes`
-- **TanStack Query (React Query)** — Data fetching and cache management for the review UI
-- **React 19** — UI library
-- **Tailwind CSS 4** — Utility-first styling via `@tailwindcss/vite` plugin
-- **Lucide React** — Icon library
-
-### Backend API
-- **Fastify 5** — Lightweight API server on port 3001, serves `/api/*` endpoints
-- **@fastify/cors** — CORS support for frontend dev server communication
-
-### Database
-- **SQLite** — Simple, embedded database for findings, repos, patch metadata, and review state
-- **better-sqlite3** — Synchronous SQLite access layer for Node.js
-
-### Core analysis and fix pipeline
-- **dependency-cruiser** — Primary cycle detector and dependency graph source; uses structured JSON output
-- **ts-morph** — Convenience layer over the TypeScript Compiler API for AST navigation and semantic analysis
-- **jscodeshift** — Primary codemod rewrite engine for moving declarations and rewriting imports
-- **recast** — Formatting-preserving printer used with jscodeshift to minimize diff noise
-
-### Validation and developer workflow
-- **TypeScript (`tsc`)** — Typecheck validation after rewrite via `tsc --noEmit`
-- **eslint** — Optional post-fix lint validation (planned)
-- **prettier** — Optional post-fix formatting normalization (planned)
-- **simple-git** — Git operations for cloning, worktree isolation, and clean diff creation
-
-### UI enhancements (planned)
-- **Monaco Editor** or **CodeMirror** — Side-by-side diff or patch inspection in the review UI
-
-### GitHub integration (later in MVP if needed)
-- **octokit** — Use later when creating PRs through GitHub API becomes worth it
-
-### Alternate candidates if primary tools have issues
-- **Madge** — Alternate dependency graph tool, simpler but less configurable than dependency-cruiser
-- **Babel parser / @babel/traverse** — Alternate AST stack for JS-first parsing, fallback if jscodeshift or ts-morph struggles on some repos
-- **tsquery** — Helpful if query-style AST matching becomes useful
-- **PostgreSQL** — Upgrade path if SQLite becomes too limiting for multi-repo history and UI filtering
-
----
-
-## MVP goals
-
-- [ ] Detect circular dependencies in JS, JSX, TS, and TSX files across cloned repositories.
-- [ ] Normalize cycle reports so duplicate cycle orderings collapse into one issue.
-- [ ] Classify cycles into high-confidence auto-fix, suggest-only, or unsupported.
-- [ ] Auto-fix only a narrow class of safe cases.
-- [ ] Generate patch files for candidate fixes.
-- [ ] Re-run dependency analysis and validation after a rewrite.
-- [ ] Store findings and artifacts in a database.
-- [ ] Provide a simple review UI to inspect findings and patches before making PRs.
-- [ ] Keep the system conservative enough that accepted patches build trust instead of creating noise.
-
----
-
-## MVP safe auto-fix scope
-
-The first release should only auto-fix cycles that match all or nearly all of the following:
-
-- [ ] Two-file cycle only.
-- [ ] Files are `.js`, `.jsx`, `.ts`, or `.tsx`.
-- [ ] Candidate shared symbol is a top-level named function, const, type alias, or interface.
-- [ ] No default export involved in the extracted symbol.
-- [ ] No class extraction in v1.
-- [ ] No module-local mutable state captured by the extracted symbol.
-- [ ] No obvious top-level side-effect dependency required for the symbol to behave correctly.
-- [ ] No namespace import or re-export trickery involved in the moved symbol.
-- [ ] The new shared file does not create another cycle.
-- [ ] Validation passes after rewrite.
-
----
-
-## MVP implementation checklist
-
-### 1. Repository runner and workspace management
-
-- [x] Create a worker that can clone a repo if it does not exist locally.
-- [x] Add update logic to fetch and hard-reset to the target remote branch head.
-- [x] Store repo metadata such as owner, name, default branch, last scanned commit, local path, and last scan time.
-- [x] Use isolated temp worktrees or temp copies for rewrite attempts so patch generation stays clean.
-- [x] Add per-repo status tracking such as queued, scanning, analyzed, patched, validation failed, ready for review, ignored.
-- [x] Add retry and failure tracking for clone, install, analyze, rewrite, and validation stages.
-
-### 2. Dependency cycle detection
-
-- [x] Run dependency-cruiser against JS, JSX, TS, and TSX files only.
-- [x] Configure output as structured JSON instead of only terminal text.
-- [x] Parse only circular dependency findings for the MVP pipeline.
-- [ ] Normalize cycle order so the same cycle is not stored multiple times due to rotation.
-- [x] Store normalized cycle path, participating files, and raw depcruise payload in the database.
-- [x] Add file filtering rules for obvious generated, vendored, dist, coverage, and test output paths.
-
-### 3. AST and semantic analysis layer
-
-- [x] Build an analysis service around ts-morph.
-- [x] Parse both files participating in a two-file cycle.
-- [x] Identify import edges crossing between the two files.
-- [x] Resolve which imported symbols are actually responsible for the cross-file dependency.
-- [x] For each candidate symbol, collect declaration kind, export kind, location, references, and free variables. (Implemented classification based on these)
-- [x] Detect whether the candidate symbol references module-local mutable state. (Via dependency check)
-- [x] Detect whether the candidate symbol depends on sibling helpers that would also need to move.
-- [x] Detect whether a candidate edge is type-only and may be solvable with `import type`.
-- [ ] Detect barrel-file scenarios where direct imports may remove the cycle without extraction.
-- [x] Produce a fix classification for each cycle.
-
-### 4. Fix classification engine
-
-- [x] Create a deterministic classification enum such as `autofix_extract_shared`, `autofix_direct_import`, `autofix_import_type`, `suggest_manual`, `unsupported`.
-- [x] Mark two-file cycles with safe top-level declarations as `autofix_extract_shared`.
-- [ ] Mark cycles caused by barrel imports as `autofix_direct_import` where safe.
-- [x] Mark TS type-only opportunities as `autofix_import_type` where safe.
-- [x] Mark class-heavy, side-effect-heavy, or multi-file entangled cycles as `suggest_manual` or `unsupported`.
-- [x] Attach a confidence score and a reason list to every classification.
-
-### 5. Shared-file extraction codemod
-
-- [x] Implement extraction of top-level named functions, consts, type aliases, and interfaces into a new leaf file. (Initial narrow implementation with deterministic pair-based shared filenames)
-- [ ] Prefer semantic file names like `shared.ts`, `render-primitives.tsx`, or `types.ts` when obvious.
-- [x] Fall back to machine-generated pair names only when no better semantic name can be inferred.
-- [x] Rewrite the original two files to import from the new shared file.
-- [x] Preserve exports so the rest of the repo behaves the same as before.
-- [x] Preserve relative import correctness from the new shared file.
-- [ ] Use recast or equivalent printing to reduce formatting churn.
-- [x] Abort and mark failed if the extracted file would itself depend back on one of the original files. (Current implementation fails closed before generation based on semantic analysis)
-
-### 6. Alternate fix codemods for v1
-
-- [ ] Implement direct-import replacement when a barrel file causes the cycle and a direct leaf import removes it safely.
-- [x] Implement `import type` conversion when a TS cycle is runtime-free and clearly type-only. (Initial patch-generation implementation)
-- [ ] Keep these fixes behind the same validation requirements as extraction fixes.
-
-### 7. Validation pipeline
-
-- [x] Re-run dependency-cruiser after each rewrite attempt.
-- [x] Verify that the original target cycle no longer exists.
-- [ ] Verify that no new circular dependency was introduced by the rewrite.
-- [x] Run `tsc --noEmit` when a TypeScript project is detected. (Current implementation runs when `tsconfig.json` exists)
-- [ ] Optionally run repo lint if it is cheap and predictable.
-- [ ] Optionally run targeted tests if the repo has a simple and reliable command for them.
-- [x] If validation fails, store the failure reason and keep the patch for manual inspection if useful.
-
-### 8. Patch generation and artifact storage
-
-- [x] Generate a unified diff patch for every successful rewrite. (Initial generated patch artifact format)
-- [x] Store patch text, touched files, classification, confidence, and validation summary in the database.
-- [ ] Store before and after cycle results for easy UI comparison.
-- [x] Keep a copy of the generated shared file contents or transformed file contents for review. (Included in persisted patch text)
-- [ ] Track whether a finding has been reviewed, approved, rejected, ignored, or turned into a PR candidate.
-
-### 9. Database schema
-
-- [x] Create a `repositories` table.
-- [x] Create a `scans` table linked to repositories and commit SHAs.
-- [x] Create a `cycles` table for normalized cycle issues.
-- [x] Create a `fix_candidates` table for classification output and confidence.
-- [x] Create a `patches` table for generated patch content and validation status.
-- [x] Create a `review_decisions` table for human triage state.
-- [x] Add indexes for repo, commit, status, confidence, and review state.
-
-### 10. Review UI
-
-- [x] Build a repositories list view.
-- [x] Build a findings queue filtered by status and confidence.
-- [x] Show normalized cycle path and participating files.
-- [x] Show fix classification, confidence, and reasons.
-- [x] Show unified diff patch text.
-- [x] Show before and after dependency summary.
-- [x] Add review actions such as approve, reject, ignore, and revisit later.
-- [ ] Add basic search and filters by repo, cycle size, classification, and validation status.
-
-### 11. CLI and operations
+The next phase of this project is focused on turning the system into a data-generating cycle lab that learns which rewrites are useful, safe, and reviewable across real repositories.
 
-- [x] Build a CLI command to scan one repo.
-- [x] Build a CLI command to scan all tracked repos.
-- [x] Build a CLI command to retry failed candidates.
-- [x] Build a CLI command to export approved patches.
-- [ ] Add logging for clone, dep analysis, classification, rewrite, and validation stages.
-- [ ] Add concurrency limits so a cheap server does not thrash itself.
+The goal is to move from:
 
-### 12. Backend API
+`detect -> classify -> patch -> validate -> review`
 
-- [x] Create Fastify server on port 3001.
-- [x] Implement REST endpoints for repositories CRUD.
-- [x] Implement findings and cycle detail endpoints.
-- [x] Implement review decision endpoint.
-- [ ] Add authentication or API key protection.
-- [ ] Add request validation schemas.
+to:
 
-### 13. Metrics and trust-building
+`detect -> extract features -> rank against historical evidence -> generate candidates -> validate -> review -> learn`
 
-- [ ] Track total repos scanned.
-- [ ] Track total cycles found.
-- [ ] Track high-confidence candidates found.
-- [ ] Track successful auto-fixes.
-- [ ] Track validation pass rate.
-- [ ] Track review approval rate.
-- [ ] Track accepted PR rate later when GitHub integration is added.
+This plan is the documentation source of truth for that transition.
 
----
+## Phase Goal
+
+Completion for this phase means:
+
+- every cycle produces reusable feature and evidence data, even when no fix is generated
+- ranking and promotion are driven by historical data, not only static heuristic weights
+- the planner uses an explicit graph/search layer for candidate generation
+- the system identifies and auto-promotes a materially larger set of real-world patterns across the benchmark corpus
+- benchmark and review data measurably improve future ranking and promotion decisions
 
-## Recommended MVP release slices
+## Slice 1: Make Data Capture the Primary Product Surface
 
-### Slice 1: detector only
+### Required outcomes
 
-- [ ] Clone or update a repo.
-- [ ] Run dependency-cruiser.
-- [ ] Normalize circular dependency findings.
-- [ ] Store results in SQLite.
-- [ ] Show findings in a minimal UI.
+- Add first-class `cycle_observations` and `candidate_observations` style storage, either as new tables or as structured extensions of the current cycle/candidate records.
+- Capture, for every scan:
+  - canonical cycle identity
+  - repo profile
+  - feature vector
+  - strategy attempts
+  - selected rank order
+  - validation result and failure category
+  - review outcome
+  - benchmark and acceptance labels
+- Persist graph-derived metadata even for `unsupported` and `suggest_manual` cases.
+- Add rescoring and replay paths so historical candidates can be re-ranked when evidence changes.
+- Add reporting surfaces for:
+  - top failure clusters
+  - most common cycle shapes
+  - strategy success rate by repo profile
+  - acceptance rate by strategy family
+  - unsupported but recurrent pattern groups
+- Make `retry:failed` a real workflow that consumes stored observations and produces new patch or validation history without erasing prior attempts.
 
-### Slice 2: classifier only
+### Why this slice matters
 
-- [ ] Add AST and semantic analysis.
-- [ ] Classify cycles into safe, suggest-only, unsupported.
-- [ ] Display classification reasons in the UI.
-- [ ] Do not rewrite yet.
+Without this, the system still behaves like a one-shot heuristic tool. With it, every run improves the training and evaluation dataset.
 
-### Slice 3: first autofix
+## Slice 2: Introduce a Reusable Graph-Analysis Core
 
-- [x] Implement shared-file extraction for a very narrow safe case.
-- [x] Generate patch files.
-- [x] Re-run depcruise and typecheck. (Initial validation pipeline implemented)
-- [x] Store successful patches.
+### Required outcomes
 
-### Slice 4: review workflow
+- Build a reusable symbol-level dependency graph layer beneath the planner.
+- The graph layer must compute:
+  - symbol-to-symbol dependencies
+  - symbol-level SCCs
+  - file-level and symbol-level import and export edges
+  - transitive re-export resolution
+  - top-level initialization and side-effect risk labels
+  - declaration movability and API-preservation signals
+- Keep graph output serializable so it can be stored with observations and benchmark rows.
+- Replace strategy-local barrel logic with a reusable export graph module.
 
-- [ ] Add review states and patch approval.
-- [ ] Add export of approved patch files.
-- [ ] Improve UI diff display and filtering.
-
-### Slice 5: scale-out quality
-
-- [ ] Add direct-import and `import type` fixes.
-- [ ] Add concurrency controls and batch scans.
-- [ ] Improve confidence scoring.
-- [ ] Add basic repository allowlist and ignore rules.
-
----
-
-## Things we probably cannot safely handle in the first release
-
-### Hard architectural cycles
-
-- [ ] Multi-file cycles with business logic spread across three or more files.
-- [ ] Cycles involving workflow orchestration, service registries, or plugin loaders.
-- [ ] Cycles where the real fix is dependency inversion rather than extraction.
-
-### Import-time behavior and side effects
-
-- [ ] Modules with top-level side effects that influence runtime behavior.
-- [ ] Modules that register handlers, patch globals, or initialize caches on import.
-- [ ] Cycles where import evaluation order may be semantically important.
-
-### Complex symbol kinds
-
-- [ ] Classes with instance state, private fields, decorators, or inheritance-sensitive behavior.
-- [ ] Default-export-heavy modules with ambiguous safe extraction boundaries.
-- [ ] Namespace imports and re-export graphs that obscure the true dependency edge.
-
-### Framework-specific edge cases
-
-- [ ] Framework magic files and convention-based imports that are not easy to reason about generically.
-- [ ] Dynamic import routing systems and code splitting patterns that hide actual runtime edges.
-- [ ] Build-time generated files or macro-driven source transforms.
-
-### Validation complexity
-
-- [ ] Repositories with no reliable automated validation command.
-- [ ] Monorepos with unusual workspace bootstrapping requirements.
-- [ ] Repositories whose tests are too expensive or too flaky to use as part of automated patch acceptance.
-
----
-
-## Roadmap for future releases
-
-### Future release: safer and broader analysis
-
-- [ ] Add stronger free-variable and dependency-closure analysis.
-- [ ] Add side-effect detection scoring at module level.
-- [ ] Add better handling for sibling helper chains that need to move together.
-- [ ] Add import-order risk scoring.
-
-### Future release: broader fix types
-
-- [ ] Support multi-symbol extraction in one pass.
-- [ ] Support extraction of small clusters of dependent helper functions.
-- [ ] Support splitting runtime from types automatically into `types.ts`.
-- [ ] Support dependency inversion suggestions for service-layer cycles.
-- [ ] Support barrel import cleanup as a first-class fix path.
-
-### Future release: richer repository understanding
-
-- [ ] Detect common repo tooling and infer validation commands automatically.
-- [ ] Add monorepo package awareness and per-package scan targeting.
-- [ ] Add framework profiles for React, Next.js, Vite, Express, Nest, and similar ecosystems.
-- [ ] Add repo-specific ignore and allow rules.
-
-### Future release: better review and PR flow
-
-- [ ] Add GitHub authentication and PR creation with Octokit.
-- [ ] Generate PR descriptions explaining the detected cycle, the fix type, and validation results.
-- [ ] Add reviewer notes and acceptance history.
-- [ ] Add support for re-running a previously approved patch on a newer commit.
-
-### Future release: trust and quality metrics
-
-- [ ] Add historical fix acceptance rate by classification type.
-- [ ] Add false-positive and false-fix tracking.
-- [ ] Add confidence calibration based on actual review outcomes.
-- [ ] Add dashboards for repo health and autofix success rate.
-
-### Future release: horizontal scale
-
-- [ ] Add a queue and worker model for many repositories.
-- [ ] Add object storage for patch artifacts and scan reports.
-- [ ] Upgrade from SQLite to PostgreSQL if scan volume grows.
-- [ ] Add deduplicated caching of repository analysis state by commit SHA.
-
----
-
-## Suggested first-repo testing strategy
-
-- [ ] Test first on a small set of repositories you know how to validate.
-- [ ] Include a few TypeScript-heavy repos and a few mixed JS or TSX repos.
-- [ ] Start by running in detector-only mode and comparing findings with manual inspection.
-- [ ] Enable autofix only on repos where validation is predictable.
-- [ ] Review and score every generated patch manually before thinking about PR automation.
-- [ ] Use the earliest approval and rejection data to refine safe-case heuristics.
-
----
-
-## Practical success criteria for the MVP
-
-- [ ] It can scan many repositories without manual setup for each one.
-- [ ] It can identify circular dependencies reliably enough to be useful.
-- [ ] It only auto-fixes a narrow class of cases with a high validation pass rate.
-- [ ] It produces patch files that are small, understandable, and easy to review.
-- [ ] It gives a human reviewer enough evidence to trust or reject a patch quickly.
-- [ ] It builds a feedback loop that improves the classifier over time.
-
----
-
-## Notes on project philosophy
-
-- [ ] Prefer a small number of highly reliable fixes over broad but noisy automation.
-- [ ] Keep detection, classification, rewrite, and validation as separate layers.
-- [ ] Make every classification explainable.
-- [ ] Treat cycle removal as a trust problem as much as a technical one.
-- [ ] Design for reviewability, not just automation.
+### Why this slice matters
+
+Broader automation requires reasoning about real dependency structure, not only file-level heuristics and ad hoc AST checks.
+
+## Slice 3: Replace Single-Strategy Heuristics with Explicit Search
+
+### Required outcomes
+
+- Generate candidate rewrites by searching over graph edits instead of directly choosing one heuristic outcome.
+- Implement search primitives for:
+  - weighted feedback-edge removal
+  - def-use and dependency-closure slicing
+  - graph partition or leaf-cluster detection for larger SCCs
+  - constrained candidate scoring for API preservation, files touched, side-effect risk, and naming fit
+- Keep multiple viable candidates ranked through persistence, validation, and review instead of collapsing too early to a single winner.
+
+### Strategy families to add on top of the graph core
+
+- `state_setter_inline`
+- `type_value_split`
+- `slice_extract_shared_v2`
+- `barrel_export_graph_rewrite_v2`
+- `internal_entrypoint_pattern` as manual-only initially
+
+### Why this slice matters
+
+This is the step that turns the planner from a fixed classifier into a search-and-rank engine.
+
+## Slice 4: Turn the Corpus into the Main Evaluation Loop
+
+### Required outcomes
+
+- Treat benchmark mining as the primary evaluation framework, not side data.
+- Maintain a stable corpus of real TypeScript repositories spanning:
+  - libraries
+  - applications
+  - monorepos and workspaces
+  - barrel-heavy repos
+  - state-heavy UI repos
+- For each repo, cycle, and candidate, store:
+  - graph features
+  - planner features
+  - validation outcomes
+  - review labels
+  - acceptance labels
+  - diff-shape metrics
+- Add offline evaluation commands that answer:
+  - which patterns recur most often
+  - which patterns are easiest to solve mechanically
+  - which strategies regress on specific repo profiles
+  - where automation should stay manual-only
+
+### Definition of a discovered pattern
+
+A pattern is considered discovered when there is:
+
+- a recurring cycle shape
+- a recurring successful transformation
+- acceptable validation and review outcomes across multiple repositories
+
+## Slice 5: Add Learned Ranking After the Data Pipeline Is Stable
+
+### Required outcomes
+
+- Keep the deterministic scorer as the baseline.
+- Export model-ready datasets from stored observation tables.
+- Train offline ranking models to predict:
+  - patch acceptability
+  - validation risk
+  - diff noisiness
+  - repo-convention mismatch risk
+- Use learned ranking only to order already-safe candidates.
+- Keep model inference optional, versioned, and directly comparable against heuristic ranking.
+
+### Important boundary
+
+ML is a ranking mechanism, not a correctness mechanism.
+
+## Slice 6: Finish the Automation Boundary
+
+### Required outcomes
+
+- Patch generation should happen only for candidates that clear ranking, confidence, and evidence gates.
+- PR creation should happen only for candidates with passed validation and positive acceptance signals for similar cases.
+- Add active-learning surfaces for:
+  - best unsupported clusters
+  - high-score but repeatedly rejected clusters
+  - manual fixes that should become formal strategies
+- Make the review UI and API expose the evidence behind each rank so human decisions improve the training data.
+
+## Interfaces and Data Changes
+
+- Add persistent observation storage or extend current tables so every cycle attempt is queryable as training data.
+- Version feature vectors, graph summaries, and ranking outputs for replay and rescoring.
+- Extend planner output to include:
+  - graph summary
+  - feature vector snapshot
+  - evidence summary
+  - promotion eligibility
+  - failure signature history
+- Extend CLI and API with:
+  - `rescore`
+  - `report:patterns`
+  - `report:strategy-performance`
+  - `report:unsupported-clusters`
+  - real `retry:failed`
+
+## Test and Acceptance Plan
+
+- Unit tests for:
+  - graph extraction
+  - SCC detection
+  - re-export resolution
+  - side-effect labeling
+  - slicing
+  - candidate search scoring
+- Integration tests for:
+  - scan -> observe -> rank -> validate -> review -> rescore loops
+  - retry and replay workflows
+  - evidence-informed reranking
+- Corpus tests that verify new benchmark and review data changes ranking outcomes.
+- Acceptance tests for each new strategy family on real-repo fixtures and benchmark-labeled cases.
+
+## Phase Completion Criteria
+
+- every scanned cycle yields a stored observation row
+- ranking changes measurably when evidence changes
+- `retry:failed` and rescoring work end to end
+- at least three strategy families beyond the current baseline show repeated accepted results in the corpus
+- benchmark reports identify recurrent solvable clusters instead of isolated one-off fixes
+
+## Project Principles
+
+- Data collection and pattern discovery are the top priority.
+- New strategy work must plug into the evidence pipeline, not bypass it.
+- Graph and search infrastructure should be built before many more bespoke heuristics.
+- Prefer globally useful patterns over repo-specific cleverness.
+- Default to no patch when the evidence is weak.

--- a/README.md
+++ b/README.md
@@ -1,115 +1,131 @@
 # Circular Dependency Autofix Bot
 
-Scans JavaScript and TypeScript repositories for circular dependencies, extracts planner features, ranks safe rewrite strategies, generates candidate patches, validates them, and provides a review/PR workflow for the cases worth sending upstream.
+This project is evolving from a conservative autofix bot into a data-first cycle analysis platform for JavaScript and TypeScript repositories.
+
+The core goal is no longer just "find a few safe fixes." The goal is to collect high-quality evidence about real circular dependency problems, identify recurring fix patterns, and automate the patterns that repeatedly validate and survive review.
+
+## Primary Goals
+
+- Turn every scan into reusable training and evaluation data, including unsupported cases.
+- Build a graph-aware planner that reasons about symbol dependencies instead of relying only on file-level heuristics.
+- Rank candidates using historical evidence from benchmarks, validation failures, and human review outcomes.
+- Keep correctness rule-driven and validation-driven, while using data and ML only to rank safe candidates.
+- Grow from narrow, trusted fixes into broader automation only when repeated real-repo evidence supports it.
+
+## Target Workflow
+
+The target product workflow is:
+
+`detect -> extract features -> rank against historical evidence -> generate candidates -> validate -> review -> learn`
+
+Each stage has a distinct job:
+
+1. `detect`
+   - find normalized circular dependency issues in real repositories
+2. `extract features`
+   - compute cycle shape, repo profile, import/export structure, side-effect risk, and graph metadata
+3. `rank against historical evidence`
+   - compare candidate strategies against benchmark cases, validation history, and review outcomes
+4. `generate candidates`
+   - produce multiple possible rewrites instead of collapsing too early to one heuristic answer
+5. `validate`
+   - confirm the target cycle is gone, no new cycles were introduced, and repo-native validation or `tsc` passes
+6. `review`
+   - expose the evidence, patch, validation results, and ranking rationale to a human reviewer
+7. `learn`
+   - feed review outcomes, validation failures, and benchmark labels back into future ranking
+
+## Data-First Direction
+
+The project now treats data capture as a first-class product surface.
+
+Every cycle should eventually produce reusable observations such as:
+
+- canonical cycle identity
+- participating files and normalized shape
+- repo profile and validation environment
+- extracted feature vectors
+- strategy attempts, scores, and ranking
+- generated patches and replay bundles
+- validation outcomes and failure categories
+- review decisions and acceptance labels
+
+The long-term value of the system comes from this loop. Even unsupported cycles should become analyzable examples rather than dead ends.
+
+## Strategy Roadmap
+
+### Current strategy families
+
+- `autofix_import_type`
+- `autofix_direct_import`
+- `autofix_extract_shared`
+- `autofix_host_state_update`
+
+### Next strategy families
+
+- `state_setter_inline`
+- `type_value_split`
+- `slice_extract_shared_v2`
+- `barrel_export_graph_rewrite_v2`
+- `internal_entrypoint_pattern` as manual-only until benchmark evidence supports promotion
+
+## Graph, Search, and ML Roadmap
+
+The medium-term technical direction is explicit:
+
+- build a reusable symbol-level dependency graph layer
+- compute symbol-level SCCs, import/export edges, re-export resolution, and side-effect risk
+- search over candidate graph edits instead of only applying fixed heuristics
+- use weighted edge scoring, def-use slicing, and clustering to find the cheapest safe cycle-breaking rewrites
+- export model-ready datasets and add learned ranking later, only for ranking already-safe candidates
+
+ML is not the correctness mechanism. Validation and structural safety checks remain the correctness boundary.
+
+## Repository Layout
+
+```text
+├── src/                 # TanStack Start frontend and review UI
+├── backend/             # Fastify API server
+├── analyzer/            # Cycle detection, feature extraction, planner logic
+├── codemod/             # Patch generation and rewrite logic
+├── cli/                 # Scan, retry, export, and reporting commands
+├── db/                  # SQLite schema and data access layer
+├── worktrees/           # Local repo clones and isolated workspaces
+├── PLAN.md              # Source-of-truth roadmap for the data-first platform
+├── DEPS.md              # Dependency rationale and planned technical additions
+└── AGENTS.md            # Implementation guidance for contributors and coding agents
+```
 
 ## Quick Start
 
 ```bash
-# Install mise (if not already installed)
-brew install mise   # macOS
-# or see https://mise.jdx.dev/getting-started.html
-
-# Install pinned tools
+brew install mise
 mise install
-
-# Install dependencies
 pnpm install
-
-# Start dev servers (frontend + backend)
 pnpm run dev
 ```
 
-- **Frontend:** http://localhost:3000 (TanStack Start)
-- **Backend API:** http://localhost:3001/api (Fastify)
+- Frontend: `http://localhost:3000`
+- Backend API: `http://localhost:3001/api`
 
-## Architecture
-
-```
-├── src/                         # TanStack Start frontend and review UI
-│   ├── routes/                  # Repository, cycle, findings, and about routes
-│   ├── components/              # Shared UI shell
-│   ├── lib/                     # API client helpers
-│   └── routeTree.gen.ts         # Generated route tree
-├── backend/                     # Fastify API server
-│   └── server.ts                # REST endpoints for scans, cycles, patches, and reviews
-├── analyzer/                    # Detection, normalization, feature extraction, and strategy ranking
-│   ├── analyzer.ts              # dependency-cruiser entrypoint and repo/evidence wiring
-│   ├── cycleNormalization.ts    # Canonical cycle identity helpers
-│   └── semantic/                # Feature extraction, evidence scoring, planner output
-├── cli/                         # CLI orchestration, validation, benchmarking, and PR automation
-│   ├── scanner/                 # Target resolution, persistence, and replay bundle generation
-│   ├── createPullRequest/       # Scratch checkout, snapshot replay, and PR rendering
-│   ├── acceptanceBenchmark.ts   # Acceptance benchmark snapshotting and annotations
-│   ├── benchmarkCorpus.ts       # Corpus batch mining
-│   ├── benchmarkMiner.ts        # Local git-history miner
-│   ├── repoProfile.ts           # Repo-native validation command inference
-│   ├── smoke.ts                 # Fixture-driven real-repo smoke suite
-│   ├── validation.ts            # Graph + repo-native validation
-│   └── index.ts                 # CLI entrypoint
-├── codemod/                     # Patch generation and file snapshot export
-│   └── generatePatch.ts
-├── db/                          # SQLite schema, DTOs, prepared statements, and metrics inputs
-│   └── index.ts
-├── benchmarks/                  # Real-repo corpus definitions and notes
-├── smoke.fixtures.json          # Default smoke suite fixture list
-└── worktrees/                   # Temp clones / scratch checkouts (gitignored)
-```
-
-## CLI Commands
+## Current CLI Surface
 
 ```bash
-pnpm run scan <repo-url-or-path>                 # Scan a repository and persist cycles/candidates
-pnpm run explain <repo-url-or-path>              # Print planner output for each detected cycle
-pnpm run profile:repo <repo-path>                # Infer repo-native validation commands
-pnpm run smoke [fixturesPath]                    # Run the real-repo smoke suite
-pnpm run benchmark:acceptance                    # Snapshot acceptance benchmark cases from corpus scans
-pnpm run mine:corpus                             # Mine historical benchmark cases from the repo corpus
-pnpm run mine:repo-history <repo-path>           # Mine benchmark cases from one local checkout
-pnpm run create:pr <patchId> --issue <number>   # Replay a stored patch and open a PR
-pnpm run export:patches [outputDir]              # Export approved or PR-candidate patch files
+pnpm run scan <repo-url-or-path>
+pnpm run scan:all
+pnpm run retry:failed
+pnpm run export:patches
 ```
 
-`scan:all` and `retry:failed` are still placeholders; the main operational paths are the commands above.
+Planned additions include rescoring, reporting, and corpus-analysis commands that make the data loop directly inspectable.
 
-## How It Works
+## Engineering Principles
 
-1. **Resolve a target** from a local path or remote repository URL and capture repository metadata.
-2. **Detect cycles** with `dependency-cruiser`, then normalize rotated equivalents into a canonical cycle identity.
-3. **Extract planner features** for each cycle and evaluate supported strategies:
-   - `autofix_import_type`
-   - `autofix_direct_import`
-   - `autofix_extract_shared`
-   - `autofix_host_state_update`
-4. **Rank candidates** with planner heuristics plus historical evidence from benchmark cases, validation failures, and review outcomes.
-5. **Generate patches** for promoted candidates, including replayable file snapshots for deterministic PR creation.
-6. **Validate rewrites** by replaying the patch in a scratch checkout, re-running analysis, failing on persisted or newly introduced cycles, and running repo-native validation commands plus `tsc --noEmit` when available.
-7. **Review or benchmark** results through the UI, acceptance benchmark workflow, or smoke suite.
-8. **Create PRs** only for candidates that clear the upstreamability threshold.
-
-## Safe Auto-Fix Scope (v1)
-
-The tool is still intentionally conservative. It targets narrow cycle shapes where the rewrite can be explained and validated mechanically:
-
-- Primarily two-file cycles, with a narrow barrel/direct-import exception
-- Files are `.js`, `.jsx`, `.ts`, or `.tsx`
-- Candidate declarations are simple top-level functions, consts, type aliases, or interfaces
-- No default exports or class extraction
-- No unsafe module-scope side effects
-- No extraction that would recreate the cycle in the shared file
-- No PR creation unless the candidate clears promotion and validation thresholds
-
-## Tech Stack
-
-| Layer | Technology |
-|---|---|
-| Runtime | Node.js 25 (via mise) |
-| Package Manager | pnpm 10 (via mise) |
-| Frontend | TanStack Start + React 19 + Tailwind CSS 4 |
-| Backend | Fastify 5 |
-| Database | SQLite (better-sqlite3) |
-| Analysis | dependency-cruiser + ts-morph |
-| Codemods | ts-morph + recast-friendly patch export |
-| Testing | Vitest |
+- Prefer explainable ranking over opaque automation.
+- Keep detection, feature extraction, ranking, rewriting, validation, and review separated.
+- Persist enough information to replay, rescore, and compare decisions later.
+- Default to no patch when evidence is weak.
+- Optimize for globally useful patterns, not repo-specific hacks.
 
 ## License
 

--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -215,6 +215,12 @@ describe('SemanticAnalyzer', () => {
       selectedStrategy: 'direct_import',
       selectedClassification: 'autofix_direct_import',
       selectedScore: 0.9,
+      graphSummary: {
+        metrics: {
+          barrelModuleCount: 1,
+          exportEdgeCount: 2,
+        },
+      },
     });
     expect(result.plan).toEqual({
       kind: 'direct_import',

--- a/analyzer/semantic/SemanticAnalyzer.ts
+++ b/analyzer/semantic/SemanticAnalyzer.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {
-  type ExportDeclaration,
   type FunctionDeclaration,
   type Identifier,
   type ImportDeclaration,
@@ -13,6 +12,7 @@ import {
 import type { Classification } from '../../db/index.js';
 import { createEmptyHistoricalEvidenceSnapshot } from './evidence.js';
 import { extractCycleFeatures } from './features.js';
+import { buildCycleGraph, findDirectImportPlanFromGraph } from './graph.js';
 import {
   applyHistoricalEvidence,
   createNotApplicableAttempt,
@@ -27,8 +27,6 @@ import {
 import type {
   CyclePlanningContext,
   CyclePlanningResult,
-  DirectImportFixPlan,
-  DirectImportSearchResult,
   ExtractSharedFixPlan,
   HistoricalEvidenceSnapshot,
   HostStateUpdateFixPlan,
@@ -100,6 +98,7 @@ export class SemanticAnalyzer {
       cycleShape: context.cycleShape,
       cycleSignals: context.cycleSignals,
       features: context.features,
+      graphSummary: context.graphSummary,
       fallbackClassification: selectedAttempt?.classification ?? fallbackDecision.classification,
       fallbackConfidence: selectedAttempt?.confidence ?? fallbackDecision.confidence,
       fallbackReasons: selectedAttempt?.reasons ?? fallbackDecision.reasons,
@@ -125,10 +124,21 @@ export class SemanticAnalyzer {
     const sourceFileB = fileB ? sourceFiles.get(fileB) : undefined;
     const importsAToB = sourceFileA && fileB ? this.findImportsTo(sourceFileA, fileB) : [];
     const importsBToA = sourceFileB && fileA ? this.findImportsTo(sourceFileB, fileA) : [];
+    const graphSummary = buildCycleGraph({
+      cycleFiles: uniqueFiles,
+      isWithinRepo: (absolutePath) => this.isWithinRepo(absolutePath),
+      loadSourceFile: (repoRelativePath) => this.loadCycleSourceFile(repoRelativePath),
+      resolveModulePath: (filePath, moduleSpecifier) =>
+        this.resolveModulePath(path.join(this.repoPath, filePath), moduleSpecifier),
+      toRepoRelativePath: (absolutePath) => this.toRepoRelativePath(absolutePath),
+    });
     const cycleSignals = {
       explicitImportEdges: importsAToB.length + importsBToA.length,
       loadedFiles: [...sourceFiles.values()].filter(Boolean).length,
       missingFiles: [...sourceFiles.values()].filter((sourceFile) => !sourceFile).length,
+      barrelModules: graphSummary.metrics.barrelModuleCount,
+      sideEffectModules: graphSummary.metrics.sideEffectModuleCount,
+      symbolSccs: graphSummary.metrics.symbolSccCount,
     };
 
     return {
@@ -141,9 +151,11 @@ export class SemanticAnalyzer {
       cycleSignals,
       repositoryProfile: this.plannerOptions.repositoryProfile,
       historicalEvidence: this.plannerOptions.historicalEvidence ?? createEmptyHistoricalEvidenceSnapshot(),
+      graphSummary,
       features: extractCycleFeatures({
         uniqueFiles,
         cycleShape,
+        graphSummary,
         cycleSignals,
         repositoryProfile: this.plannerOptions.repositoryProfile,
       }),
@@ -191,7 +203,7 @@ export class SemanticAnalyzer {
             cycleSize: context.uniqueFiles.length,
           },
         }),
-        evaluate: (context) => this.evaluateDirectImportAttempt(context.uniqueFiles),
+        evaluate: (context) => this.evaluateDirectImportAttempt(context.uniqueFiles, context.graphSummary),
       },
       {
         strategy: 'host_state_update',
@@ -433,10 +445,13 @@ export class SemanticAnalyzer {
     };
   }
 
-  private evaluateDirectImportAttempt(cycleFiles: string[]): StrategyAttempt {
-    const directImportResult = this.buildDirectImportPlan(cycleFiles);
+  private evaluateDirectImportAttempt(
+    cycleFiles: string[],
+    graphSummary: CyclePlanningContext['graphSummary'],
+  ): StrategyAttempt {
+    const directImportResult = findDirectImportPlanFromGraph(graphSummary, cycleFiles);
     if (!directImportResult.plan || directImportResult.plan.length === 0) {
-      if (directImportResult.sawBarrelScenario) {
+      if (directImportResult.ambiguousResolution) {
         return createRejectedAttempt(
           'direct_import',
           'Barrel re-export graph is ambiguous or side-effectful.',
@@ -968,278 +983,6 @@ export class SemanticAnalyzer {
 
   private normalizeRepoRelativePath(filePath: string): string {
     return filePath.split(path.sep).join('/');
-  }
-
-  private buildDirectImportPlan(cycleFiles: string[]): DirectImportSearchResult {
-    let sawBarrelScenario = false;
-
-    for (const sourceFilePath of cycleFiles) {
-      const searchResult = this.findDirectImportCandidateForSource(sourceFilePath, cycleFiles);
-      sawBarrelScenario ||= searchResult.sawBarrelScenario;
-      if (searchResult.plan) {
-        return searchResult;
-      }
-    }
-
-    return {
-      sawBarrelScenario,
-    };
-  }
-
-  private findDirectImportCandidateForSource(sourceFilePath: string, cycleFiles: string[]): DirectImportSearchResult {
-    const sourceFile = this.loadCycleSourceFile(sourceFilePath);
-    if (!sourceFile) {
-      return { sawBarrelScenario: false };
-    }
-
-    let sawBarrelScenario = false;
-
-    for (const barrelFilePath of cycleFiles) {
-      if (barrelFilePath === sourceFilePath) {
-        continue;
-      }
-
-      const barrelFile = this.loadCycleSourceFile(barrelFilePath);
-      if (!barrelFile || !this.hasReExportDeclarations(barrelFile)) {
-        continue;
-      }
-
-      const importDeclarations = this.findImportsTo(sourceFile, barrelFilePath);
-      if (importDeclarations.length === 0) {
-        continue;
-      }
-
-      sawBarrelScenario = true;
-
-      const candidate = this.findDirectImportCandidateForDeclarations(
-        sourceFilePath,
-        barrelFilePath,
-        barrelFile,
-        importDeclarations,
-        cycleFiles,
-      );
-      if (candidate) {
-        return {
-          sawBarrelScenario: true,
-          plan: [candidate],
-        };
-      }
-    }
-
-    return { sawBarrelScenario };
-  }
-
-  private findDirectImportCandidateForDeclarations(
-    sourceFilePath: string,
-    barrelFilePath: string,
-    barrelFile: SourceFile,
-    importDeclarations: ImportDeclaration[],
-    cycleFiles: string[],
-  ): DirectImportFixPlan['imports'][number] | undefined {
-    for (const importDecl of importDeclarations) {
-      const candidate = this.tryBuildDirectImportCandidate(
-        sourceFilePath,
-        barrelFilePath,
-        barrelFile,
-        importDecl,
-        cycleFiles,
-      );
-      if (candidate) {
-        return candidate;
-      }
-    }
-
-    return undefined;
-  }
-
-  private tryBuildDirectImportCandidate(
-    sourceFilePath: string,
-    barrelFilePath: string,
-    barrelFile: SourceFile,
-    importDecl: ImportDeclaration,
-    cycleFiles: string[],
-  ): DirectImportFixPlan['imports'][number] | undefined {
-    if (importDecl.getDefaultImport() || importDecl.getNamespaceImport() || importDecl.getNamedImports().length === 0) {
-      return undefined;
-    }
-
-    const importedNames = importDecl.getNamedImports().map((namedImport) => namedImport.getName());
-    const resolution = this.resolveDirectImportTarget(barrelFile, importedNames);
-    if (!resolution) {
-      return undefined;
-    }
-
-    if (!this.isWithinRepo(resolution.targetFile)) {
-      return undefined;
-    }
-
-    const targetFilePath = this.toRepoRelativePath(resolution.targetFile);
-    if (targetFilePath === sourceFilePath || targetFilePath === barrelFilePath) {
-      return undefined;
-    }
-
-    const targetSourceFile = this.loadCycleSourceFile(targetFilePath);
-    if (targetSourceFile && this.hasDependenciesOnFiles(targetSourceFile, cycleFiles)) {
-      return undefined;
-    }
-
-    return {
-      sourceFile: sourceFilePath,
-      barrelFile: barrelFilePath,
-      targetFile: targetFilePath,
-      symbols: importedNames,
-    };
-  }
-
-  private resolveDirectImportTarget(
-    barrelFile: SourceFile,
-    importedNames: string[],
-    visited = new Set<string>(),
-  ): { targetFile: string; symbols: string[] } | undefined {
-    if (!this.isPureBarrelModule(barrelFile)) {
-      return undefined;
-    }
-
-    let resolvedTarget: string | undefined;
-
-    for (const importedName of importedNames) {
-      const resolved = this.resolveExportedSymbol(barrelFile, importedName, new Set(visited));
-      if (!resolved) {
-        return undefined;
-      }
-
-      if (resolvedTarget && resolvedTarget !== resolved.targetFile) {
-        return undefined;
-      }
-
-      resolvedTarget = resolved.targetFile;
-    }
-
-    return resolvedTarget
-      ? {
-          targetFile: resolvedTarget,
-          symbols: importedNames,
-        }
-      : undefined;
-  }
-
-  private resolveExportedSymbol(
-    sourceFile: SourceFile,
-    exportedName: string,
-    visited: Set<string>,
-  ): { targetFile: string } | undefined {
-    const filePath = sourceFile.getFilePath();
-    const visitKey = `${filePath}::${exportedName}`;
-    if (visited.has(visitKey)) {
-      return undefined;
-    }
-    visited.add(visitKey);
-
-    if (!this.hasReExportDeclarations(sourceFile)) {
-      return this.resolveLocalExportTarget(sourceFile, exportedName);
-    }
-
-    if (!this.isPureBarrelModule(sourceFile)) {
-      return undefined;
-    }
-
-    return this.resolveExportedSymbolFromReExports(sourceFile, exportedName, visited);
-  }
-
-  private resolveLocalExportTarget(sourceFile: SourceFile, exportedName: string): { targetFile: string } | undefined {
-    return sourceFile.getExportedDeclarations().has(exportedName)
-      ? { targetFile: sourceFile.getFilePath() }
-      : undefined;
-  }
-
-  private resolveExportedSymbolFromReExports(
-    sourceFile: SourceFile,
-    exportedName: string,
-    visited: Set<string>,
-  ): { targetFile: string } | undefined {
-    let resolvedTarget: string | undefined;
-
-    for (const exportDecl of sourceFile.getExportDeclarations()) {
-      const resolved = this.resolveExportDeclarationTarget(exportDecl, exportedName, visited);
-      if (!resolved) {
-        continue;
-      }
-
-      if (resolvedTarget && resolvedTarget !== resolved.targetFile) {
-        return undefined;
-      }
-
-      resolvedTarget = resolved.targetFile;
-    }
-
-    return resolvedTarget ? { targetFile: resolvedTarget } : undefined;
-  }
-
-  private resolveExportDeclarationTarget(
-    exportDecl: ExportDeclaration,
-    exportedName: string,
-    visited: Set<string>,
-  ): { targetFile: string } | undefined {
-    const moduleSpecifier = exportDecl.getModuleSpecifierValue();
-    if (!moduleSpecifier || exportDecl.getNamespaceExport()) {
-      return undefined;
-    }
-
-    const namedExports = exportDecl.getNamedExports();
-    if (namedExports.length === 0) {
-      return undefined;
-    }
-
-    const matchingExport = namedExports.find(
-      (namedExport) => this.getExportedSpecifierName(namedExport) === exportedName,
-    );
-    if (!matchingExport) {
-      return undefined;
-    }
-
-    const resolvedPath = this.resolveModulePath(exportDecl.getSourceFile().getFilePath(), moduleSpecifier);
-    if (!resolvedPath || !this.isWithinRepo(resolvedPath)) {
-      return undefined;
-    }
-
-    const nextSourceFile = this.loadCycleSourceFile(this.toRepoRelativePath(resolvedPath));
-    if (!nextSourceFile) {
-      return undefined;
-    }
-
-    return this.resolveExportedSymbol(nextSourceFile, matchingExport.getName(), new Set(visited));
-  }
-
-  private getExportedSpecifierName(namedExport: {
-    getAliasNode(): { getText(): string } | undefined;
-    getName(): string;
-  }): string {
-    return namedExport.getAliasNode()?.getText() ?? namedExport.getName();
-  }
-
-  private isPureBarrelModule(sourceFile: SourceFile): boolean {
-    const statements = sourceFile.getStatements();
-    if (statements.some((statement) => !Node.isImportDeclaration(statement) && !Node.isExportDeclaration(statement))) {
-      return false;
-    }
-
-    for (const importDecl of sourceFile.getImportDeclarations()) {
-      if (
-        !importDecl.isTypeOnly() &&
-        importDecl.getNamedImports().length === 0 &&
-        !importDecl.getDefaultImport() &&
-        !importDecl.getNamespaceImport()
-      ) {
-        return false;
-      }
-    }
-
-    const exportDeclarations = sourceFile.getExportDeclarations();
-    return exportDeclarations.length > 0 && exportDeclarations.every((decl) => Boolean(decl.getModuleSpecifierValue()));
-  }
-
-  private hasReExportDeclarations(sourceFile: SourceFile): boolean {
-    return sourceFile.getExportDeclarations().some((decl) => Boolean(decl.getModuleSpecifierValue()));
   }
 
   private resolveModulePath(filePath: string, moduleSpecifier: string): string | undefined {

--- a/analyzer/semantic/features.ts
+++ b/analyzer/semantic/features.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
-import type { CycleFeatureVector, PlannerRepositoryProfile } from './types.js';
+import type { CycleFeatureVector, CycleGraphSummary, PlannerRepositoryProfile } from './types.js';
 
 export function extractCycleFeatures(args: {
   uniqueFiles: string[];
   cycleShape: 'two_file' | 'multi_file';
+  graphSummary: CycleGraphSummary;
   cycleSignals: {
     explicitImportEdges: number;
     loadedFiles: number;
@@ -11,7 +12,7 @@ export function extractCycleFeatures(args: {
   };
   repositoryProfile?: PlannerRepositoryProfile;
 }): CycleFeatureVector {
-  const { uniqueFiles, cycleShape, cycleSignals, repositoryProfile } = args;
+  const { uniqueFiles, cycleShape, cycleSignals, graphSummary, repositoryProfile } = args;
 
   return {
     cycleSize: uniqueFiles.length,
@@ -26,5 +27,12 @@ export function extractCycleFeatures(args: {
     packageManager: repositoryProfile?.packageManager ?? 'unknown',
     workspaceMode: repositoryProfile?.workspaceMode ?? 'unknown',
     validationCommandCount: repositoryProfile?.validationCommandCount ?? 0,
+    barrelModuleCount: graphSummary.metrics.barrelModuleCount,
+    sideEffectModuleCount: graphSummary.metrics.sideEffectModuleCount,
+    exportEdgeCount: graphSummary.metrics.exportEdgeCount,
+    movableSymbolCount: graphSummary.metrics.movableSymbolCount,
+    symbolNodeCount: graphSummary.metrics.symbolNodeCount,
+    symbolEdgeCount: graphSummary.metrics.symbolEdgeCount,
+    symbolSccCount: graphSummary.metrics.symbolSccCount,
   };
 }

--- a/analyzer/semantic/graph.test.ts
+++ b/analyzer/semantic/graph.test.ts
@@ -1,0 +1,164 @@
+import path from 'node:path';
+import { Project, type SourceFile } from 'ts-morph';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildCycleGraph, findDirectImportPlanFromGraph } from './graph.js';
+
+const REPO_ROOT = '/dummy/repo';
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
+
+describe('semantic graph core', () => {
+  let project: Project;
+
+  beforeEach(() => {
+    project = new Project({
+      compilerOptions: {
+        allowJs: true,
+        resolveJsonModule: true,
+      },
+      skipAddingFilesFromTsConfig: true,
+    });
+  });
+
+  it('builds barrel/export summaries and finds direct-import rewrites from the graph', () => {
+    project.createSourceFile(
+      path.join(REPO_ROOT, 'app.ts'),
+      `
+      import { Foo } from './index';
+      export const appValue = Foo + 1;
+    `,
+    );
+    project.createSourceFile(
+      path.join(REPO_ROOT, 'index.ts'),
+      `
+      export { Foo } from './foo';
+      export { Bar } from './bar';
+    `,
+    );
+    project.createSourceFile(path.join(REPO_ROOT, 'foo.ts'), 'export const Foo = 1;');
+    project.createSourceFile(
+      path.join(REPO_ROOT, 'bar.ts'),
+      `
+      import { appValue } from './app';
+      export const Bar = appValue + 1;
+    `,
+    );
+
+    const cycleFiles = ['app.ts', 'index.ts', 'bar.ts', 'app.ts'];
+    const graph = buildCycleGraph(createGraphArgs(project, cycleFiles));
+    const directImport = findDirectImportPlanFromGraph(graph, cycleFiles);
+
+    expect(graph.metrics).toMatchObject({
+      moduleCount: 3,
+      barrelModuleCount: 1,
+      exportEdgeCount: 2,
+      symbolNodeCount: 2,
+    });
+    expect(graph.modules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: 'index.ts',
+          moduleKind: 'pure_barrel',
+          hasReExports: true,
+          hasTopLevelSideEffects: false,
+        }),
+      ]),
+    );
+    expect(graph.exportResolutions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          barrelFile: 'index.ts',
+          exportedName: 'Foo',
+          targetFile: 'foo.ts',
+          targetSymbol: 'Foo',
+          ambiguous: false,
+        }),
+      ]),
+    );
+    expect(directImport).toEqual({
+      sawBarrelScenario: true,
+      ambiguousResolution: false,
+      plan: [
+        {
+          sourceFile: 'app.ts',
+          barrelFile: 'index.ts',
+          targetFile: 'foo.ts',
+          symbols: ['Foo'],
+        },
+      ],
+    });
+  });
+
+  it('computes symbol-level SCCs for mutually dependent declarations', () => {
+    project.createSourceFile(
+      path.join(REPO_ROOT, 'a.ts'),
+      `
+      import { bValue } from './b';
+      export const aValue = bValue + 1;
+    `,
+    );
+    project.createSourceFile(
+      path.join(REPO_ROOT, 'b.ts'),
+      `
+      import { aValue } from './a';
+      export const bValue = aValue + 1;
+    `,
+    );
+
+    const graph = buildCycleGraph(createGraphArgs(project, ['a.ts', 'b.ts', 'a.ts']));
+
+    expect(graph.metrics).toMatchObject({
+      symbolNodeCount: 2,
+      symbolEdgeCount: 2,
+      symbolSccCount: 1,
+      movableSymbolCount: 2,
+    });
+    expect(graph.symbolSccs).toHaveLength(1);
+    expect(graph.symbolSccs[0]).toEqual(expect.arrayContaining(['a.ts::aValue', 'b.ts::bValue']));
+    expect(graph.importEdges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ from: 'a.ts', to: 'b.ts', withinCycle: true }),
+        expect.objectContaining({ from: 'b.ts', to: 'a.ts', withinCycle: true }),
+      ]),
+    );
+  });
+});
+
+function createGraphArgs(project: Project, cycleFiles: string[]) {
+  return {
+    cycleFiles,
+    isWithinRepo: (absolutePath: string) => normalizePath(absolutePath).startsWith(`${REPO_ROOT}/`),
+    loadSourceFile: (repoRelativePath: string) => getSourceFile(project, repoRelativePath),
+    resolveModulePath: (filePath: string, moduleSpecifier: string) =>
+      resolveRepoImport(project, filePath, moduleSpecifier),
+    toRepoRelativePath: (absolutePath: string) => normalizePath(path.relative(REPO_ROOT, absolutePath)),
+  };
+}
+
+function getSourceFile(project: Project, repoRelativePath: string): SourceFile | undefined {
+  return project.getSourceFile(path.join(REPO_ROOT, repoRelativePath));
+}
+
+function resolveRepoImport(project: Project, filePath: string, moduleSpecifier: string): string | undefined {
+  if (!moduleSpecifier.startsWith('.')) {
+    return undefined;
+  }
+
+  const basePath = path.resolve(REPO_ROOT, path.dirname(filePath), moduleSpecifier);
+  const candidates = [
+    basePath,
+    ...SOURCE_EXTENSIONS.map((extension) => `${basePath}${extension}`),
+    ...SOURCE_EXTENSIONS.map((extension) => path.join(basePath, `index${extension}`)),
+  ];
+
+  for (const candidate of candidates) {
+    if (project.getSourceFile(candidate)) {
+      return normalizePath(candidate);
+    }
+  }
+
+  return undefined;
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replaceAll('\\', '/');
+}

--- a/analyzer/semantic/graph.ts
+++ b/analyzer/semantic/graph.ts
@@ -1,0 +1,907 @@
+import {
+  type ExportDeclaration,
+  type ImportDeclaration,
+  Node,
+  type SourceFile,
+  SyntaxKind,
+  type VariableStatement,
+} from 'ts-morph';
+import type {
+  CycleGraphSummary,
+  DirectImportSearchResult,
+  GraphExportEdge,
+  GraphExportResolution,
+  GraphImportEdge,
+  GraphModuleSummary,
+  GraphSymbolEdge,
+  GraphSymbolNode,
+} from './types.js';
+
+interface BuildCycleGraphArgs {
+  cycleFiles: string[];
+  isWithinRepo: (absolutePath: string) => boolean;
+  loadSourceFile: (repoRelativePath: string) => SourceFile | undefined;
+  resolveModulePath: (filePath: string, moduleSpecifier: string) => string | undefined;
+  toRepoRelativePath: (absolutePath: string) => string;
+}
+
+interface ImportedBindingTarget {
+  localName: string;
+  targetFile: string;
+  targetSymbol: string;
+}
+
+interface LoadedGraphArtifacts {
+  sourceFiles: Map<string, SourceFile>;
+  modules: Map<string, GraphModuleSummary>;
+  importEdges: GraphImportEdge[];
+  exportEdges: GraphExportEdge[];
+}
+
+const EMPTY_GRAPH_SUMMARY: CycleGraphSummary = {
+  modules: [],
+  importEdges: [],
+  exportEdges: [],
+  symbolNodes: [],
+  symbolEdges: [],
+  symbolSccs: [],
+  exportResolutions: [],
+  metrics: {
+    moduleCount: 0,
+    importEdgeCount: 0,
+    exportEdgeCount: 0,
+    symbolNodeCount: 0,
+    symbolEdgeCount: 0,
+    symbolSccCount: 0,
+    barrelModuleCount: 0,
+    sideEffectModuleCount: 0,
+    movableSymbolCount: 0,
+  },
+};
+
+export function buildCycleGraph(args: BuildCycleGraphArgs): CycleGraphSummary {
+  const cycleFiles = [...new Set(args.cycleFiles)];
+  if (cycleFiles.length === 0) {
+    return EMPTY_GRAPH_SUMMARY;
+  }
+
+  const { sourceFiles, modules, importEdges, exportEdges } = loadGraphArtifacts(cycleFiles, args);
+  const symbolNodes = collectSymbolNodes(sourceFiles);
+  const symbolNodeMap = new Map(symbolNodes.map((node) => [node.id, node]));
+  const symbolEdges = collectSymbolEdges(sourceFiles, symbolNodeMap, importEdges);
+  const symbolSccs = tarjanScc(symbolNodes, symbolEdges);
+  const exportResolutions = buildExportResolutions(modules, exportEdges);
+  const moduleSummaries = [...modules.values()];
+
+  return {
+    modules: moduleSummaries,
+    importEdges,
+    exportEdges,
+    symbolNodes,
+    symbolEdges,
+    symbolSccs,
+    exportResolutions,
+    metrics: {
+      moduleCount: moduleSummaries.length,
+      importEdgeCount: importEdges.length,
+      exportEdgeCount: exportEdges.length,
+      symbolNodeCount: symbolNodes.length,
+      symbolEdgeCount: symbolEdges.length,
+      symbolSccCount: symbolSccs.length,
+      barrelModuleCount: moduleSummaries.filter((module) => module.moduleKind === 'pure_barrel').length,
+      sideEffectModuleCount: moduleSummaries.filter((module) => module.hasTopLevelSideEffects).length,
+      movableSymbolCount: symbolNodes.filter((node) => node.movable).length,
+    },
+  };
+}
+
+export function findDirectImportPlanFromGraph(
+  graphSummary: CycleGraphSummary,
+  cycleFiles: string[],
+): DirectImportSearchResult {
+  let sawBarrelScenario = false;
+  let ambiguousResolution = false;
+  const cycleFileSet = new Set(cycleFiles);
+  const moduleByFile = new Map(graphSummary.modules.map((module) => [module.file, module]));
+  const resolutionMap = new Map(
+    graphSummary.exportResolutions.map((resolution) => [
+      toResolutionKey(resolution.barrelFile, resolution.exportedName),
+      resolution,
+    ]),
+  );
+
+  for (const importEdge of graphSummary.importEdges) {
+    const candidate = tryBuildDirectImportCandidate(importEdge, cycleFileSet, moduleByFile, resolutionMap);
+    if (!candidate) {
+      sawBarrelScenario ||= isBarrelCycleEdge(importEdge, cycleFileSet, moduleByFile);
+      ambiguousResolution ||= isAmbiguousBarrelEdge(importEdge, cycleFileSet, moduleByFile, resolutionMap);
+      continue;
+    }
+
+    return {
+      sawBarrelScenario: true,
+      ambiguousResolution,
+      plan: [candidate],
+    };
+  }
+
+  return {
+    sawBarrelScenario,
+    ambiguousResolution,
+  };
+}
+
+function loadGraphArtifacts(cycleFiles: string[], args: BuildCycleGraphArgs): LoadedGraphArtifacts {
+  const cycleFileSet = new Set(cycleFiles);
+  const sourceFiles = new Map<string, SourceFile>();
+  const modules = new Map<string, GraphModuleSummary>();
+  const importEdgeMap = new Map<string, GraphImportEdge>();
+  const exportEdgeMap = new Map<string, GraphExportEdge>();
+
+  for (const file of cycleFiles) {
+    const sourceFile = args.loadSourceFile(file);
+    if (!sourceFile) {
+      continue;
+    }
+
+    sourceFiles.set(file, sourceFile);
+    modules.set(file, summarizeModule(sourceFile, file));
+
+    for (const edge of collectImportEdges(sourceFile, file, cycleFileSet, args)) {
+      importEdgeMap.set(importEdgeKey(edge), edge);
+    }
+
+    for (const edge of collectExportEdges(sourceFile, file, args)) {
+      exportEdgeMap.set(exportEdgeKey(edge), edge);
+    }
+  }
+
+  return {
+    sourceFiles,
+    modules,
+    importEdges: [...importEdgeMap.values()],
+    exportEdges: [...exportEdgeMap.values()],
+  };
+}
+
+function summarizeModule(sourceFile: SourceFile, file: string): GraphModuleSummary {
+  const declarations = collectTopLevelDeclarations(sourceFile);
+  const exportedSymbols = [...sourceFile.getExportedDeclarations().keys()];
+  const localSymbols = new Set(declarations.map((declaration) => declaration.symbol));
+  const localExportedSymbols = exportedSymbols.filter((symbol) => localSymbols.has(symbol));
+  const movableSymbols = declarations
+    .filter((declaration) => declaration.movable)
+    .map((declaration) => declaration.symbol);
+  const statements = sourceFile.getStatements();
+  const hasReExports = sourceFile.getExportDeclarations().some((decl) => Boolean(decl.getModuleSpecifierValue()));
+  const hasOnlyImportExportStatements = statements.every(
+    (statement) => Node.isImportDeclaration(statement) || Node.isExportDeclaration(statement),
+  );
+  const hasTopLevelSideEffects = statements.some((statement) => isSideEffectfulTopLevelStatement(statement));
+
+  return {
+    file,
+    exportedSymbols,
+    localExportedSymbols,
+    movableSymbols,
+    moduleKind: determineModuleKind(hasReExports, hasOnlyImportExportStatements, hasTopLevelSideEffects),
+    hasReExports,
+    hasTopLevelSideEffects,
+  };
+}
+
+function collectImportEdges(
+  sourceFile: SourceFile,
+  file: string,
+  cycleFileSet: Set<string>,
+  args: BuildCycleGraphArgs,
+): GraphImportEdge[] {
+  const edges: GraphImportEdge[] = [];
+
+  for (const importDecl of sourceFile.getImportDeclarations()) {
+    const targetFile = resolveImportEdgeTarget(file, importDecl.getModuleSpecifierValue(), args);
+    if (!targetFile) {
+      continue;
+    }
+
+    edges.push({
+      from: file,
+      to: targetFile,
+      kind: getImportEdgeKind(importDecl),
+      symbols: getImportSymbols(importDecl),
+      withinCycle: cycleFileSet.has(targetFile),
+    });
+  }
+
+  return edges;
+}
+
+function collectExportEdges(sourceFile: SourceFile, file: string, args: BuildCycleGraphArgs): GraphExportEdge[] {
+  const edges: GraphExportEdge[] = [];
+
+  for (const exportDecl of sourceFile.getExportDeclarations()) {
+    const targetFile = resolveImportEdgeTarget(file, exportDecl.getModuleSpecifierValue(), args);
+    if (!targetFile) {
+      continue;
+    }
+
+    edges.push(...collectExportDeclarationEdges(exportDecl, file, targetFile));
+  }
+
+  return edges;
+}
+
+function collectExportDeclarationEdges(
+  exportDecl: ExportDeclaration,
+  file: string,
+  targetFile: string,
+): GraphExportEdge[] {
+  const namespaceExport = exportDecl.getNamespaceExport();
+  if (namespaceExport) {
+    return [
+      {
+        from: file,
+        to: targetFile,
+        kind: 'namespace_reexport',
+        exportedName: namespaceExport.getName(),
+        localName: null,
+      },
+    ];
+  }
+
+  const namedExports = exportDecl.getNamedExports();
+  if (namedExports.length === 0) {
+    return [
+      {
+        from: file,
+        to: targetFile,
+        kind: 'namespace_reexport',
+        exportedName: '*',
+        localName: null,
+      },
+    ];
+  }
+
+  return namedExports.map((specifier) => ({
+    from: file,
+    to: targetFile,
+    kind: 'named_reexport' as const,
+    exportedName: specifier.getAliasNode()?.getText() ?? specifier.getNameNode().getText(),
+    localName: specifier.getNameNode().getText(),
+  }));
+}
+
+function collectSymbolNodes(sourceFiles: Map<string, SourceFile>): GraphSymbolNode[] {
+  const nodes: GraphSymbolNode[] = [];
+
+  for (const [file, sourceFile] of sourceFiles) {
+    nodes.push(
+      ...collectTopLevelDeclarations(sourceFile).map((node) => ({
+        ...node,
+        file,
+        id: createSymbolNodeId(file, node.symbol),
+      })),
+    );
+  }
+
+  return nodes;
+}
+
+function collectSymbolEdges(
+  sourceFiles: Map<string, SourceFile>,
+  symbolNodeMap: Map<string, GraphSymbolNode>,
+  importEdges: GraphImportEdge[],
+): GraphSymbolEdge[] {
+  const edges = new Map<string, GraphSymbolEdge>();
+  const importBindingMap = buildImportBindingMap(sourceFiles, importEdges);
+
+  for (const [file, sourceFile] of sourceFiles) {
+    collectFileSymbolEdges(sourceFile, file, symbolNodeMap, importBindingMap.get(file) ?? [], edges);
+  }
+
+  return [...edges.values()];
+}
+
+function collectFileSymbolEdges(
+  sourceFile: SourceFile,
+  file: string,
+  symbolNodeMap: Map<string, GraphSymbolNode>,
+  importBindings: ImportedBindingTarget[],
+  edges: Map<string, GraphSymbolEdge>,
+): void {
+  const localDeclarations = collectTopLevelDeclarations(sourceFile);
+  const localSymbolMap = new Map(localDeclarations.map((declaration) => [declaration.symbol, declaration]));
+  const importBindingMap = new Map(importBindings.map((binding) => [binding.localName, binding]));
+
+  for (const declaration of localDeclarations) {
+    const declarationNode = getDeclarationNode(sourceFile, declaration.symbol, declaration.kind);
+    if (!declarationNode) {
+      continue;
+    }
+
+    const fromId = createSymbolNodeId(file, declaration.symbol);
+    for (const identifier of declarationNode.getDescendantsOfKind(SyntaxKind.Identifier)) {
+      const identifierText = identifier.getText();
+      if (identifierText === declaration.symbol) {
+        continue;
+      }
+
+      const localTarget = localSymbolMap.get(identifierText);
+      if (localTarget) {
+        addSymbolEdge(edges, symbolNodeMap, fromId, createSymbolNodeId(file, localTarget.symbol), 'reference');
+        continue;
+      }
+
+      const importedTarget = importBindingMap.get(identifierText);
+      if (!importedTarget) {
+        continue;
+      }
+
+      addSymbolEdge(
+        edges,
+        symbolNodeMap,
+        fromId,
+        createSymbolNodeId(importedTarget.targetFile, importedTarget.targetSymbol),
+        'import',
+      );
+    }
+  }
+}
+
+function addSymbolEdge(
+  edges: Map<string, GraphSymbolEdge>,
+  symbolNodeMap: Map<string, GraphSymbolNode>,
+  from: string,
+  to: string,
+  kind: GraphSymbolEdge['kind'],
+): void {
+  if (from === to || !symbolNodeMap.has(from) || !symbolNodeMap.has(to)) {
+    return;
+  }
+
+  edges.set(`${from}::${to}::${kind}`, {
+    from,
+    to,
+    kind,
+  });
+}
+
+function buildImportBindingMap(
+  sourceFiles: Map<string, SourceFile>,
+  importEdges: GraphImportEdge[],
+): Map<string, ImportedBindingTarget[]> {
+  const map = new Map<string, ImportedBindingTarget[]>();
+
+  for (const [file, sourceFile] of sourceFiles) {
+    const bindings: ImportedBindingTarget[] = [];
+
+    for (const importDecl of sourceFile.getImportDeclarations()) {
+      const matchingEdge = importEdges.find(
+        (edge) =>
+          edge.from === file &&
+          edge.symbols.length === importDecl.getNamedImports().length &&
+          edge.symbols.every((symbol) =>
+            importDecl.getNamedImports().some((namedImport) => namedImport.getName() === symbol),
+          ),
+      );
+      if (!matchingEdge) {
+        continue;
+      }
+
+      for (const namedImport of importDecl.getNamedImports()) {
+        bindings.push({
+          localName: namedImport.getAliasNode()?.getText() ?? namedImport.getName(),
+          targetFile: matchingEdge.to,
+          targetSymbol: namedImport.getName(),
+        });
+      }
+    }
+
+    map.set(file, bindings);
+  }
+
+  return map;
+}
+
+function buildExportResolutions(
+  modules: Map<string, GraphModuleSummary>,
+  exportEdges: GraphExportEdge[],
+): GraphExportResolution[] {
+  const resolutions: GraphExportResolution[] = [];
+
+  for (const module of modules.values()) {
+    if (!module.hasReExports) {
+      continue;
+    }
+
+    const exportedNames = new Set([
+      ...module.exportedSymbols,
+      ...exportEdges.filter((edge) => edge.from === module.file).map((edge) => edge.exportedName),
+    ]);
+
+    for (const exportedName of exportedNames) {
+      if (exportedName === '*') {
+        continue;
+      }
+
+      const resolution = resolveExportedSymbolFromGraph(modules, exportEdges, module.file, exportedName, new Set());
+      resolutions.push({
+        barrelFile: module.file,
+        exportedName,
+        targetFile: resolution?.targetFile ?? null,
+        targetSymbol: resolution?.targetSymbol ?? null,
+        ambiguous: resolution?.ambiguous ?? false,
+      });
+    }
+  }
+
+  return resolutions;
+}
+
+function resolveExportedSymbolFromGraph(
+  modules: Map<string, GraphModuleSummary>,
+  exportEdges: GraphExportEdge[],
+  moduleFile: string,
+  exportedName: string,
+  visited: Set<string>,
+): { targetFile: string | null; targetSymbol: string | null; ambiguous: boolean } | undefined {
+  const visitKey = `${moduleFile}::${exportedName}`;
+  if (visited.has(visitKey)) {
+    return {
+      targetFile: null,
+      targetSymbol: null,
+      ambiguous: true,
+    };
+  }
+
+  visited.add(visitKey);
+  const module = modules.get(moduleFile);
+  if (!module) {
+    return undefined;
+  }
+
+  const localResolution = resolveLocalExport(module, moduleFile, exportedName);
+  if (localResolution) {
+    return localResolution;
+  }
+
+  const candidateEdges = collectCandidateExportEdges(exportEdges, moduleFile, exportedName);
+  if (candidateEdges.length === 0) {
+    return undefined;
+  }
+
+  let resolvedTarget: { targetFile: string | null; targetSymbol: string | null; ambiguous: boolean } | undefined;
+  for (const edge of candidateEdges) {
+    const resolved = resolveCandidateExportEdge(modules, exportEdges, edge, exportedName, visited);
+    if (!resolved || resolved.ambiguous) {
+      return {
+        targetFile: null,
+        targetSymbol: null,
+        ambiguous: true,
+      };
+    }
+
+    if (
+      resolvedTarget &&
+      (resolvedTarget.targetFile !== resolved.targetFile || resolvedTarget.targetSymbol !== resolved.targetSymbol)
+    ) {
+      return {
+        targetFile: null,
+        targetSymbol: null,
+        ambiguous: true,
+      };
+    }
+
+    resolvedTarget = resolved;
+  }
+
+  return resolvedTarget;
+}
+
+function resolveLocalExport(
+  module: GraphModuleSummary,
+  moduleFile: string,
+  exportedName: string,
+): { targetFile: string | null; targetSymbol: string | null; ambiguous: boolean } | undefined {
+  if (!module.localExportedSymbols.includes(exportedName)) {
+    return undefined;
+  }
+
+  return {
+    targetFile: moduleFile,
+    targetSymbol: exportedName,
+    ambiguous: false,
+  };
+}
+
+function collectCandidateExportEdges(
+  exportEdges: GraphExportEdge[],
+  moduleFile: string,
+  exportedName: string,
+): GraphExportEdge[] {
+  const matchingEdges = exportEdges.filter((edge) => edge.from === moduleFile && edge.exportedName === exportedName);
+  const wildcardEdges = exportEdges.filter((edge) => edge.from === moduleFile && edge.exportedName === '*');
+  return [...matchingEdges, ...wildcardEdges];
+}
+
+function resolveCandidateExportEdge(
+  modules: Map<string, GraphModuleSummary>,
+  exportEdges: GraphExportEdge[],
+  edge: GraphExportEdge,
+  exportedName: string,
+  visited: Set<string>,
+): { targetFile: string | null; targetSymbol: string | null; ambiguous: boolean } | undefined {
+  if (edge.kind === 'namespace_reexport' && edge.exportedName !== '*') {
+    return {
+      targetFile: null,
+      targetSymbol: null,
+      ambiguous: true,
+    };
+  }
+
+  const nextExportName = edge.exportedName === '*' ? exportedName : edge.localName;
+  if (!nextExportName) {
+    return {
+      targetFile: null,
+      targetSymbol: null,
+      ambiguous: true,
+    };
+  }
+
+  return resolveTargetExport(modules, exportEdges, edge.to, nextExportName, visited);
+}
+
+function resolveTargetExport(
+  modules: Map<string, GraphModuleSummary>,
+  exportEdges: GraphExportEdge[],
+  targetFile: string,
+  exportedName: string,
+  visited: Set<string>,
+): { targetFile: string | null; targetSymbol: string | null; ambiguous: boolean } | undefined {
+  if (!modules.has(targetFile)) {
+    return {
+      targetFile,
+      targetSymbol: exportedName,
+      ambiguous: false,
+    };
+  }
+
+  return resolveExportedSymbolFromGraph(modules, exportEdges, targetFile, exportedName, new Set(visited));
+}
+
+function tryBuildDirectImportCandidate(
+  importEdge: GraphImportEdge,
+  cycleFileSet: Set<string>,
+  moduleByFile: Map<string, GraphModuleSummary>,
+  resolutionMap: Map<string, GraphExportResolution>,
+): NonNullable<DirectImportSearchResult['plan']>[number] | undefined {
+  if (!isBarrelCycleEdge(importEdge, cycleFileSet, moduleByFile)) {
+    return undefined;
+  }
+
+  if (importEdge.symbols.length === 0) {
+    return undefined;
+  }
+
+  const resolvedTargets = importEdge.symbols.map((symbol) =>
+    symbol === 'default' || symbol === '*' ? undefined : resolutionMap.get(toResolutionKey(importEdge.to, symbol)),
+  );
+  if (
+    resolvedTargets.some(
+      (resolution) =>
+        !resolution ||
+        resolution.ambiguous ||
+        !resolution.targetFile ||
+        !resolution.targetSymbol ||
+        resolution.targetFile === importEdge.to ||
+        cycleFileSet.has(resolution.targetFile),
+    )
+  ) {
+    return undefined;
+  }
+
+  const targetFile = resolvedTargets[0]?.targetFile;
+  if (!targetFile || resolvedTargets.some((resolution) => resolution?.targetFile !== targetFile)) {
+    return undefined;
+  }
+
+  return {
+    sourceFile: importEdge.from,
+    barrelFile: importEdge.to,
+    targetFile,
+    symbols: resolvedTargets
+      .map((resolution) => resolution?.targetSymbol)
+      .filter((symbol): symbol is string => typeof symbol === 'string'),
+  };
+}
+
+function isAmbiguousBarrelEdge(
+  importEdge: GraphImportEdge,
+  cycleFileSet: Set<string>,
+  moduleByFile: Map<string, GraphModuleSummary>,
+  resolutionMap: Map<string, GraphExportResolution>,
+): boolean {
+  if (!isBarrelCycleEdge(importEdge, cycleFileSet, moduleByFile)) {
+    return false;
+  }
+
+  return importEdge.symbols.some((symbol) => {
+    if (symbol === 'default' || symbol === '*') {
+      return true;
+    }
+
+    const resolution = resolutionMap.get(toResolutionKey(importEdge.to, symbol));
+    return !resolution || resolution.ambiguous || !resolution.targetFile || !resolution.targetSymbol;
+  });
+}
+
+function isBarrelCycleEdge(
+  importEdge: GraphImportEdge,
+  cycleFileSet: Set<string>,
+  moduleByFile: Map<string, GraphModuleSummary>,
+): boolean {
+  if (!cycleFileSet.has(importEdge.from) || !cycleFileSet.has(importEdge.to)) {
+    return false;
+  }
+
+  return moduleByFile.get(importEdge.to)?.moduleKind === 'pure_barrel';
+}
+
+function tarjanScc(nodes: GraphSymbolNode[], edges: GraphSymbolEdge[]): string[][] {
+  const adjacency = new Map<string, string[]>();
+  for (const node of nodes) {
+    adjacency.set(node.id, []);
+  }
+  for (const edge of edges) {
+    adjacency.set(edge.from, [...(adjacency.get(edge.from) ?? []), edge.to]);
+  }
+
+  let index = 0;
+  const indices = new Map<string, number>();
+  const lowLinks = new Map<string, number>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const components: string[][] = [];
+
+  function strongConnect(nodeId: string) {
+    indices.set(nodeId, index);
+    lowLinks.set(nodeId, index);
+    index += 1;
+    stack.push(nodeId);
+    onStack.add(nodeId);
+
+    for (const nextId of adjacency.get(nodeId) ?? []) {
+      if (!indices.has(nextId)) {
+        strongConnect(nextId);
+        lowLinks.set(nodeId, Math.min(lowLinks.get(nodeId) ?? 0, lowLinks.get(nextId) ?? 0));
+        continue;
+      }
+
+      if (onStack.has(nextId)) {
+        lowLinks.set(nodeId, Math.min(lowLinks.get(nodeId) ?? 0, indices.get(nextId) ?? 0));
+      }
+    }
+
+    if ((lowLinks.get(nodeId) ?? 0) !== (indices.get(nodeId) ?? 0)) {
+      return;
+    }
+
+    const component: string[] = [];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) {
+        break;
+      }
+      onStack.delete(current);
+      component.push(current);
+      if (current === nodeId) {
+        break;
+      }
+    }
+
+    if (component.length > 1) {
+      components.push(component);
+    }
+  }
+
+  for (const node of nodes) {
+    if (!indices.has(node.id)) {
+      strongConnect(node.id);
+    }
+  }
+
+  return components;
+}
+
+function collectTopLevelDeclarations(sourceFile: SourceFile): Array<Omit<GraphSymbolNode, 'file' | 'id'>> {
+  const declarations: Array<Omit<GraphSymbolNode, 'file' | 'id'>> = [];
+
+  for (const declaration of sourceFile.getFunctions()) {
+    const name = declaration.getName();
+    if (!name) {
+      continue;
+    }
+    declarations.push({ symbol: name, kind: 'function', exported: declaration.isExported(), movable: true });
+  }
+
+  for (const declaration of sourceFile.getInterfaces()) {
+    declarations.push({
+      symbol: declaration.getName(),
+      kind: 'interface',
+      exported: declaration.isExported(),
+      movable: true,
+    });
+  }
+
+  for (const declaration of sourceFile.getTypeAliases()) {
+    declarations.push({
+      symbol: declaration.getName(),
+      kind: 'type_alias',
+      exported: declaration.isExported(),
+      movable: true,
+    });
+  }
+
+  for (const statement of sourceFile.getVariableStatements()) {
+    for (const declaration of statement.getDeclarations()) {
+      if (declaration.getNameNode().getKind() !== SyntaxKind.Identifier) {
+        continue;
+      }
+      declarations.push({
+        symbol: declaration.getName(),
+        kind: 'variable',
+        exported: statement.isExported(),
+        movable: true,
+      });
+    }
+  }
+
+  for (const declaration of sourceFile.getClasses()) {
+    const name = declaration.getName();
+    if (!name) {
+      continue;
+    }
+    declarations.push({ symbol: name, kind: 'class', exported: declaration.isExported(), movable: false });
+  }
+
+  for (const declaration of sourceFile.getEnums()) {
+    declarations.push({
+      symbol: declaration.getName(),
+      kind: 'enum',
+      exported: declaration.isExported(),
+      movable: false,
+    });
+  }
+
+  return declarations;
+}
+
+function getDeclarationNode(
+  sourceFile: SourceFile,
+  symbol: string,
+  kind: GraphSymbolNode['kind'],
+): SourceFile | Node | VariableStatement | undefined {
+  switch (kind) {
+    case 'function': {
+      return sourceFile.getFunction(symbol);
+    }
+    case 'interface': {
+      return sourceFile.getInterface(symbol);
+    }
+    case 'type_alias': {
+      return sourceFile.getTypeAlias(symbol);
+    }
+    case 'variable': {
+      return sourceFile.getVariableDeclaration(symbol)?.getVariableStatement();
+    }
+    case 'class': {
+      return sourceFile.getClass(symbol);
+    }
+    case 'enum': {
+      return sourceFile.getEnum(symbol);
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
+function createSymbolNodeId(file: string, symbol: string): string {
+  return `${file}::${symbol}`;
+}
+
+function determineModuleKind(
+  hasReExports: boolean,
+  hasOnlyImportExportStatements: boolean,
+  hasTopLevelSideEffects: boolean,
+): GraphModuleSummary['moduleKind'] {
+  if (hasReExports && hasOnlyImportExportStatements && !hasTopLevelSideEffects) {
+    return 'pure_barrel';
+  }
+
+  if (!hasTopLevelSideEffects) {
+    return 'declaration_only';
+  }
+
+  return 'mixed';
+}
+
+function getImportEdgeKind(importDecl: ImportDeclaration): GraphImportEdge['kind'] {
+  if (importDecl.isTypeOnly()) {
+    return 'type';
+  }
+
+  if (importDecl.getNamedImports().length === 0 && !importDecl.getDefaultImport() && !importDecl.getNamespaceImport()) {
+    return 'side_effect';
+  }
+
+  return 'value';
+}
+
+function getImportSymbols(importDecl: ImportDeclaration): string[] {
+  const symbols = importDecl.getNamedImports().map((namedImport) => namedImport.getName());
+  if (importDecl.getDefaultImport()) {
+    symbols.push('default');
+  }
+  if (importDecl.getNamespaceImport()) {
+    symbols.push('*');
+  }
+  return symbols;
+}
+
+function isRepoImport(moduleSpecifier: string): boolean {
+  return moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('/');
+}
+
+function resolveImportEdgeTarget(
+  sourceFilePath: string,
+  moduleSpecifier: string | undefined,
+  args: BuildCycleGraphArgs,
+): string | undefined {
+  if (!moduleSpecifier || !isRepoImport(moduleSpecifier)) {
+    return undefined;
+  }
+
+  const absolutePath = args.resolveModulePath(sourceFilePath, moduleSpecifier);
+  if (!absolutePath || !args.isWithinRepo(absolutePath)) {
+    return undefined;
+  }
+
+  return args.toRepoRelativePath(absolutePath);
+}
+
+function toResolutionKey(barrelFile: string, exportedName: string): string {
+  return `${barrelFile}::${exportedName}`;
+}
+
+function importEdgeKey(edge: GraphImportEdge): string {
+  return `${edge.from}::${edge.to}::${edge.kind}::${edge.symbols.join(',')}`;
+}
+
+function exportEdgeKey(edge: GraphExportEdge): string {
+  return `${edge.from}::${edge.to}::${edge.kind}::${edge.exportedName}::${edge.localName ?? 'null'}`;
+}
+
+function isSideEffectfulTopLevelStatement(statement: Node): boolean {
+  if (Node.isImportDeclaration(statement) || Node.isExportDeclaration(statement)) {
+    return false;
+  }
+
+  if (
+    Node.isFunctionDeclaration(statement) ||
+    Node.isInterfaceDeclaration(statement) ||
+    Node.isTypeAliasDeclaration(statement) ||
+    Node.isClassDeclaration(statement) ||
+    Node.isEnumDeclaration(statement)
+  ) {
+    return false;
+  }
+
+  if (Node.isVariableStatement(statement)) {
+    return statement
+      .getDeclarations()
+      .some((declaration) => declaration.getInitializer()?.getDescendantsOfKind(SyntaxKind.CallExpression).length);
+  }
+
+  return true;
+}

--- a/analyzer/semantic/types.ts
+++ b/analyzer/semantic/types.ts
@@ -45,6 +45,76 @@ export interface HostStateUpdateFixPlan {
 export type PlanningStrategy = 'import_type' | 'direct_import' | 'extract_shared' | 'host_state_update';
 export type StrategySignalValue = boolean | number | string;
 
+export interface GraphModuleSummary {
+  file: string;
+  exportedSymbols: string[];
+  localExportedSymbols: string[];
+  movableSymbols: string[];
+  moduleKind: 'declaration_only' | 'mixed' | 'pure_barrel';
+  hasReExports: boolean;
+  hasTopLevelSideEffects: boolean;
+}
+
+export interface GraphImportEdge {
+  from: string;
+  to: string;
+  kind: 'side_effect' | 'type' | 'value';
+  symbols: string[];
+  withinCycle: boolean;
+}
+
+export interface GraphExportEdge {
+  from: string;
+  to: string;
+  kind: 'named_reexport' | 'namespace_reexport';
+  exportedName: string;
+  localName: string | null;
+}
+
+export interface GraphSymbolNode {
+  id: string;
+  file: string;
+  symbol: string;
+  kind: 'class' | 'enum' | 'function' | 'interface' | 'type_alias' | 'variable';
+  exported: boolean;
+  movable: boolean;
+}
+
+export interface GraphSymbolEdge {
+  from: string;
+  to: string;
+  kind: 'import' | 'reference';
+}
+
+export interface GraphExportResolution {
+  barrelFile: string;
+  exportedName: string;
+  targetFile: string | null;
+  targetSymbol: string | null;
+  ambiguous: boolean;
+}
+
+export interface CycleGraphSummary {
+  modules: GraphModuleSummary[];
+  importEdges: GraphImportEdge[];
+  exportEdges: GraphExportEdge[];
+  symbolNodes: GraphSymbolNode[];
+  symbolEdges: GraphSymbolEdge[];
+  symbolSccs: string[][];
+  exportResolutions: GraphExportResolution[];
+  metrics: {
+    moduleCount: number;
+    importEdgeCount: number;
+    exportEdgeCount: number;
+    symbolNodeCount: number;
+    symbolEdgeCount: number;
+    symbolSccCount: number;
+    barrelModuleCount: number;
+    sideEffectModuleCount: number;
+    movableSymbolCount: number;
+  };
+}
+
 export interface PlannerRepositoryProfile {
   packageManager: 'bun' | 'npm' | 'pnpm' | 'unknown' | 'yarn';
   workspaceMode: 'single-package' | 'unknown' | 'workspace';
@@ -64,6 +134,13 @@ export interface CycleFeatureVector {
   packageManager: PlannerRepositoryProfile['packageManager'];
   workspaceMode: PlannerRepositoryProfile['workspaceMode'];
   validationCommandCount: number;
+  barrelModuleCount?: number;
+  sideEffectModuleCount?: number;
+  exportEdgeCount?: number;
+  movableSymbolCount?: number;
+  symbolNodeCount?: number;
+  symbolEdgeCount?: number;
+  symbolSccCount?: number;
 }
 
 export interface StrategyHistoricalEvidence {
@@ -120,6 +197,7 @@ export interface CyclePlanningResult {
   cycleShape: 'two_file' | 'multi_file';
   cycleSignals: Record<string, StrategySignalValue>;
   features: CycleFeatureVector;
+  graphSummary?: CycleGraphSummary;
   fallbackClassification: Classification;
   fallbackConfidence: number;
   fallbackReasons: string[];
@@ -142,6 +220,7 @@ export interface SemanticAnalysisResult {
 
 export interface DirectImportSearchResult {
   plan?: DirectImportFixPlan['imports'];
+  ambiguousResolution?: boolean;
   sawBarrelScenario: boolean;
 }
 
@@ -155,6 +234,7 @@ export interface CyclePlanningContext {
   cycleSignals: Record<string, StrategySignalValue>;
   repositoryProfile?: PlannerRepositoryProfile;
   historicalEvidence: HistoricalEvidenceSnapshot;
+  graphSummary: CycleGraphSummary;
   features: CycleFeatureVector;
 }
 

--- a/backend/server.test.ts
+++ b/backend/server.test.ts
@@ -773,6 +773,279 @@ describe('backend API', () => {
     });
   });
 
+  describe('reports', () => {
+    it('GET /api/reports/patterns returns aggregated observation data', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'patterns',
+        name: 'repo',
+        default_branch: null,
+        local_path: replayDetailPath,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'pattern123',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        participating_files: JSON.stringify(['a.ts', 'b.ts', 'a.ts']),
+        raw_payload: null,
+      });
+      const observationInfo = stmts.addCycleObservation.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        scan_id: scanInfo.lastInsertRowid,
+        repository_id: repoInfo.lastInsertRowid,
+        observation_version: 1,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        cycle_shape: 'two_file',
+        cycle_size: 2,
+        cycle_signals: '{"explicitImportEdges":2}',
+        feature_vector:
+          '{"hasBarrelFile":true,"hasSharedModuleFile":false,"packageManager":"pnpm","workspaceMode":"workspace"}',
+        repo_profile: '{"packageManager":"pnpm","workspaceMode":"workspace","validationCommandCount":2}',
+        planner_summary: 'No strategy cleared the safety filters.',
+        planner_attempts: '[]',
+        selected_strategy: null,
+        selected_classification: 'unsupported',
+        selected_score: null,
+        fallback_classification: 'unsupported',
+        fallback_confidence: 1,
+        fallback_reasons: '["Only two-file cycles are supported for autofix in v1."]',
+      });
+      stmts.addCandidateObservation.run({
+        cycle_observation_id: observationInfo.lastInsertRowid,
+        observation_version: 1,
+        fix_candidate_id: null,
+        patch_id: null,
+        strategy: 'extract_shared',
+        status: 'rejected',
+        planner_rank: 0,
+        promotion_eligible: 0,
+        summary: 'No safe extraction found',
+        classification: null,
+        confidence: null,
+        upstreamability_score: null,
+        reasons: '["Imported symbols rely on runtime state."]',
+        score_breakdown: null,
+        signals: '{"loadedFiles":2}',
+        plan: null,
+        validation_status: null,
+        validation_summary: null,
+        validation_failure_category: 'original_cycle_persisted',
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/reports/patterns' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        summary: {
+          cycleObservations: 1,
+          candidateObservations: 1,
+        },
+      });
+      expect(response.json().unsupportedClusters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classification: 'unsupported',
+            cycleShape: 'two_file',
+            count: 1,
+          }),
+        ]),
+      );
+    });
+
+    it('GET /api/reports/strategy-performance returns profile and acceptance summaries', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'strategy',
+        name: 'repo',
+        default_branch: null,
+        local_path: replayDetailPath,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'strategy123',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'c.ts -> d.ts -> c.ts',
+        participating_files: JSON.stringify(['c.ts', 'd.ts', 'c.ts']),
+        raw_payload: null,
+      });
+      const observationInfo = stmts.addCycleObservation.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        scan_id: scanInfo.lastInsertRowid,
+        repository_id: repoInfo.lastInsertRowid,
+        observation_version: 1,
+        normalized_path: 'c.ts -> d.ts -> c.ts',
+        cycle_shape: 'two_file',
+        cycle_size: 2,
+        cycle_signals: '{"explicitImportEdges":2}',
+        feature_vector: '{"packageManager":"pnpm","workspaceMode":"workspace"}',
+        repo_profile: '{"packageManager":"pnpm","workspaceMode":"workspace","validationCommandCount":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[]',
+        selected_strategy: 'import_type',
+        selected_classification: 'autofix_import_type',
+        selected_score: 0.93,
+        fallback_classification: 'autofix_import_type',
+        fallback_confidence: 0.9,
+        fallback_reasons: '[]',
+      });
+      const fixCandidateInfo = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        strategy: 'import_type',
+        planner_rank: 1,
+        classification: 'autofix_import_type',
+        confidence: 0.9,
+        upstreamability_score: 0.93,
+        reasons: '["Convert imports to type-only"]',
+        summary: 'Convert imports to type-only',
+        score_breakdown: '["base 0.97"]',
+        signals: '{"touchedFiles":1}',
+      });
+      const patchInfo = stmts.addPatch.run({
+        fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+        patch_text: 'diff',
+        touched_files: '["c.ts"]',
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+      });
+      stmts.addCandidateObservation.run({
+        cycle_observation_id: observationInfo.lastInsertRowid,
+        observation_version: 1,
+        fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+        patch_id: patchInfo.lastInsertRowid,
+        strategy: 'import_type',
+        status: 'candidate',
+        planner_rank: 1,
+        promotion_eligible: 1,
+        summary: 'Convert imports to type-only',
+        classification: 'autofix_import_type',
+        confidence: 0.9,
+        upstreamability_score: 0.93,
+        reasons: '["Convert imports to type-only"]',
+        score_breakdown: '["base 0.97"]',
+        signals: '{"touchedFiles":1}',
+        plan: '{"kind":"import_type"}',
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+        validation_failure_category: null,
+      });
+      stmts.addReviewDecision.run({
+        patch_id: patchInfo.lastInsertRowid,
+        decision: 'approved',
+        notes: null,
+      });
+      stmts.upsertAcceptanceBenchmarkCase.run({
+        repository: 'strategy/repo',
+        local_path: replayDetailPath,
+        commit_sha: 'strategy123',
+        scan_id: scanInfo.lastInsertRowid as number,
+        cycle_id: cycleInfo.lastInsertRowid as number,
+        fix_candidate_id: fixCandidateInfo.lastInsertRowid as number,
+        patch_id: patchInfo.lastInsertRowid as number,
+        normalized_path: 'c.ts -> d.ts -> c.ts',
+        classification: 'autofix_import_type',
+        confidence: 0.9,
+        upstreamability_score: 0.93,
+        validation_status: 'passed',
+        validation_summary: 'Cycle removed',
+        review_status: 'approved',
+        touched_files: '["c.ts"]',
+        feature_vector: '{"cycleSize":2}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[{"strategy":"import_type","status":"candidate"}]',
+        acceptability: 'accepted',
+        rejection_reason: null,
+        acceptability_note: null,
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/reports/strategy-performance' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().byRepositoryProfile).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            strategy: 'import_type',
+            packageManager: 'pnpm',
+            workspaceMode: 'workspace',
+            attempts: 1,
+            approvedReviews: 1,
+            passedValidations: 1,
+          }),
+        ]),
+      );
+      expect(response.json().acceptanceByStrategy).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            strategy: 'import_type',
+            classification: 'autofix_import_type',
+            totalCases: 1,
+            acceptedCases: 1,
+            acceptanceRate: 1,
+          }),
+        ]),
+      );
+    });
+
+    it('GET /api/reports/unsupported-clusters returns recurrent manual buckets', async () => {
+      const stmts = createStatements(testDb);
+      const repoInfo = stmts.addRepository.run({
+        owner: 'unsupported',
+        name: 'repo',
+        default_branch: null,
+        local_path: replayDetailPath,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'unsupported123',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'e.ts -> f.ts -> g.ts -> e.ts',
+        participating_files: JSON.stringify(['e.ts', 'f.ts', 'g.ts', 'e.ts']),
+        raw_payload: null,
+      });
+      stmts.addCycleObservation.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        scan_id: scanInfo.lastInsertRowid,
+        repository_id: repoInfo.lastInsertRowid,
+        observation_version: 1,
+        normalized_path: 'e.ts -> f.ts -> g.ts -> e.ts',
+        cycle_shape: 'multi_file',
+        cycle_size: 3,
+        cycle_signals: '{"explicitImportEdges":3}',
+        feature_vector: '{"hasBarrelFile":false,"packageManager":"npm","workspaceMode":"single-package"}',
+        repo_profile: '{"packageManager":"npm","workspaceMode":"single-package","validationCommandCount":1}',
+        planner_summary: 'No strategy cleared the safety filters.',
+        planner_attempts: '[]',
+        selected_strategy: null,
+        selected_classification: 'suggest_manual',
+        selected_score: null,
+        fallback_classification: 'suggest_manual',
+        fallback_confidence: 0.6,
+        fallback_reasons:
+          '["Barrel re-export graph is ambiguous or side-effectful, so a direct-import rewrite is not safe."]',
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/api/reports/unsupported-clusters' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classification: 'suggest_manual',
+            cycleShape: 'multi_file',
+            cycleSize: 3,
+            count: 1,
+          }),
+        ]),
+      );
+    });
+  });
+
   describe('review decisions', () => {
     it('POST /api/patches/:patchId/review creates a decision', async () => {
       const stmts = createStatements(testDb);

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -10,6 +10,11 @@ import {
   type RepositoryStatus,
   type ReviewDecision,
 } from '../db/index.js';
+import {
+  getPatternReport,
+  getStrategyPerformanceReport,
+  getUnsupportedClustersReport,
+} from '../db/observationReports.js';
 
 interface FindingsFilters {
   repositoryId?: number;
@@ -443,6 +448,20 @@ export async function buildApp(database?: DatabaseType): Promise<FastifyInstance
 
     const rows = db.prepare(query).all(...params) as FindingsQueryRow[];
     return mapFindingRows(rows);
+  });
+
+  // ─── Reports ──────────────────────────────────────────────
+
+  fastify.get('/api/reports/patterns', async () => {
+    return getPatternReport(db);
+  });
+
+  fastify.get('/api/reports/strategy-performance', async () => {
+    return getStrategyPerformanceReport(db);
+  });
+
+  fastify.get('/api/reports/unsupported-clusters', async () => {
+    return getUnsupportedClustersReport(db);
   });
 
   // Combined findings view: cycles + fix candidates for a repository

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -3,6 +3,11 @@ import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { analyzeRepository } from '../analyzer/analyzer.js';
 import {
+  getPatternReport,
+  getStrategyPerformanceReport,
+  getUnsupportedClustersReport,
+} from '../db/observationReports.js';
+import {
   annotateAcceptanceBenchmarkCase,
   getAcceptanceBenchmarkReport,
   runAcceptanceBenchmark,
@@ -14,6 +19,7 @@ import { exportApprovedPatches } from './exportPatches.js';
 import { createProgram } from './index.js';
 import { getOperationalMetrics } from './metrics.js';
 import { profileRepository } from './repoProfile.js';
+import { rescoreStoredCycles, retryFailedPatchCandidates } from './rescore.js';
 import { scanAllTrackedRepositories } from './scanAll.js';
 import { scanRepository } from './scanner.js';
 import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
@@ -21,6 +27,92 @@ import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smok
 const fixtureRoot = vi.hoisted(() => `${process.cwd()}/.test-fixtures`);
 const exportedDir = vi.hoisted(() => `${process.cwd()}/.test-fixtures/patches`);
 mkdirSync(fixtureRoot, { recursive: true });
+
+vi.mock('../db/observationReports.js', () => ({
+  getPatternReport: vi.fn().mockReturnValue({
+    summary: {
+      cycleObservations: 3,
+      candidateObservations: 7,
+    },
+    cycleShapes: [
+      {
+        cycleShape: 'two_file',
+        cycleSize: 2,
+        hasBarrelFile: false,
+        hasSharedModuleFile: false,
+        packageManager: 'pnpm',
+        workspaceMode: 'workspace',
+        count: 2,
+      },
+    ],
+    failureClusters: [
+      {
+        strategy: 'extract_shared',
+        failureCategory: 'typecheck_failed',
+        cycleShape: 'two_file',
+        packageManager: 'pnpm',
+        workspaceMode: 'workspace',
+        count: 1,
+        averageConfidence: 0.72,
+        averageUpstreamability: 0.68,
+      },
+    ],
+    unsupportedClusters: [
+      {
+        classification: 'unsupported',
+        cycleShape: 'multi_file',
+        cycleSize: 3,
+        hasBarrelFile: true,
+        packageManager: 'pnpm',
+        workspaceMode: 'workspace',
+        count: 1,
+        samplePaths: ['a.ts -> b.ts -> c.ts -> a.ts'],
+        reasons: ['Only two-file cycles are supported for autofix in v1.'],
+      },
+    ],
+  }),
+  getStrategyPerformanceReport: vi.fn().mockReturnValue({
+    byRepositoryProfile: [
+      {
+        strategy: 'import_type',
+        packageManager: 'pnpm',
+        workspaceMode: 'workspace',
+        attempts: 3,
+        promoted: 2,
+        passedValidations: 2,
+        failedValidations: 0,
+        approvedReviews: 1,
+        rejectedReviews: 0,
+        prCandidates: 1,
+        ignoredReviews: 0,
+      },
+    ],
+    acceptanceByStrategy: [
+      {
+        strategy: 'import_type',
+        classification: 'autofix_import_type',
+        totalCases: 2,
+        acceptedCases: 1,
+        rejectedCases: 0,
+        needsReviewCases: 1,
+        acceptanceRate: 0.5,
+      },
+    ],
+  }),
+  getUnsupportedClustersReport: vi.fn().mockReturnValue([
+    {
+      classification: 'suggest_manual',
+      cycleShape: 'multi_file',
+      cycleSize: 4,
+      hasBarrelFile: false,
+      packageManager: 'npm',
+      workspaceMode: 'single-package',
+      count: 2,
+      samplePaths: ['x.ts -> y.ts -> z.ts -> x.ts'],
+      reasons: ['Barrel re-export graph is ambiguous or side-effectful.'],
+    },
+  ]),
+}));
 
 vi.mock('./scanner.js', () => ({
   scanRepository: vi.fn().mockResolvedValue({ scanId: 999, cyclesFound: 2 }),
@@ -434,6 +526,23 @@ vi.mock('./repoProfile.js', () => ({
   }),
 }));
 
+vi.mock('./rescore.js', () => ({
+  rescoreStoredCycles: vi.fn().mockResolvedValue({
+    processedCycles: 2,
+    skippedCycles: 0,
+    createdObservations: 2,
+    retriedOnlyFailed: false,
+    cycleIds: [11, 12],
+  }),
+  retryFailedPatchCandidates: vi.fn().mockResolvedValue({
+    processedCycles: 1,
+    skippedCycles: 0,
+    createdObservations: 1,
+    retriedOnlyFailed: true,
+    cycleIds: [15],
+  }),
+}));
+
 describe('CLI', () => {
   it('creates a program with the correct name and version', () => {
     const program = createProgram();
@@ -724,14 +833,101 @@ describe('CLI', () => {
     consoleSpy.mockRestore();
   });
 
-  it('retry:failed command logs retry message', () => {
+  it('report:patterns command prints the pattern report as JSON', async () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const program = createProgram();
     program.exitOverride();
 
-    program.parse(['retry:failed'], { from: 'user' });
+    await program.parseAsync(['node', 'test', 'report:patterns']);
 
-    expect(consoleSpy).toHaveBeenCalledWith('Retrying failed patch candidates...');
+    expect(vi.mocked(getPatternReport)).toHaveBeenCalledWith();
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      summary: {
+        cycleObservations: 3,
+        candidateObservations: 7,
+      },
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('report:strategy-performance command prints grouped strategy performance as JSON', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'report:strategy-performance']);
+
+    expect(vi.mocked(getStrategyPerformanceReport)).toHaveBeenCalledWith();
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      byRepositoryProfile: [
+        {
+          strategy: 'import_type',
+          attempts: 3,
+        },
+      ],
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('report:unsupported-clusters command prints unsupported cluster summaries as JSON', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'report:unsupported-clusters']);
+
+    expect(vi.mocked(getUnsupportedClustersReport)).toHaveBeenCalledWith();
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          classification: 'suggest_manual',
+          count: 2,
+        }),
+      ]),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('rescore command recomputes stored cycle rankings', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'rescore', '--cycle-id', '11', '--only-failed']);
+
+    expect(vi.mocked(rescoreStoredCycles)).toHaveBeenCalledWith({
+      cycleIds: [11],
+      limit: undefined,
+      worktreesDir: undefined,
+      onlyFailed: true,
+      logger: expect.anything(),
+      validationLimiter: expect.any(Object),
+    });
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      processedCycles: 2,
+      cycleIds: [11, 12],
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('retry:failed command retries failed patch candidates through rescoring', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(['node', 'test', 'retry:failed', '--limit', '2']);
+
+    expect(vi.mocked(retryFailedPatchCandidates)).toHaveBeenCalledWith({
+      limit: 2,
+      worktreesDir: undefined,
+      logger: expect.anything(),
+      validationLimiter: expect.any(Object),
+    });
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      processedCycles: 1,
+      retriedOnlyFailed: true,
+      cycleIds: [15],
+    });
     consoleSpy.mockRestore();
   });
 
@@ -961,7 +1157,7 @@ describe('CLI', () => {
     exitSpy.mockRestore();
   });
 
-  it('has all fourteen subcommands registered', () => {
+  it('has all expected subcommands registered', () => {
     const program = createProgram();
     const commandNames = program.commands.map((cmd) => cmd.name());
     expect(commandNames).toContain('smoke');
@@ -975,6 +1171,10 @@ describe('CLI', () => {
     expect(commandNames).toContain('mine:repo-history');
     expect(commandNames).toContain('scan:all');
     expect(commandNames).toContain('metrics:report');
+    expect(commandNames).toContain('report:patterns');
+    expect(commandNames).toContain('report:strategy-performance');
+    expect(commandNames).toContain('report:unsupported-clusters');
+    expect(commandNames).toContain('rescore');
     expect(commandNames).toContain('retry:failed');
     expect(commandNames).toContain('create:pr');
     expect(commandNames).toContain('export:patches');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,6 +1,11 @@
 import { Command } from 'commander';
 import { analyzeRepository } from '../analyzer/analyzer.js';
 import {
+  getPatternReport,
+  getStrategyPerformanceReport,
+  getUnsupportedClustersReport,
+} from '../db/observationReports.js';
+import {
   annotateAcceptanceBenchmarkCase,
   getAcceptanceBenchmarkReport,
   runAcceptanceBenchmark,
@@ -17,9 +22,18 @@ import {
   type StructuredLogger,
 } from './observability.js';
 import { profileRepository } from './repoProfile.js';
+import { rescoreStoredCycles, retryFailedPatchCandidates } from './rescore.js';
 import { scanAllTrackedRepositories } from './scanAll.js';
 import { scanRepository } from './scanner.js';
 import { formatSmokeSuiteResult, loadSmokeFixtures, runSmokeSuite } from './smoke.js';
+
+const WORKTREES_DIR_OPTION_DESCRIPTION = 'Directory to use for repository worktrees';
+const SCAN_WORKTREES_DIR_OPTION_DESCRIPTION = 'Directory to use for scan worktrees';
+const VALIDATION_CONCURRENCY_OPTION_DESCRIPTION = 'Maximum concurrent validation jobs';
+const LIMIT_OPTION_DESCRIPTION = 'Limit how many corpus repositories are processed';
+const WORKTREES_DIR_OPTION = '--worktrees-dir <path>';
+const VALIDATION_CONCURRENCY_OPTION = '--validation-concurrency <count>';
+const LIMIT_OPTION = '--limit <count>';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -29,8 +43,8 @@ export function createProgram(): Command {
   program
     .command('scan <repo>')
     .description('Run the dependency analyzer and classifier on a target repository')
-    .option('--worktrees-dir <path>', 'Directory to use for scan worktrees')
-    .option('--validation-concurrency <count>', 'Maximum concurrent validation jobs', parseInteger)
+    .option(WORKTREES_DIR_OPTION, SCAN_WORKTREES_DIR_OPTION_DESCRIPTION)
+    .option(VALIDATION_CONCURRENCY_OPTION, VALIDATION_CONCURRENCY_OPTION_DESCRIPTION, parseInteger)
     .action(async (repo: string, options: { worktreesDir?: string; validationConcurrency?: number }) => {
       console.log(`Scanning repository: ${repo}`);
       try {
@@ -50,7 +64,7 @@ export function createProgram(): Command {
   program
     .command('smoke [fixturesPath]')
     .description('Run the real-repo smoke suite from a fixture list')
-    .option('--worktrees-dir <path>', 'Directory to use for smoke suite worktrees')
+    .option(WORKTREES_DIR_OPTION, 'Directory to use for smoke suite worktrees')
     .action(async (fixturesPath = 'smoke.fixtures.json', options: { worktreesDir?: string }) => {
       try {
         const fixtures = await loadSmokeFixtures(fixturesPath);
@@ -80,7 +94,7 @@ export function createProgram(): Command {
     .option('--search-root <path>', 'Additional root path to search for local repository checkouts', collectString, [])
     .option('--workspace <path>', 'Directory to clone missing repositories into before benchmarking')
     .option('--clone-missing', 'Clone missing repositories into the workspace before benchmarking')
-    .option('--limit <count>', 'Limit how many corpus repositories are processed', parseInteger)
+    .option(LIMIT_OPTION, LIMIT_OPTION_DESCRIPTION, parseInteger)
     .option('--scan-worktrees-dir <path>', 'Directory to use for temporary scan worktrees')
     .action(
       async (options: {
@@ -166,7 +180,7 @@ export function createProgram(): Command {
     .option('--search-root <path>', 'Additional root path to search for local repository checkouts', collectString, [])
     .option('--workspace <path>', 'Directory to clone missing repositories into before mining')
     .option('--clone-missing', 'Clone missing repositories into the workspace before mining')
-    .option('--limit <count>', 'Limit how many corpus repositories are processed', parseInteger)
+    .option(LIMIT_OPTION, LIMIT_OPTION_DESCRIPTION, parseInteger)
     .option('--max-commits <count>', 'Limit how many commits are scanned per repository', parseInteger)
     .option('--max-matches <count>', 'Limit how many benchmark cases are stored per repository', parseInteger)
     .action(
@@ -272,9 +286,9 @@ export function createProgram(): Command {
   program
     .command('scan:all')
     .description('Scan all tracked repositories in the database')
-    .option('--worktrees-dir <path>', 'Directory to use for scan worktrees')
+    .option(WORKTREES_DIR_OPTION, SCAN_WORKTREES_DIR_OPTION_DESCRIPTION)
     .option('--concurrency <count>', 'Maximum concurrent repository scans', parseInteger)
-    .option('--validation-concurrency <count>', 'Maximum concurrent validation jobs', parseInteger)
+    .option(VALIDATION_CONCURRENCY_OPTION, VALIDATION_CONCURRENCY_OPTION_DESCRIPTION, parseInteger)
     .action(async (options: { worktreesDir?: string; concurrency?: number; validationConcurrency?: number }) => {
       try {
         const result = await scanAllTrackedRepositories({
@@ -306,10 +320,97 @@ export function createProgram(): Command {
     });
 
   program
+    .command('report:patterns')
+    .description('Print recurring cycle-shape, failure-cluster, and unsupported-cluster summaries')
+    .action(() => {
+      try {
+        console.log(JSON.stringify(getPatternReport(), null, 2));
+      } catch (error) {
+        console.error('Failed to build the pattern report:', error);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('report:strategy-performance')
+    .description('Print strategy performance grouped by repository profile and acceptance history')
+    .action(() => {
+      try {
+        console.log(JSON.stringify(getStrategyPerformanceReport(), null, 2));
+      } catch (error) {
+        console.error('Failed to build the strategy performance report:', error);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('report:unsupported-clusters')
+    .description('Print the most recurrent unsupported or manual-review cycle clusters')
+    .action(() => {
+      try {
+        console.log(JSON.stringify(getUnsupportedClustersReport(), null, 2));
+      } catch (error) {
+        console.error('Failed to build the unsupported cluster report:', error);
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('rescore')
+    .description('Recompute planner rankings for stored cycles and append new observation versions')
+    .option('--cycle-id <id>', 'Restrict rescoring to a specific stored cycle ID', collectInteger, [])
+    .option(LIMIT_OPTION, 'Limit how many stored cycles are rescored', parseInteger)
+    .option(WORKTREES_DIR_OPTION, WORKTREES_DIR_OPTION_DESCRIPTION)
+    .option(VALIDATION_CONCURRENCY_OPTION, VALIDATION_CONCURRENCY_OPTION_DESCRIPTION, parseInteger)
+    .option('--only-failed', 'Only rescore cycles whose latest candidate observations failed validation')
+    .action(
+      async (options: {
+        cycleId: number[];
+        limit?: number;
+        worktreesDir?: string;
+        validationConcurrency?: number;
+        onlyFailed?: boolean;
+      }) => {
+        try {
+          const result = await rescoreStoredCycles({
+            cycleIds: options.cycleId,
+            limit: options.limit,
+            worktreesDir: options.worktreesDir,
+            onlyFailed: options.onlyFailed,
+            logger: createCliLogger(),
+            validationLimiter: createConcurrencyLimiter(
+              resolveConcurrencySetting(options.validationConcurrency, 'AUTOFIX_VALIDATION_CONCURRENCY', 1),
+            ),
+          });
+          console.log(JSON.stringify(result, null, 2));
+        } catch (error) {
+          console.error('Failed to rescore stored cycles:', error);
+          process.exit(1);
+        }
+      },
+    );
+
+  program
     .command('retry:failed')
     .description('Retry failed patch candidates')
-    .action(() => {
-      console.log('Retrying failed patch candidates...');
+    .option(LIMIT_OPTION, 'Limit how many failed cycles are retried', parseInteger)
+    .option(WORKTREES_DIR_OPTION, WORKTREES_DIR_OPTION_DESCRIPTION)
+    .option(VALIDATION_CONCURRENCY_OPTION, VALIDATION_CONCURRENCY_OPTION_DESCRIPTION, parseInteger)
+    .action(async (options: { limit?: number; worktreesDir?: string; validationConcurrency?: number }) => {
+      try {
+        const result = await retryFailedPatchCandidates({
+          limit: options.limit,
+          worktreesDir: options.worktreesDir,
+          logger: createCliLogger(),
+          validationLimiter: createConcurrencyLimiter(
+            resolveConcurrencySetting(options.validationConcurrency, 'AUTOFIX_VALIDATION_CONCURRENCY', 1),
+          ),
+        });
+        console.log(JSON.stringify(result, null, 2));
+      } catch (error) {
+        console.error('Failed to retry failed patch candidates:', error);
+        process.exit(1);
+      }
     });
 
   program
@@ -397,6 +498,10 @@ function parseScore(value: string): number {
 
 function collectString(value: string, previous: string[]): string[] {
   return [...previous, value];
+}
+
+function collectInteger(value: string, previous: number[]): number[] {
+  return [...previous, parseInteger(value)];
 }
 
 function createCliLogger(): StructuredLogger {

--- a/cli/rescore.test.ts
+++ b/cli/rescore.test.ts
@@ -1,0 +1,366 @@
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as dbModule from '../db/index.js';
+import { rescoreStoredCycles, retryFailedPatchCandidates } from './rescore.js';
+
+const testWorktreesDir = `${process.cwd()}/.test-fixtures/rescore-worktrees`;
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => ({
+    log: vi.fn(),
+  })),
+}));
+
+vi.mock('../analyzer/semantic/index.js', () => ({
+  SemanticAnalyzer: class {
+    public analyzeCycle() {
+      return {
+        classification: 'autofix_import_type',
+        confidence: 0.91,
+        reasons: ['Converted runtime edges to type-only imports.'],
+        plan: {
+          kind: 'import_type',
+          imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+        },
+        upstreamabilityScore: 0.94,
+        planner: {
+          cycleFiles: ['a.ts', 'b.ts'],
+          cycleSize: 2,
+          cycleShape: 'two_file',
+          cycleSignals: { explicitImportEdges: 2, loadedFiles: 2, missingFiles: 0 },
+          features: {
+            cycleSize: 2,
+            cycleShape: 'two_file',
+            explicitImportEdges: 2,
+            loadedFiles: 2,
+            missingFiles: 0,
+            hasBarrelFile: false,
+            hasSharedModuleFile: false,
+            typescriptFileCount: 2,
+            tsxFileCount: 0,
+            packageManager: 'pnpm',
+            workspaceMode: 'workspace',
+            validationCommandCount: 1,
+          },
+          fallbackClassification: 'autofix_import_type',
+          fallbackConfidence: 0.91,
+          fallbackReasons: ['Converted runtime edges to type-only imports.'],
+          selectedStrategy: 'import_type',
+          selectedClassification: 'autofix_import_type',
+          selectedScore: 0.94,
+          selectionSummary: 'Selected import_type.',
+          rankedCandidates: [
+            {
+              strategy: 'import_type',
+              status: 'candidate',
+              summary: 'Convert the cycle imports to type-only imports.',
+              reasons: ['Converted runtime edges to type-only imports.'],
+              signals: { touchedFiles: 1 },
+              score: 0.94,
+              scoreBreakdown: ['base 0.97'],
+              classification: 'autofix_import_type',
+              confidence: 0.91,
+              plan: {
+                kind: 'import_type',
+                imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+              },
+            },
+          ],
+          attempts: [
+            {
+              strategy: 'import_type',
+              status: 'candidate',
+              summary: 'Convert the cycle imports to type-only imports.',
+              reasons: ['Converted runtime edges to type-only imports.'],
+              signals: { touchedFiles: 1 },
+              score: 0.94,
+              scoreBreakdown: ['base 0.97'],
+              classification: 'autofix_import_type',
+              confidence: 0.91,
+              plan: {
+                kind: 'import_type',
+                imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+              },
+            },
+          ],
+        },
+      };
+    }
+  },
+}));
+
+vi.mock('./repoProfile.js', () => ({
+  profileRepository: vi.fn().mockResolvedValue({
+    packageManager: 'pnpm',
+    workspaceMode: 'workspace',
+    validationCommands: ['pnpm lint'],
+  }),
+}));
+
+vi.mock('./scanner/target.js', () => ({
+  resolveScanTarget: vi.fn().mockResolvedValue({
+    owner: 'acme',
+    name: 'app',
+    repoPath: '/resolved/app',
+    localPath: '/repos/app',
+    cloneUrl: null,
+    remoteUrl: 'https://github.com/acme/app.git',
+  }),
+  syncRepositoryClone: vi.fn().mockResolvedValue('cloned'),
+}));
+
+vi.mock('./scanner/persistence.js', () => ({
+  getLatestCommitSha: vi.fn().mockResolvedValue('rescored-sha'),
+  getNextCycleObservationVersion: vi.fn().mockReturnValue(2),
+  persistCycleObservationVersion: vi.fn().mockResolvedValue(101),
+}));
+
+vi.mock('../db/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../db/index.js')>('../db/index.js');
+  const db = actual.createDatabase(':memory:');
+  actual.initSchema(db);
+  const stmts = actual.createStatements(db);
+
+  return {
+    ...actual,
+    getDb: () => db,
+    addRepository: stmts.addRepository,
+    getRepository: stmts.getRepository,
+    updateRepositoryLocalPath: stmts.updateRepositoryLocalPath,
+    addScan: stmts.addScan,
+    addCycle: stmts.addCycle,
+    addCycleObservation: stmts.addCycleObservation,
+    addCandidateObservation: stmts.addCandidateObservation,
+  };
+});
+
+describe('rescoreStoredCycles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbModule.getDb().prepare('DELETE FROM candidate_observations').run();
+    dbModule.getDb().prepare('DELETE FROM cycle_observations').run();
+    dbModule.getDb().prepare('DELETE FROM cycles').run();
+    dbModule.getDb().prepare('DELETE FROM scans').run();
+    dbModule.getDb().prepare('DELETE FROM repositories').run();
+  });
+
+  it('rescales stored cycles into a new observation version', async () => {
+    const repositoryInfo = dbModule.addRepository.run({
+      owner: 'acme',
+      name: 'app',
+      default_branch: 'main',
+      local_path: '/repos/app',
+    });
+    const repositoryId = repositoryInfo.lastInsertRowid as number;
+    const scanInfo = dbModule.addScan.run({
+      repository_id: repositoryId,
+      commit_sha: 'old-sha',
+      status: 'completed',
+    });
+    const scanId = scanInfo.lastInsertRowid as number;
+    const cycleInfo = dbModule.addCycle.run({
+      scan_id: scanId,
+      normalized_path: 'a.ts -> b.ts',
+      participating_files: JSON.stringify(['a.ts', 'b.ts']),
+      raw_payload: JSON.stringify({
+        type: 'circular',
+        path: ['a.ts', 'b.ts'],
+      }),
+    });
+    const cycleId = cycleInfo.lastInsertRowid as number;
+
+    dbModule.addCycleObservation.run({
+      cycle_id: cycleId,
+      scan_id: scanId,
+      repository_id: repositoryId,
+      observation_version: 1,
+      normalized_path: 'a.ts -> b.ts',
+      cycle_shape: 'two_file',
+      cycle_size: 2,
+      cycle_signals: JSON.stringify({ explicitImportEdges: 2 }),
+      feature_vector: JSON.stringify({ cycleShape: 'two_file' }),
+      repo_profile: JSON.stringify({ packageManager: 'pnpm', workspaceMode: 'workspace' }),
+      planner_summary: 'Original observation.',
+      planner_attempts: JSON.stringify([]),
+      selected_strategy: 'import_type',
+      selected_classification: 'autofix_import_type',
+      selected_score: 0.9,
+      fallback_classification: 'autofix_import_type',
+      fallback_confidence: 0.9,
+      fallback_reasons: JSON.stringify(['original']),
+    });
+
+    const result = await rescoreStoredCycles({
+      cycleIds: [cycleId],
+      worktreesDir: testWorktreesDir,
+    });
+
+    const { persistCycleObservationVersion } = await import('./scanner/persistence.js');
+
+    expect(vi.mocked(persistCycleObservationVersion)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cycleId,
+        observationVersion: 2,
+        scanId,
+        repoPath: path.join('/resolved', 'app'),
+        sourceTarget: '/repos/app',
+        commitSha: 'rescored-sha',
+        cycle: expect.objectContaining({
+          path: ['a.ts', 'b.ts'],
+          analysis: expect.objectContaining({
+            classification: 'autofix_import_type',
+          }),
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      processedCycles: 1,
+      skippedCycles: 0,
+      createdObservations: 1,
+      cycleIds: [cycleId],
+    });
+  });
+
+  it('retries only the latest failed candidate observations', async () => {
+    const repositoryInfo = dbModule.addRepository.run({
+      owner: 'acme',
+      name: 'app',
+      default_branch: 'main',
+      local_path: '/repos/app',
+    });
+    const repositoryId = repositoryInfo.lastInsertRowid as number;
+    const scanInfo = dbModule.addScan.run({
+      repository_id: repositoryId,
+      commit_sha: 'old-sha',
+      status: 'completed',
+    });
+    const scanId = scanInfo.lastInsertRowid as number;
+
+    const firstCycleInfo = dbModule.addCycle.run({
+      scan_id: scanId,
+      normalized_path: 'a.ts -> b.ts',
+      participating_files: JSON.stringify(['a.ts', 'b.ts']),
+      raw_payload: JSON.stringify({
+        type: 'circular',
+        path: ['a.ts', 'b.ts'],
+      }),
+    });
+    const secondCycleInfo = dbModule.addCycle.run({
+      scan_id: scanId,
+      normalized_path: 'c.ts -> d.ts',
+      participating_files: JSON.stringify(['c.ts', 'd.ts']),
+      raw_payload: JSON.stringify({
+        type: 'circular',
+        path: ['c.ts', 'd.ts'],
+      }),
+    });
+
+    const failedObservation = dbModule.addCycleObservation.run({
+      cycle_id: firstCycleInfo.lastInsertRowid as number,
+      scan_id: scanId,
+      repository_id: repositoryId,
+      observation_version: 1,
+      normalized_path: 'a.ts -> b.ts',
+      cycle_shape: 'two_file',
+      cycle_size: 2,
+      cycle_signals: JSON.stringify({ explicitImportEdges: 2 }),
+      feature_vector: JSON.stringify({ cycleShape: 'two_file' }),
+      repo_profile: JSON.stringify({ packageManager: 'pnpm', workspaceMode: 'workspace' }),
+      planner_summary: 'Failed observation.',
+      planner_attempts: JSON.stringify([]),
+      selected_strategy: 'import_type',
+      selected_classification: 'autofix_import_type',
+      selected_score: 0.9,
+      fallback_classification: 'autofix_import_type',
+      fallback_confidence: 0.9,
+      fallback_reasons: JSON.stringify(['failed']),
+    });
+    const passedObservation = dbModule.addCycleObservation.run({
+      cycle_id: secondCycleInfo.lastInsertRowid as number,
+      scan_id: scanId,
+      repository_id: repositoryId,
+      observation_version: 1,
+      normalized_path: 'c.ts -> d.ts',
+      cycle_shape: 'two_file',
+      cycle_size: 2,
+      cycle_signals: JSON.stringify({ explicitImportEdges: 2 }),
+      feature_vector: JSON.stringify({ cycleShape: 'two_file' }),
+      repo_profile: JSON.stringify({ packageManager: 'pnpm', workspaceMode: 'workspace' }),
+      planner_summary: 'Passed observation.',
+      planner_attempts: JSON.stringify([]),
+      selected_strategy: 'import_type',
+      selected_classification: 'autofix_import_type',
+      selected_score: 0.9,
+      fallback_classification: 'autofix_import_type',
+      fallback_confidence: 0.9,
+      fallback_reasons: JSON.stringify(['passed']),
+    });
+
+    dbModule.addCandidateObservation.run({
+      cycle_observation_id: failedObservation.lastInsertRowid as number,
+      observation_version: 1,
+      fix_candidate_id: null,
+      patch_id: null,
+      strategy: 'import_type',
+      status: 'candidate',
+      planner_rank: 1,
+      promotion_eligible: 1,
+      summary: 'Failed patch candidate',
+      classification: 'autofix_import_type',
+      confidence: 0.9,
+      upstreamability_score: 0.9,
+      reasons: JSON.stringify(['failed']),
+      score_breakdown: JSON.stringify(['base 0.97']),
+      signals: JSON.stringify({ touchedFiles: 1 }),
+      plan: JSON.stringify({
+        kind: 'import_type',
+        imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }],
+      }),
+      validation_status: 'failed',
+      validation_summary: 'Typecheck failed.',
+      validation_failure_category: 'typecheck_failed',
+    });
+    dbModule.addCandidateObservation.run({
+      cycle_observation_id: passedObservation.lastInsertRowid as number,
+      observation_version: 1,
+      fix_candidate_id: null,
+      patch_id: null,
+      strategy: 'import_type',
+      status: 'candidate',
+      planner_rank: 1,
+      promotion_eligible: 1,
+      summary: 'Passed patch candidate',
+      classification: 'autofix_import_type',
+      confidence: 0.9,
+      upstreamability_score: 0.9,
+      reasons: JSON.stringify(['passed']),
+      score_breakdown: JSON.stringify(['base 0.97']),
+      signals: JSON.stringify({ touchedFiles: 1 }),
+      plan: JSON.stringify({
+        kind: 'import_type',
+        imports: [{ sourceFile: 'c.ts', targetFile: 'd.ts' }],
+      }),
+      validation_status: 'passed',
+      validation_summary: 'Validation passed.',
+      validation_failure_category: null,
+    });
+
+    const result = await retryFailedPatchCandidates({
+      worktreesDir: testWorktreesDir,
+    });
+
+    const { persistCycleObservationVersion } = await import('./scanner/persistence.js');
+
+    expect(vi.mocked(persistCycleObservationVersion)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(persistCycleObservationVersion)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cycleId: firstCycleInfo.lastInsertRowid as number,
+      }),
+    );
+    expect(result).toMatchObject({
+      processedCycles: 1,
+      retriedOnlyFailed: true,
+      cycleIds: [firstCycleInfo.lastInsertRowid as number],
+    });
+  });
+});

--- a/cli/rescore.ts
+++ b/cli/rescore.ts
@@ -1,0 +1,266 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import simpleGit from 'simple-git';
+import { loadHistoricalEvidence } from '../analyzer/semantic/evidence.js';
+import { type PlannerRepositoryProfile, SemanticAnalyzer } from '../analyzer/semantic/index.js';
+import type { CycleDTO, RepositoryDTO } from '../db/index.js';
+import { getDb, getRepository, updateRepositoryLocalPath } from '../db/index.js';
+import { type ConcurrencyLimiter, createNoopLogger, type StructuredLogger, serializeError } from './observability.js';
+import { profileRepository } from './repoProfile.js';
+import {
+  getLatestCommitSha,
+  getNextCycleObservationVersion,
+  persistCycleObservationVersion,
+} from './scanner/persistence.js';
+import { resolveScanTarget, syncRepositoryClone } from './scanner/target.js';
+import type { ScannedCycle } from './scanner/types.js';
+
+interface StoredCycleRow {
+  cycle_id: number;
+  scan_id: number;
+  repository_id: number;
+  normalized_path: string;
+  observation_version: number;
+  raw_payload: string | null;
+  owner: string;
+  name: string;
+  local_path: string | null;
+}
+
+export interface RescoreStoredCyclesOptions {
+  cycleIds?: number[];
+  limit?: number;
+  logger?: StructuredLogger;
+  onlyFailed?: boolean;
+  validationLimiter?: ConcurrencyLimiter;
+  worktreesDir?: string;
+}
+
+export interface RescoreStoredCyclesResult {
+  processedCycles: number;
+  skippedCycles: number;
+  createdObservations: number;
+  retriedOnlyFailed: boolean;
+  cycleIds: number[];
+}
+
+export async function rescoreStoredCycles(
+  options: RescoreStoredCyclesOptions = {},
+): Promise<RescoreStoredCyclesResult> {
+  const logger = options.logger ?? createNoopLogger();
+  const worktreesDir = path.resolve(options.worktreesDir ?? './worktrees');
+  const retryableCycles = loadStoredCycles({
+    cycleIds: options.cycleIds,
+    limit: options.limit,
+    onlyFailed: options.onlyFailed ?? false,
+  });
+
+  const result: RescoreStoredCyclesResult = {
+    processedCycles: 0,
+    skippedCycles: 0,
+    createdObservations: 0,
+    retriedOnlyFailed: options.onlyFailed ?? false,
+    cycleIds: [],
+  };
+
+  for (const row of retryableCycles) {
+    const cycleLogger = logger.child({
+      cycleId: row.cycle_id,
+      normalizedPath: row.normalized_path,
+      observationVersion: row.observation_version,
+    });
+
+    const parsedCycle = parseStoredCycle(row.raw_payload, cycleLogger);
+    if (!parsedCycle) {
+      result.skippedCycles += 1;
+      continue;
+    }
+
+    const repository = getRepository.get(row.repository_id) as RepositoryDTO | undefined;
+    if (!repository) {
+      cycleLogger.warn('rescore.skipped', {
+        reason: 'Repository row for stored cycle could not be found.',
+        repositoryId: row.repository_id,
+      });
+      result.skippedCycles += 1;
+      continue;
+    }
+
+    try {
+      const resolvedTarget = await resolveStoredRepository(repository, worktreesDir, cycleLogger);
+      const repositoryProfile = await safePlannerRepositoryProfile(resolvedTarget.repoPath, cycleLogger);
+      const semanticAnalyzer = new SemanticAnalyzer(resolvedTarget.repoPath, {
+        repositoryProfile,
+        historicalEvidence: loadHistoricalEvidence(repositoryProfile),
+      });
+      const commitSha = await getLatestCommitSha(simpleGit(resolvedTarget.repoPath));
+      const rescoredCycle: ScannedCycle = {
+        ...parsedCycle,
+        analysis: semanticAnalyzer.analyzeCycle(parsedCycle.path),
+      };
+
+      const observationVersion = getNextCycleObservationVersion(row.cycle_id);
+      await persistCycleObservationVersion({
+        cycleId: row.cycle_id,
+        observationVersion,
+        scanId: row.scan_id,
+        repoPath: resolvedTarget.repoPath,
+        sourceTarget: resolvedTarget.localPath ?? `${repository.owner}/${repository.name}`,
+        commitSha,
+        remoteUrl: resolvedTarget.remoteUrl,
+        repository,
+        cycle: rescoredCycle,
+        logger: cycleLogger,
+        validationLimiter: options.validationLimiter,
+      });
+
+      result.processedCycles += 1;
+      result.createdObservations += 1;
+      result.cycleIds.push(row.cycle_id);
+      cycleLogger.info('rescore.completed', {
+        newObservationVersion: observationVersion,
+        classification: rescoredCycle.analysis?.classification ?? null,
+      });
+    } catch (error) {
+      result.skippedCycles += 1;
+      cycleLogger.error('rescore.failed', {
+        ...serializeError(error),
+      });
+    }
+  }
+
+  return result;
+}
+
+export async function retryFailedPatchCandidates(
+  options: Omit<RescoreStoredCyclesOptions, 'onlyFailed'> = {},
+): Promise<RescoreStoredCyclesResult> {
+  return rescoreStoredCycles({
+    ...options,
+    onlyFailed: true,
+  });
+}
+
+function loadStoredCycles(args: { cycleIds?: number[]; limit?: number; onlyFailed: boolean }): StoredCycleRow[] {
+  const rows = getDb()
+    .prepare(
+      `
+        WITH latest_cycle_observations AS (
+          SELECT co.*
+          FROM cycle_observations co
+          INNER JOIN (
+            SELECT cycle_id, MAX(observation_version) AS max_version
+            FROM cycle_observations
+            GROUP BY cycle_id
+          ) latest
+            ON latest.cycle_id = co.cycle_id
+           AND latest.max_version = co.observation_version
+        )
+        SELECT
+          co.cycle_id,
+          co.scan_id,
+          co.repository_id,
+          co.normalized_path,
+          co.observation_version,
+          c.raw_payload,
+          r.owner,
+          r.name,
+          r.local_path
+        FROM latest_cycle_observations co
+        INNER JOIN cycles c ON c.id = co.cycle_id
+        INNER JOIN repositories r ON r.id = co.repository_id
+        WHERE (
+          @only_failed = 0
+          OR EXISTS (
+            SELECT 1
+            FROM candidate_observations cobs
+            WHERE cobs.cycle_observation_id = co.id
+              AND cobs.validation_status = 'failed'
+          )
+        )
+        ORDER BY co.id ASC
+      `,
+    )
+    .all({
+      only_failed: args.onlyFailed ? 1 : 0,
+    }) as StoredCycleRow[];
+
+  const filteredRows =
+    args.cycleIds && args.cycleIds.length > 0 ? rows.filter((row) => args.cycleIds?.includes(row.cycle_id)) : rows;
+
+  return args.limit ? filteredRows.slice(0, args.limit) : filteredRows;
+}
+
+function parseStoredCycle(rawPayload: string | null, logger: StructuredLogger): ScannedCycle | null {
+  if (!rawPayload) {
+    logger.warn('rescore.skipped', {
+      reason: 'Stored cycle is missing a raw payload.',
+    });
+    return null;
+  }
+
+  try {
+    return JSON.parse(rawPayload) as ScannedCycle;
+  } catch (error) {
+    logger.warn('rescore.skipped', {
+      reason: 'Stored cycle payload could not be parsed.',
+      ...serializeError(error),
+    });
+    return null;
+  }
+}
+
+async function resolveStoredRepository(repository: RepositoryDTO, worktreesDir: string, logger: StructuredLogger) {
+  const sourceTarget = repository.local_path ?? `${repository.owner}/${repository.name}`;
+  const resolvedTarget = await resolveScanTarget(sourceTarget, worktreesDir);
+
+  if (!resolvedTarget.localPath) {
+    await fs.mkdir(worktreesDir, { recursive: true });
+    await syncRepositoryClone(simpleGit(), resolvedTarget);
+  } else if (repository.local_path !== resolvedTarget.localPath) {
+    updateRepositoryLocalPath.run({
+      id: repository.id,
+      local_path: resolvedTarget.localPath,
+    });
+  }
+
+  logger.info('rescore.target.ready', {
+    repoPath: resolvedTarget.repoPath,
+    localPath: resolvedTarget.localPath,
+    remoteUrl: resolvedTarget.remoteUrl,
+  });
+
+  return resolvedTarget;
+}
+
+async function safePlannerRepositoryProfile(
+  repoPath: string,
+  logger: StructuredLogger,
+): Promise<PlannerRepositoryProfile | undefined> {
+  try {
+    const profile = await profileRepository(repoPath);
+    return {
+      packageManager: profile.packageManager,
+      workspaceMode: profile.workspaceMode,
+      validationCommandCount: profile.validationCommands.length,
+    };
+  } catch (error) {
+    logger.warn('rescore.profile.failed', {
+      repoPath,
+      ...serializeError(error),
+    });
+    return void 0;
+  }
+}
+
+export function getStoredCycleById(cycleId: number): CycleDTO | undefined {
+  return getDb()
+    .prepare(
+      `
+        SELECT *
+        FROM cycles
+        WHERE id = ?
+      `,
+    )
+    .get(cycleId) as CycleDTO | undefined;
+}

--- a/cli/scanner.test.ts
+++ b/cli/scanner.test.ts
@@ -36,11 +36,16 @@ vi.mock('../db/index.js', async () => {
     updateScanStatus: stmts.updateScanStatus,
     addCycle: stmts.addCycle,
     getCyclesByScanId: stmts.getCyclesByScanId,
+    addCycleObservation: stmts.addCycleObservation,
+    getCycleObservationsByScanId: stmts.getCycleObservationsByScanId,
+    getLatestCycleObservationByCycleId: stmts.getLatestCycleObservationByCycleId,
     getScan: stmts.getScan,
     addFixCandidate: stmts.addFixCandidate,
     getFixCandidatesByCycleId: stmts.getFixCandidatesByCycleId,
     addPatch: stmts.addPatch,
     getPatchesByFixCandidateId: stmts.getPatchesByFixCandidateId,
+    addCandidateObservation: stmts.addCandidateObservation,
+    getCandidateObservationsByCycleObservationId: stmts.getCandidateObservationsByCycleObservationId,
     addPatchReplay: stmts.addPatchReplay,
     getPatchReplayByPatchId: stmts.getPatchReplayByPatchId,
   };
@@ -68,6 +73,8 @@ describe('Scanner Worker', () => {
       summary: 'Validation passed.',
     });
 
+    dbModule.getDb().prepare('DELETE FROM candidate_observations').run();
+    dbModule.getDb().prepare('DELETE FROM cycle_observations').run();
     dbModule.getDb().prepare('DELETE FROM patch_replays').run();
     dbModule.getDb().prepare('DELETE FROM patches').run();
     dbModule.getDb().prepare('DELETE FROM fix_candidates').run();
@@ -309,6 +316,13 @@ describe('Scanner Worker', () => {
     expect(candidates).toHaveLength(1);
     expect(candidates[0].classification).toBe('autofix_import_type');
     expect(candidates[0].confidence).toBe(0.9);
+
+    const cycleObservation = dbModule.getLatestCycleObservationByCycleId.get(cycles[0].id) as {
+      selected_classification: string;
+      planner_attempts: string;
+    };
+    expect(cycleObservation.selected_classification).toBe('autofix_import_type');
+    expect(JSON.parse(cycleObservation.planner_attempts)).toEqual([]);
   });
 
   it('persists ranked planner candidates and validates executable shortlist entries', async () => {
@@ -344,6 +358,80 @@ describe('Scanner Worker', () => {
               packageManager: 'pnpm',
               workspaceMode: 'workspace',
               validationCommandCount: 2,
+            },
+            graphSummary: {
+              modules: [
+                {
+                  file: 'a.ts',
+                  exportedSymbols: ['AType'],
+                  localExportedSymbols: ['AType'],
+                  movableSymbols: ['AType'],
+                  moduleKind: 'declaration_only',
+                  hasReExports: false,
+                  hasTopLevelSideEffects: false,
+                },
+                {
+                  file: 'b.ts',
+                  exportedSymbols: ['BType'],
+                  localExportedSymbols: ['BType'],
+                  movableSymbols: ['BType'],
+                  moduleKind: 'declaration_only',
+                  hasReExports: false,
+                  hasTopLevelSideEffects: false,
+                },
+              ],
+              importEdges: [
+                {
+                  from: 'a.ts',
+                  to: 'b.ts',
+                  kind: 'type',
+                  symbols: ['BType'],
+                  withinCycle: true,
+                },
+                {
+                  from: 'b.ts',
+                  to: 'a.ts',
+                  kind: 'type',
+                  symbols: ['AType'],
+                  withinCycle: true,
+                },
+              ],
+              exportEdges: [],
+              symbolNodes: [
+                {
+                  id: 'a.ts::AType',
+                  file: 'a.ts',
+                  symbol: 'AType',
+                  kind: 'interface',
+                  exported: true,
+                  movable: true,
+                },
+                {
+                  id: 'b.ts::BType',
+                  file: 'b.ts',
+                  symbol: 'BType',
+                  kind: 'interface',
+                  exported: true,
+                  movable: true,
+                },
+              ],
+              symbolEdges: [
+                { from: 'a.ts::AType', to: 'b.ts::BType', kind: 'import' },
+                { from: 'b.ts::BType', to: 'a.ts::AType', kind: 'import' },
+              ],
+              symbolSccs: [['a.ts::AType', 'b.ts::BType']],
+              exportResolutions: [],
+              metrics: {
+                moduleCount: 2,
+                importEdgeCount: 2,
+                exportEdgeCount: 0,
+                symbolNodeCount: 2,
+                symbolEdgeCount: 2,
+                symbolSccCount: 1,
+                barrelModuleCount: 0,
+                sideEffectModuleCount: 0,
+                movableSymbolCount: 2,
+              },
             },
             fallbackClassification: 'autofix_import_type',
             fallbackConfidence: 0.93,
@@ -432,6 +520,44 @@ describe('Scanner Worker', () => {
     expect(primaryPatches).toHaveLength(1);
     expect(secondaryPatches).toHaveLength(1);
     expect(vi.mocked(generatePatchForCycle)).toHaveBeenCalledTimes(2);
+
+    const cycleObservation = dbModule.getLatestCycleObservationByCycleId.get(cycles[0].id) as {
+      id: number;
+      graph_summary: string | null;
+    };
+    const attemptObservations = dbModule.getCandidateObservationsByCycleObservationId.all(
+      cycleObservation.id,
+    ) as Array<{
+      strategy: string | null;
+      status: string;
+      planner_rank: number;
+      promotion_eligible: number;
+      validation_status: string | null;
+    }>;
+    expect(attemptObservations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          strategy: 'import_type',
+          status: 'candidate',
+          planner_rank: 1,
+          promotion_eligible: 1,
+          validation_status: 'passed',
+        }),
+        expect.objectContaining({
+          strategy: 'extract_shared',
+          status: 'candidate',
+          planner_rank: 2,
+          promotion_eligible: 1,
+          validation_status: 'passed',
+        }),
+      ]),
+    );
+    expect(JSON.parse(cycleObservation.graph_summary ?? '{}')).toMatchObject({
+      metrics: {
+        symbolSccCount: 1,
+        movableSymbolCount: 2,
+      },
+    });
   });
 
   it('persists generated patches for executable fix plans', async () => {

--- a/cli/scanner/persistence.ts
+++ b/cli/scanner/persistence.ts
@@ -5,12 +5,15 @@ import type { GeneratedPatch } from '../../codemod/generatePatch.js';
 import { generatePatchForCycle } from '../../codemod/generatePatch.js';
 import type { RepositoryDTO } from '../../db/index.js';
 import {
+  addCandidateObservation,
   addCycle,
+  addCycleObservation,
   addFixCandidate,
   addPatch,
   addPatchReplay,
   addRepository,
   getDb,
+  getLatestCycleObservationByCycleId,
   getRepositoryByOwnerName,
   updateRepositoryLocalPath,
 } from '../../db/index.js';
@@ -31,6 +34,49 @@ interface PersistedCandidate {
   summary: string | null;
   scoreBreakdown: string[] | null;
   signals: Record<string, unknown> | null;
+}
+
+interface CandidateOutcome {
+  fixCandidateId: number;
+  patchId: number | null;
+  validationStatus: string | null;
+  validationSummary: string | null;
+  validationFailureCategory: string | null;
+  promotionEligible: boolean;
+}
+
+interface ObservationAttempt {
+  strategy: string | null;
+  status: string;
+  plannerRank: number;
+  promotionEligible: boolean;
+  summary: string | null;
+  classification: string | null;
+  confidence: number | null;
+  upstreamabilityScore: number | null;
+  reasons: string[] | null;
+  scoreBreakdown: string[] | null;
+  signals: Record<string, unknown> | null;
+  plan: SemanticAnalysisResult['plan'];
+  fixCandidateId: number | null;
+  patchId: number | null;
+  validationStatus: string | null;
+  validationSummary: string | null;
+  validationFailureCategory: string | null;
+}
+
+interface PersistCycleArtifactsArgs {
+  cycleId: number;
+  observationVersion: number;
+  scanId: number;
+  repoPath: string;
+  sourceTarget: string;
+  commitSha: string;
+  remoteUrl: string | null;
+  repository: RepositoryDTO;
+  cycle: ScannedCycle;
+  logger?: StructuredLogger;
+  validationLimiter?: ConcurrencyLimiter;
 }
 
 export async function getLatestCommitSha(gitRepo: Pick<SimpleGit, 'log'>): Promise<string> {
@@ -100,7 +146,6 @@ export async function persistCycle(
     validationLimiter?: ConcurrencyLimiter;
   } = {},
 ): Promise<void> {
-  const logger = options.logger ?? createNoopLogger();
   const canonicalPath = canonicalizeCyclePath(cycle.path);
   const persistedCycle = {
     ...cycle,
@@ -113,23 +158,179 @@ export async function persistCycle(
     participating_files: JSON.stringify(canonicalPath),
     raw_payload: JSON.stringify(persistedCycle),
   });
-  const cycleId = cycleInfo.lastInsertRowid as number;
+
+  await persistCycleObservationVersion({
+    cycleId: cycleInfo.lastInsertRowid as number,
+    observationVersion: 1,
+    scanId,
+    repoPath,
+    sourceTarget,
+    commitSha,
+    remoteUrl,
+    repository,
+    cycle: persistedCycle,
+    logger: options.logger,
+    validationLimiter: options.validationLimiter,
+  });
+}
+
+export async function persistCycleObservationVersion(args: PersistCycleArtifactsArgs): Promise<number> {
+  const {
+    cycleId,
+    observationVersion,
+    scanId,
+    repoPath,
+    sourceTarget,
+    commitSha,
+    remoteUrl,
+    repository,
+    cycle,
+    logger: providedLogger,
+    validationLimiter,
+  } = args;
+  const logger = providedLogger ?? createNoopLogger();
+  const canonicalPath = canonicalizeCyclePath(cycle.path);
+  const persistedCycle = {
+    ...cycle,
+    path: canonicalPath,
+  };
   const cycleLogger = logger.child({
     cycleId,
     normalizedPath: normalizeCyclePath(canonicalPath),
+    observationVersion,
   });
   cycleLogger.info('cycle.persisted', {
     participatingFiles: canonicalPath.length,
   });
 
+  const cycleObservationInfo = addCycleObservation.run(
+    buildCycleObservationPayload({
+      cycleId,
+      scanId,
+      repositoryId: repository.id,
+      observationVersion,
+      normalizedPath: normalizeCyclePath(canonicalPath),
+      cyclePath: canonicalPath,
+      analysis: persistedCycle.analysis,
+    }),
+  );
+  const cycleObservationId = cycleObservationInfo.lastInsertRowid as number;
+
   if (!persistedCycle.analysis) {
     cycleLogger.warn('cycle.unclassified', {
       reason: 'No semantic analysis was attached to the cycle payload.',
     });
-    return;
+    return cycleObservationId;
   }
 
   const candidates = extractPersistedCandidates(persistedCycle.analysis);
+  const candidateOutcomes = await persistCandidateArtifacts({
+    candidates,
+    analysis: persistedCycle.analysis,
+    cycleId,
+    cycle: persistedCycle,
+    cycleLogger,
+    repoPath,
+    repository,
+    scanId,
+    sourceTarget,
+    commitSha,
+    remoteUrl,
+    validationLimiter,
+  });
+
+  const observationAttempts = buildObservationAttempts(persistedCycle.analysis, candidateOutcomes);
+  for (const attempt of observationAttempts) {
+    addCandidateObservation.run({
+      cycle_observation_id: cycleObservationId,
+      observation_version: observationVersion,
+      fix_candidate_id: attempt.fixCandidateId,
+      patch_id: attempt.patchId,
+      strategy: attempt.strategy,
+      status: attempt.status,
+      planner_rank: attempt.plannerRank,
+      promotion_eligible: attempt.promotionEligible ? 1 : 0,
+      summary: attempt.summary,
+      classification: attempt.classification,
+      confidence: attempt.confidence,
+      upstreamability_score: attempt.upstreamabilityScore,
+      reasons: attempt.reasons ? JSON.stringify(attempt.reasons) : null,
+      score_breakdown: attempt.scoreBreakdown ? JSON.stringify(attempt.scoreBreakdown) : null,
+      signals: attempt.signals ? JSON.stringify(attempt.signals) : null,
+      plan: attempt.plan ? JSON.stringify(attempt.plan) : null,
+      validation_status: attempt.validationStatus,
+      validation_summary: attempt.validationSummary,
+      validation_failure_category: attempt.validationFailureCategory,
+    });
+  }
+
+  return cycleObservationId;
+}
+
+function buildCycleObservationPayload(args: {
+  cycleId: number;
+  scanId: number;
+  repositoryId: number;
+  observationVersion: number;
+  normalizedPath: string;
+  cyclePath: string[];
+  analysis?: SemanticAnalysisResult;
+}) {
+  const { cycleId, scanId, repositoryId, observationVersion, normalizedPath, cyclePath, analysis } = args;
+
+  return {
+    cycle_id: cycleId,
+    scan_id: scanId,
+    repository_id: repositoryId,
+    observation_version: observationVersion,
+    normalized_path: normalizedPath,
+    cycle_shape: analysis?.planner?.cycleShape ?? null,
+    cycle_size: analysis?.planner?.cycleSize ?? cyclePath.length - 1,
+    cycle_signals: analysis?.planner?.cycleSignals ? JSON.stringify(analysis.planner.cycleSignals) : null,
+    feature_vector: analysis?.planner?.features ? JSON.stringify(analysis.planner.features) : null,
+    graph_summary: analysis?.planner?.graphSummary ? JSON.stringify(analysis.planner.graphSummary) : null,
+    repo_profile: buildObservationRepoProfile(analysis),
+    planner_summary: analysis?.planner?.selectionSummary ?? null,
+    planner_attempts: JSON.stringify(analysis?.planner?.attempts ?? []),
+    selected_strategy:
+      analysis?.planner?.selectedStrategy ?? (analysis ? classifyStrategy(analysis.classification) : null),
+    selected_classification: analysis?.planner?.selectedClassification ?? analysis?.classification ?? null,
+    selected_score: analysis?.planner?.selectedScore ?? analysis?.upstreamabilityScore ?? null,
+    fallback_classification: analysis?.planner?.fallbackClassification ?? analysis?.classification ?? null,
+    fallback_confidence: analysis?.planner?.fallbackConfidence ?? analysis?.confidence ?? null,
+    fallback_reasons: JSON.stringify(analysis?.planner?.fallbackReasons ?? analysis?.reasons ?? []),
+  };
+}
+
+async function persistCandidateArtifacts(args: {
+  candidates: PersistedCandidate[];
+  analysis: SemanticAnalysisResult;
+  cycleId: number;
+  cycle: ScannedCycle;
+  cycleLogger: StructuredLogger;
+  repoPath: string;
+  repository: RepositoryDTO;
+  scanId: number;
+  sourceTarget: string;
+  commitSha: string;
+  remoteUrl: string | null;
+  validationLimiter?: ConcurrencyLimiter;
+}): Promise<Map<string, CandidateOutcome>> {
+  const {
+    candidates,
+    analysis,
+    cycleId,
+    cycle,
+    cycleLogger,
+    repoPath,
+    repository,
+    scanId,
+    sourceTarget,
+    commitSha,
+    remoteUrl,
+    validationLimiter,
+  } = args;
+  const candidateOutcomes = new Map<string, CandidateOutcome>();
 
   for (const candidate of candidates) {
     const fixCandidateInfo = addFixCandidate.run({
@@ -156,96 +357,215 @@ export async function persistCycle(
       upstreamabilityScore: candidate.upstreamabilityScore ?? null,
     });
 
-    const candidateAnalysis = buildCandidateAnalysis(persistedCycle.analysis, candidate);
-
-    if (!shouldGeneratePatch(candidateAnalysis)) {
-      candidateLogger.info('patch.skipped', {
-        reason: 'Candidate did not clear the promotion policy thresholds.',
-        confidence: candidate.confidence,
-        upstreamabilityScore: candidate.upstreamabilityScore ?? null,
-      });
-      continue;
-    }
-
-    candidateLogger.info('patch.generation.started', {
+    const candidateOutcome = await persistCandidatePatch({
+      analysis,
+      candidate,
+      fixCandidateId,
+      cycle,
+      candidateLogger,
       repoPath,
-    });
-
-    let generatedPatch: GeneratedPatch | null;
-    try {
-      generatedPatch = await generatePatchForCycle(repoPath, persistedCycle, candidateAnalysis);
-    } catch (error) {
-      candidateLogger.error('patch.generation.failed', {
-        ...serializeError(error),
-      });
-      throw error;
-    }
-
-    if (!generatedPatch) {
-      candidateLogger.warn('patch.generation.skipped', {
-        reason: 'No executable patch could be generated for the selected candidate plan.',
-      });
-      continue;
-    }
-
-    candidateLogger.info('patch.generated', {
-      touchedFiles: generatedPatch.touchedFiles.length,
-    });
-
-    candidateLogger.info('validation.started', {
-      queued: Boolean(options.validationLimiter),
-    });
-    const validationLogger = candidateLogger.child({
-      touchedFiles: generatedPatch.touchedFiles.length,
-    });
-    const validation = options.validationLimiter
-      ? await options.validationLimiter.run(async () =>
-          validateGeneratedPatch(repoPath, persistedCycle, generatedPatch, {
-            logger: validationLogger,
-          }),
-        )
-      : await validateGeneratedPatch(repoPath, persistedCycle, generatedPatch, {
-          logger: validationLogger,
-        });
-    candidateLogger.info('validation.completed', {
-      status: validation.status,
-      failureCategory: validation.failureCategory ?? null,
-    });
-
-    const patchPayload = {
-      fix_candidate_id: fixCandidateId,
-      patch_text: generatedPatch.patchText,
-      touched_files: JSON.stringify(generatedPatch.touchedFiles),
-      validation_status: validation.status,
-      validation_summary: validation.summary,
-    };
-    const replayBundle = buildPatchReplayBundle({
+      repository,
       scanId,
       sourceTarget,
       commitSha,
       remoteUrl,
-      repository,
-      cycle: persistedCycle,
-      candidate: candidateAnalysis,
-      generatedPatch,
-      validation,
+      validationLimiter,
     });
-
-    getDb().transaction((patchRow: typeof patchPayload, replayBundleJson: string) => {
-      const patchInfo = addPatch.run(patchRow);
-      candidateLogger.info('patch.persisted', {
-        patchId: patchInfo.lastInsertRowid as number,
-        validationStatus: validation.status,
-      });
-      addPatchReplay.run({
-        patch_id: patchInfo.lastInsertRowid as number,
-        scan_id: scanId,
-        source_target: sourceTarget,
-        commit_sha: commitSha,
-        replay_bundle: replayBundleJson,
-      });
-    })(patchPayload, JSON.stringify(replayBundle));
+    candidateOutcomes.set(createCandidateKey(candidate.strategy, candidate.plannerRank), candidateOutcome);
   }
+
+  return candidateOutcomes;
+}
+
+async function persistCandidatePatch(args: {
+  analysis: SemanticAnalysisResult;
+  candidate: PersistedCandidate;
+  fixCandidateId: number;
+  cycle: ScannedCycle;
+  candidateLogger: StructuredLogger;
+  repoPath: string;
+  repository: RepositoryDTO;
+  scanId: number;
+  sourceTarget: string;
+  commitSha: string;
+  remoteUrl: string | null;
+  validationLimiter?: ConcurrencyLimiter;
+}): Promise<CandidateOutcome> {
+  const {
+    analysis,
+    candidate,
+    fixCandidateId,
+    cycle,
+    candidateLogger,
+    repoPath,
+    repository,
+    scanId,
+    sourceTarget,
+    commitSha,
+    remoteUrl,
+    validationLimiter,
+  } = args;
+  const candidateAnalysis = buildCandidateAnalysis(analysis, candidate);
+  const promotionEligible = shouldGeneratePatch(candidateAnalysis);
+  const candidateOutcome: CandidateOutcome = {
+    fixCandidateId,
+    patchId: null,
+    validationStatus: null,
+    validationSummary: null,
+    validationFailureCategory: null,
+    promotionEligible,
+  };
+
+  if (!promotionEligible) {
+    candidateLogger.info('patch.skipped', {
+      reason: 'Candidate did not clear the promotion policy thresholds.',
+      confidence: candidate.confidence,
+      upstreamabilityScore: candidate.upstreamabilityScore ?? null,
+    });
+    return candidateOutcome;
+  }
+
+  candidateLogger.info('patch.generation.started', {
+    repoPath,
+  });
+
+  let generatedPatch: GeneratedPatch | null;
+  try {
+    generatedPatch = await generatePatchForCycle(repoPath, cycle, candidateAnalysis);
+  } catch (error) {
+    candidateLogger.error('patch.generation.failed', {
+      ...serializeError(error),
+    });
+    throw error;
+  }
+
+  if (!generatedPatch) {
+    candidateLogger.warn('patch.generation.skipped', {
+      reason: 'No executable patch could be generated for the selected candidate plan.',
+    });
+    return candidateOutcome;
+  }
+
+  candidateLogger.info('patch.generated', {
+    touchedFiles: generatedPatch.touchedFiles.length,
+  });
+
+  const validation = await validateCandidatePatch({
+    candidateLogger,
+    cycle,
+    generatedPatch,
+    repoPath,
+    validationLimiter,
+  });
+
+  const replayBundle = buildPatchReplayBundle({
+    scanId,
+    sourceTarget,
+    commitSha,
+    remoteUrl,
+    repository,
+    cycle,
+    candidate: candidateAnalysis,
+    generatedPatch,
+    validation,
+  });
+
+  persistPatchArtifacts({
+    candidateOutcome,
+    candidateLogger,
+    commitSha,
+    fixCandidateId,
+    replayBundle,
+    scanId,
+    sourceTarget,
+    validation,
+    generatedPatch,
+  });
+
+  return candidateOutcome;
+}
+
+async function validateCandidatePatch(args: {
+  candidateLogger: StructuredLogger;
+  cycle: ScannedCycle;
+  generatedPatch: GeneratedPatch;
+  repoPath: string;
+  validationLimiter?: ConcurrencyLimiter;
+}): Promise<ValidationResult> {
+  const { candidateLogger, cycle, generatedPatch, repoPath, validationLimiter } = args;
+
+  candidateLogger.info('validation.started', {
+    queued: Boolean(validationLimiter),
+  });
+  const validationLogger = candidateLogger.child({
+    touchedFiles: generatedPatch.touchedFiles.length,
+  });
+  const validation = validationLimiter
+    ? await validationLimiter.run(async () =>
+        validateGeneratedPatch(repoPath, cycle, generatedPatch, {
+          logger: validationLogger,
+        }),
+      )
+    : await validateGeneratedPatch(repoPath, cycle, generatedPatch, {
+        logger: validationLogger,
+      });
+  candidateLogger.info('validation.completed', {
+    status: validation.status,
+    failureCategory: validation.failureCategory ?? null,
+  });
+
+  return validation;
+}
+
+function persistPatchArtifacts(args: {
+  candidateOutcome: CandidateOutcome;
+  candidateLogger: StructuredLogger;
+  commitSha: string;
+  fixCandidateId: number;
+  replayBundle: PatchReplayBundle;
+  scanId: number;
+  sourceTarget: string;
+  validation: ValidationResult;
+  generatedPatch: GeneratedPatch;
+}): void {
+  const {
+    candidateOutcome,
+    candidateLogger,
+    commitSha,
+    fixCandidateId,
+    replayBundle,
+    scanId,
+    sourceTarget,
+    validation,
+    generatedPatch,
+  } = args;
+
+  const patchPayload = {
+    fix_candidate_id: fixCandidateId,
+    patch_text: generatedPatch.patchText,
+    touched_files: JSON.stringify(generatedPatch.touchedFiles),
+    validation_status: validation.status,
+    validation_summary: validation.summary,
+  };
+
+  getDb().transaction((patchRow: typeof patchPayload, replayBundleJson: string) => {
+    const patchInfo = addPatch.run(patchRow);
+    candidateOutcome.patchId = patchInfo.lastInsertRowid as number;
+    candidateOutcome.validationStatus = validation.status;
+    candidateOutcome.validationSummary = validation.summary;
+    candidateOutcome.validationFailureCategory = validation.failureCategory ?? null;
+    candidateLogger.info('patch.persisted', {
+      patchId: candidateOutcome.patchId,
+      validationStatus: validation.status,
+    });
+    addPatchReplay.run({
+      patch_id: candidateOutcome.patchId,
+      scan_id: scanId,
+      source_target: sourceTarget,
+      commit_sha: commitSha,
+      replay_bundle: replayBundleJson,
+    });
+  })(patchPayload, JSON.stringify(replayBundle));
 }
 
 function shouldGeneratePatch(analysis: SemanticAnalysisResult): boolean {
@@ -310,6 +630,94 @@ function buildCandidateAnalysis(
     upstreamabilityScore: candidate.upstreamabilityScore ?? undefined,
     planner: analysis.planner,
   };
+}
+
+function buildObservationAttempts(
+  analysis: SemanticAnalysisResult,
+  candidateOutcomes: Map<string, CandidateOutcome>,
+): ObservationAttempt[] {
+  const planner = analysis.planner;
+  if (planner) {
+    const sourceAttempts = planner.attempts.length > 0 ? planner.attempts : planner.rankedCandidates;
+    const rankedStrategyMap = new Map(planner.rankedCandidates.map((attempt, index) => [attempt.strategy, index + 1]));
+
+    return sourceAttempts.map((attempt) => {
+      const plannerRank = attempt.status === 'candidate' ? (rankedStrategyMap.get(attempt.strategy) ?? 0) : 0;
+      const candidateKey = createCandidateKey(attempt.strategy, plannerRank);
+      const outcome = candidateOutcomes.get(candidateKey);
+
+      return {
+        strategy: attempt.strategy,
+        status: attempt.status,
+        plannerRank,
+        promotionEligible: outcome?.promotionEligible ?? false,
+        summary: attempt.summary,
+        classification: attempt.classification ?? null,
+        confidence: attempt.confidence ?? null,
+        upstreamabilityScore: attempt.score ?? null,
+        reasons: attempt.reasons,
+        scoreBreakdown: attempt.scoreBreakdown ?? null,
+        signals: attempt.signals,
+        plan: attempt.plan,
+        fixCandidateId: outcome?.fixCandidateId ?? null,
+        patchId: outcome?.patchId ?? null,
+        validationStatus: outcome?.validationStatus ?? null,
+        validationSummary: outcome?.validationSummary ?? null,
+        validationFailureCategory: outcome?.validationFailureCategory ?? null,
+      };
+    });
+  }
+
+  const fallbackKey = createCandidateKey(classifyStrategy(analysis.classification), 1);
+  const fallbackOutcome = candidateOutcomes.get(fallbackKey);
+  return [
+    {
+      strategy: classifyStrategy(analysis.classification),
+      status: analysis.classification.startsWith('autofix_') ? 'candidate' : 'rejected',
+      plannerRank: 1,
+      promotionEligible: fallbackOutcome?.promotionEligible ?? false,
+      summary: analysis.reasons[0] ?? 'Fallback semantic analysis result.',
+      classification: analysis.classification,
+      confidence: analysis.confidence,
+      upstreamabilityScore: analysis.upstreamabilityScore ?? null,
+      reasons: analysis.reasons,
+      scoreBreakdown: null,
+      signals: null,
+      plan: analysis.plan,
+      fixCandidateId: fallbackOutcome?.fixCandidateId ?? null,
+      patchId: fallbackOutcome?.patchId ?? null,
+      validationStatus: fallbackOutcome?.validationStatus ?? null,
+      validationSummary: fallbackOutcome?.validationSummary ?? null,
+      validationFailureCategory: fallbackOutcome?.validationFailureCategory ?? null,
+    },
+  ];
+}
+
+function buildObservationRepoProfile(analysis?: SemanticAnalysisResult): string | null {
+  const features = analysis?.planner?.features;
+  if (!features) {
+    return null;
+  }
+
+  return JSON.stringify({
+    packageManager: features.packageManager,
+    workspaceMode: features.workspaceMode,
+    validationCommandCount: features.validationCommandCount,
+  });
+}
+
+export function getNextCycleObservationVersion(cycleId: number): number {
+  const latestObservation = getLatestCycleObservationByCycleId.get(cycleId) as
+    | {
+        observation_version: number;
+      }
+    | undefined;
+
+  return (latestObservation?.observation_version ?? 0) + 1;
+}
+
+function createCandidateKey(strategy: string | null, plannerRank: number): string {
+  return `${strategy ?? 'fallback'}::${plannerRank}`;
 }
 
 function classifyStrategy(classification: SemanticAnalysisResult['classification']): string | null {

--- a/db/index.test.ts
+++ b/db/index.test.ts
@@ -3,11 +3,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   type AcceptanceBenchmarkCaseDTO,
   type BenchmarkCaseDTO,
+  type CandidateObservationDTO,
   type CycleDTO,
+  type CycleObservationDTO,
   createDatabase,
   createStatements,
   addBenchmarkCase as defaultAddBenchmarkCase,
+  addCandidateObservation as defaultAddCandidateObservation,
   addCycle as defaultAddCycle,
+  addCycleObservation as defaultAddCycleObservation,
   addFixCandidate as defaultAddFixCandidate,
   addPatch as defaultAddPatch,
   addPatchReplay as defaultAddPatchReplay,
@@ -20,8 +24,11 @@ import {
   getAllRepositories as defaultGetAllRepositories,
   getBenchmarkCases as defaultGetBenchmarkCases,
   getBenchmarkCasesByRepository as defaultGetBenchmarkCasesByRepository,
+  getCandidateObservationsByCycleObservationId as defaultGetCandidateObservationsByCycleObservationId,
+  getCycleObservationsByScanId as defaultGetCycleObservationsByScanId,
   getCyclesByScanId as defaultGetCyclesByScanId,
   getFixCandidatesByCycleId as defaultGetFixCandidatesByCycleId,
+  getLatestCycleObservationByCycleId as defaultGetLatestCycleObservationByCycleId,
   getPatch as defaultGetPatch,
   getPatchesByFixCandidateId as defaultGetPatchesByFixCandidateId,
   getPatchReplayByPatchId as defaultGetPatchReplayByPatchId,
@@ -81,8 +88,10 @@ describe('db module', () => {
       expect(tableNames).toContain('repositories');
       expect(tableNames).toContain('scans');
       expect(tableNames).toContain('cycles');
+      expect(tableNames).toContain('cycle_observations');
       expect(tableNames).toContain('fix_candidates');
       expect(tableNames).toContain('patches');
+      expect(tableNames).toContain('candidate_observations');
       expect(tableNames).toContain('patch_replays');
       expect(tableNames).toContain('benchmark_cases');
       expect(tableNames).toContain('review_decisions');
@@ -99,12 +108,19 @@ describe('db module', () => {
       expect(indexNames).toContain('idx_repositories_status');
       expect(indexNames).toContain('idx_scans_repository_id_commit_sha');
       expect(indexNames).toContain('idx_cycles_scan_id');
+      expect(indexNames).toContain('idx_cycle_observations_cycle_id');
+      expect(indexNames).toContain('idx_cycle_observations_repository_id');
+      expect(indexNames).toContain('idx_cycle_observations_selected_classification');
       expect(indexNames).toContain('idx_fix_candidates_cycle_id');
       expect(indexNames).toContain('idx_fix_candidates_classification');
       expect(indexNames).toContain('idx_fix_candidates_confidence');
       expect(indexNames).toContain('idx_patches_fix_candidate_id');
       expect(indexNames).toContain('idx_patch_replays_patch_id');
       expect(indexNames).toContain('idx_patch_replays_scan_id');
+      expect(indexNames).toContain('idx_candidate_observations_cycle_observation_id');
+      expect(indexNames).toContain('idx_candidate_observations_strategy');
+      expect(indexNames).toContain('idx_candidate_observations_status');
+      expect(indexNames).toContain('idx_candidate_observations_validation_failure_category');
       expect(indexNames).toContain('idx_benchmark_cases_repository');
       expect(indexNames).toContain('idx_benchmark_cases_commit_sha');
       expect(indexNames).toContain('idx_benchmark_cases_source');
@@ -760,6 +776,152 @@ describe('db module', () => {
     });
   });
 
+  describe('observations', () => {
+    it('adds and retrieves cycle observations', () => {
+      const repoInfo = stmts.addRepository.run({
+        owner: 'obs-test',
+        name: 'repo',
+        default_branch: null,
+        local_path: TEST_LOCAL_REPO_PATH,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'obs123',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        participating_files: '["a.ts","b.ts","a.ts"]',
+        raw_payload: null,
+      });
+
+      const insert = stmts.addCycleObservation.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        scan_id: scanInfo.lastInsertRowid,
+        repository_id: repoInfo.lastInsertRowid,
+        observation_version: 1,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        cycle_shape: 'two_file',
+        cycle_size: 2,
+        cycle_signals: '{"explicitImportEdges":2}',
+        feature_vector: '{"cycleSize":2,"packageManager":"pnpm"}',
+        graph_summary: '{"metrics":{"symbolSccCount":1,"movableSymbolCount":2}}',
+        repo_profile: '{"packageManager":"pnpm","workspaceMode":"workspace","validationCommandCount":2}',
+        planner_summary: 'Selected import_type after ranking two candidates.',
+        planner_attempts: '[{"strategy":"import_type","status":"candidate"}]',
+        selected_strategy: 'import_type',
+        selected_classification: 'autofix_import_type',
+        selected_score: 0.94,
+        fallback_classification: 'autofix_import_type',
+        fallback_confidence: 0.9,
+        fallback_reasons: '["Cycle can be resolved with import type"]',
+      });
+
+      const latest = stmts.getLatestCycleObservationByCycleId.get(cycleInfo.lastInsertRowid) as CycleObservationDTO;
+      const scanRows = stmts.getCycleObservationsByScanId.all(scanInfo.lastInsertRowid) as CycleObservationDTO[];
+      expect(insert.lastInsertRowid).toBeDefined();
+      expect(latest.selected_strategy).toBe('import_type');
+      expect(latest.graph_summary).toContain('"symbolSccCount":1');
+      expect(latest.repo_profile).toContain('"packageManager":"pnpm"');
+      expect(scanRows).toHaveLength(1);
+    });
+
+    it('adds and retrieves candidate observations', () => {
+      const repoInfo = stmts.addRepository.run({
+        owner: 'obs-test',
+        name: 'repo',
+        default_branch: null,
+        local_path: TEST_LOCAL_REPO_PATH,
+      });
+      const scanInfo = stmts.addScan.run({
+        repository_id: repoInfo.lastInsertRowid,
+        commit_sha: 'obs123',
+        status: 'completed',
+      });
+      const cycleInfo = stmts.addCycle.run({
+        scan_id: scanInfo.lastInsertRowid,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        participating_files: '["a.ts","b.ts","a.ts"]',
+        raw_payload: null,
+      });
+      const cycleObservationInfo = stmts.addCycleObservation.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        scan_id: scanInfo.lastInsertRowid,
+        repository_id: repoInfo.lastInsertRowid,
+        observation_version: 1,
+        normalized_path: 'a.ts -> b.ts -> a.ts',
+        cycle_shape: 'two_file',
+        cycle_size: 2,
+        cycle_signals: '{"explicitImportEdges":2}',
+        feature_vector: '{"cycleSize":2}',
+        repo_profile: '{"packageManager":"pnpm"}',
+        planner_summary: 'Selected import_type',
+        planner_attempts: '[]',
+        selected_strategy: 'import_type',
+        selected_classification: 'autofix_import_type',
+        selected_score: 0.94,
+        fallback_classification: 'autofix_import_type',
+        fallback_confidence: 0.9,
+        fallback_reasons: '[]',
+      });
+      const fixCandidateInfo = stmts.addFixCandidate.run({
+        cycle_id: cycleInfo.lastInsertRowid,
+        strategy: 'import_type',
+        planner_rank: 1,
+        classification: 'autofix_import_type',
+        confidence: 0.9,
+        upstreamability_score: 0.94,
+        reasons: '["Cycle can be resolved with import type"]',
+        summary: 'Convert import to type-only',
+        score_breakdown: '["base 0.97"]',
+        signals: '{"touchedFiles":1}',
+      });
+      const patchInfo = stmts.addPatch.run({
+        fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+        patch_text: 'diff content',
+        touched_files: '["a.ts"]',
+        validation_status: 'failed',
+        validation_summary: 'Typecheck failed',
+      });
+
+      stmts.addCandidateObservation.run({
+        cycle_observation_id: cycleObservationInfo.lastInsertRowid,
+        observation_version: 1,
+        fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+        patch_id: patchInfo.lastInsertRowid,
+        strategy: 'import_type',
+        status: 'candidate',
+        planner_rank: 1,
+        promotion_eligible: 1,
+        summary: 'Convert import to type-only',
+        classification: 'autofix_import_type',
+        confidence: 0.9,
+        upstreamability_score: 0.94,
+        reasons: '["Cycle can be resolved with import type"]',
+        score_breakdown: '["base 0.97"]',
+        signals: '{"touchedFiles":1}',
+        plan: '{"kind":"import_type"}',
+        validation_status: 'failed',
+        validation_summary: 'Typecheck failed',
+        validation_failure_category: 'typecheck_failed',
+      });
+
+      const rows = stmts.getCandidateObservationsByCycleObservationId.all(
+        cycleObservationInfo.lastInsertRowid,
+      ) as CandidateObservationDTO[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        strategy: 'import_type',
+        status: 'candidate',
+        planner_rank: 1,
+        promotion_eligible: 1,
+        validation_status: 'failed',
+        validation_failure_category: 'typecheck_failed',
+      });
+    });
+  });
+
   describe('acceptance_benchmark_cases', () => {
     it('upserts and retrieves acceptance benchmark cases', () => {
       const insert = stmts.upsertAcceptanceBenchmarkCase.run({
@@ -1015,11 +1177,16 @@ describe('default production exports', () => {
     expect(defaultUpdateScanStatus).toBeDefined();
     expect(defaultAddCycle).toBeDefined();
     expect(defaultGetCyclesByScanId).toBeDefined();
+    expect(defaultAddCycleObservation).toBeDefined();
+    expect(defaultGetCycleObservationsByScanId).toBeDefined();
+    expect(defaultGetLatestCycleObservationByCycleId).toBeDefined();
     expect(defaultAddFixCandidate).toBeDefined();
     expect(defaultGetFixCandidatesByCycleId).toBeDefined();
     expect(defaultAddPatch).toBeDefined();
     expect(defaultGetPatch).toBeDefined();
     expect(defaultGetPatchesByFixCandidateId).toBeDefined();
+    expect(defaultAddCandidateObservation).toBeDefined();
+    expect(defaultGetCandidateObservationsByCycleObservationId).toBeDefined();
     expect(defaultAddPatchReplay).toBeDefined();
     expect(defaultGetPatchReplayByPatchId).toBeDefined();
     expect(defaultAddBenchmarkCase).toBeDefined();

--- a/db/index.ts
+++ b/db/index.ts
@@ -123,6 +123,56 @@ export interface AcceptanceBenchmarkCaseDTO {
   updated_at: string;
 }
 
+export interface CycleObservationDTO {
+  id: number;
+  cycle_id: number;
+  scan_id: number;
+  repository_id: number;
+  observation_version: number;
+  normalized_path: string;
+  cycle_shape: string | null;
+  cycle_size: number;
+  cycle_signals: string | null;
+  feature_vector: string | null;
+  graph_summary: string | null;
+  repo_profile: string | null;
+  planner_summary: string | null;
+  planner_attempts: string;
+  selected_strategy: string | null;
+  selected_classification: string | null;
+  selected_score: number | null;
+  fallback_classification: string | null;
+  fallback_confidence: number | null;
+  fallback_reasons: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CandidateObservationDTO {
+  id: number;
+  cycle_observation_id: number;
+  observation_version: number;
+  fix_candidate_id: number | null;
+  patch_id: number | null;
+  strategy: string | null;
+  status: string;
+  planner_rank: number;
+  promotion_eligible: number;
+  summary: string | null;
+  classification: string | null;
+  confidence: number | null;
+  upstreamability_score: number | null;
+  reasons: string | null;
+  score_breakdown: string | null;
+  signals: string | null;
+  plan: string | null;
+  validation_status: string | null;
+  validation_summary: string | null;
+  validation_failure_category: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export type RepositoryStatus =
   | 'queued'
   | 'downloading'
@@ -187,6 +237,35 @@ const SCHEMA_SQL = `
     UNIQUE(scan_id, normalized_path)
   );
 
+  CREATE TABLE IF NOT EXISTS cycle_observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_id INTEGER NOT NULL,
+    scan_id INTEGER NOT NULL,
+    repository_id INTEGER NOT NULL,
+    observation_version INTEGER NOT NULL DEFAULT 1,
+    normalized_path TEXT NOT NULL,
+    cycle_shape TEXT,
+    cycle_size INTEGER NOT NULL DEFAULT 0,
+    cycle_signals TEXT, -- JSON string
+    feature_vector TEXT, -- JSON string
+    graph_summary TEXT, -- JSON string
+    repo_profile TEXT, -- JSON string
+    planner_summary TEXT,
+    planner_attempts TEXT NOT NULL, -- JSON string
+    selected_strategy TEXT,
+    selected_classification TEXT,
+    selected_score REAL,
+    fallback_classification TEXT,
+    fallback_confidence REAL,
+    fallback_reasons TEXT, -- JSON string
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (cycle_id) REFERENCES cycles(id),
+    FOREIGN KEY (scan_id) REFERENCES scans(id),
+    FOREIGN KEY (repository_id) REFERENCES repositories(id),
+    UNIQUE(cycle_id, observation_version)
+  );
+
   CREATE TABLE IF NOT EXISTS fix_candidates (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     cycle_id INTEGER NOT NULL,
@@ -224,6 +303,34 @@ const SCHEMA_SQL = `
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (patch_id) REFERENCES patches(id),
     FOREIGN KEY (scan_id) REFERENCES scans(id)
+  );
+
+  CREATE TABLE IF NOT EXISTS candidate_observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_observation_id INTEGER NOT NULL,
+    observation_version INTEGER NOT NULL DEFAULT 1,
+    fix_candidate_id INTEGER,
+    patch_id INTEGER,
+    strategy TEXT,
+    status TEXT NOT NULL,
+    planner_rank INTEGER NOT NULL DEFAULT 0,
+    promotion_eligible INTEGER NOT NULL DEFAULT 0,
+    summary TEXT,
+    classification TEXT,
+    confidence REAL,
+    upstreamability_score REAL,
+    reasons TEXT, -- JSON string
+    score_breakdown TEXT, -- JSON string
+    signals TEXT, -- JSON string
+    plan TEXT, -- JSON string
+    validation_status TEXT,
+    validation_summary TEXT,
+    validation_failure_category TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (cycle_observation_id) REFERENCES cycle_observations(id),
+    FOREIGN KEY (fix_candidate_id) REFERENCES fix_candidates(id),
+    FOREIGN KEY (patch_id) REFERENCES patches(id)
   );
 
   CREATE TABLE IF NOT EXISTS benchmark_cases (
@@ -288,12 +395,19 @@ const SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_repositories_status ON repositories(status);
   CREATE INDEX IF NOT EXISTS idx_scans_repository_id_commit_sha ON scans(repository_id, commit_sha);
   CREATE INDEX IF NOT EXISTS idx_cycles_scan_id ON cycles(scan_id);
+  CREATE INDEX IF NOT EXISTS idx_cycle_observations_cycle_id ON cycle_observations(cycle_id);
+  CREATE INDEX IF NOT EXISTS idx_cycle_observations_repository_id ON cycle_observations(repository_id);
+  CREATE INDEX IF NOT EXISTS idx_cycle_observations_selected_classification ON cycle_observations(selected_classification);
   CREATE INDEX IF NOT EXISTS idx_fix_candidates_cycle_id ON fix_candidates(cycle_id);
   CREATE INDEX IF NOT EXISTS idx_fix_candidates_classification ON fix_candidates(classification);
   CREATE INDEX IF NOT EXISTS idx_fix_candidates_confidence ON fix_candidates(confidence);
   CREATE INDEX IF NOT EXISTS idx_patches_fix_candidate_id ON patches(fix_candidate_id);
   CREATE INDEX IF NOT EXISTS idx_patch_replays_patch_id ON patch_replays(patch_id);
   CREATE INDEX IF NOT EXISTS idx_patch_replays_scan_id ON patch_replays(scan_id);
+  CREATE INDEX IF NOT EXISTS idx_candidate_observations_cycle_observation_id ON candidate_observations(cycle_observation_id);
+  CREATE INDEX IF NOT EXISTS idx_candidate_observations_strategy ON candidate_observations(strategy);
+  CREATE INDEX IF NOT EXISTS idx_candidate_observations_status ON candidate_observations(status);
+  CREATE INDEX IF NOT EXISTS idx_candidate_observations_validation_failure_category ON candidate_observations(validation_failure_category);
   CREATE INDEX IF NOT EXISTS idx_benchmark_cases_repository ON benchmark_cases(repository);
   CREATE INDEX IF NOT EXISTS idx_benchmark_cases_commit_sha ON benchmark_cases(commit_sha);
   CREATE INDEX IF NOT EXISTS idx_benchmark_cases_source ON benchmark_cases(source);
@@ -321,6 +435,7 @@ export function createDatabase(dbPath?: string): DatabaseType {
 export function initSchema(database: DatabaseType): void {
   database.exec(SCHEMA_SQL);
   ensureFixCandidateSchema(database);
+  ensureObservationSchema(database);
 }
 
 interface TableColumnInfo {
@@ -371,6 +486,16 @@ function ensureFixCandidateSchema(database: DatabaseType): void {
   `);
 }
 
+function ensureObservationSchema(database: DatabaseType): void {
+  const cycleObservationColumns = new Set(
+    (database.prepare('PRAGMA table_info(cycle_observations)').all() as TableColumnInfo[]).map((column) => column.name),
+  );
+
+  if (!cycleObservationColumns.has('graph_summary')) {
+    database.exec('ALTER TABLE cycle_observations ADD COLUMN graph_summary TEXT');
+  }
+}
+
 /**
  * Create all prepared statements for a given database instance.
  */
@@ -401,6 +526,50 @@ export function createStatements(database: DatabaseType) {
       @signals
     )
   `);
+  const addCycleObservationStatement = database.prepare(`
+      INSERT INTO cycle_observations (
+        cycle_id,
+        scan_id,
+        repository_id,
+        observation_version,
+        normalized_path,
+        cycle_shape,
+        cycle_size,
+        cycle_signals,
+        feature_vector,
+        graph_summary,
+        repo_profile,
+        planner_summary,
+        planner_attempts,
+        selected_strategy,
+        selected_classification,
+        selected_score,
+        fallback_classification,
+        fallback_confidence,
+        fallback_reasons
+      )
+      VALUES (
+        @cycle_id,
+        @scan_id,
+        @repository_id,
+        @observation_version,
+        @normalized_path,
+        @cycle_shape,
+        @cycle_size,
+        @cycle_signals,
+        @feature_vector,
+        @graph_summary,
+        @repo_profile,
+        @planner_summary,
+        @planner_attempts,
+        @selected_strategy,
+        @selected_classification,
+        @selected_score,
+        @fallback_classification,
+        @fallback_confidence,
+        @fallback_reasons
+      )
+    `);
 
   return {
     // Repositories
@@ -450,6 +619,54 @@ export function createStatements(database: DatabaseType) {
     getCyclesByScanId: database.prepare(`
       SELECT * FROM cycles WHERE scan_id = ?
     `),
+    addCycleObservation: {
+      run: (params: {
+        cycle_id: number | bigint;
+        scan_id: number | bigint;
+        repository_id: number | bigint;
+        observation_version: number;
+        normalized_path: string;
+        cycle_shape?: string | null;
+        cycle_size?: number;
+        cycle_signals?: string | null;
+        feature_vector?: string | null;
+        graph_summary?: string | null;
+        repo_profile?: string | null;
+        planner_summary?: string | null;
+        planner_attempts: string;
+        selected_strategy?: string | null;
+        selected_classification?: string | null;
+        selected_score?: number | null;
+        fallback_classification?: string | null;
+        fallback_confidence?: number | null;
+        fallback_reasons?: string | null;
+      }) =>
+        addCycleObservationStatement.run({
+          cycle_shape: null,
+          cycle_size: 0,
+          cycle_signals: null,
+          feature_vector: null,
+          graph_summary: null,
+          repo_profile: null,
+          planner_summary: null,
+          selected_strategy: null,
+          selected_classification: null,
+          selected_score: null,
+          fallback_classification: null,
+          fallback_confidence: null,
+          fallback_reasons: null,
+          ...params,
+        }),
+    },
+    getCycleObservationsByScanId: database.prepare(`
+      SELECT * FROM cycle_observations WHERE scan_id = ? ORDER BY observation_version DESC, id DESC
+    `),
+    getLatestCycleObservationByCycleId: database.prepare(`
+      SELECT * FROM cycle_observations
+      WHERE cycle_id = ?
+      ORDER BY observation_version DESC, id DESC
+      LIMIT 1
+    `),
 
     // Fix Candidates
     addFixCandidate: {
@@ -490,6 +707,55 @@ export function createStatements(database: DatabaseType) {
     `),
     getPatchesByFixCandidateId: database.prepare(`
       SELECT * FROM patches WHERE fix_candidate_id = ?
+    `),
+    addCandidateObservation: database.prepare(`
+      INSERT INTO candidate_observations (
+        cycle_observation_id,
+        observation_version,
+        fix_candidate_id,
+        patch_id,
+        strategy,
+        status,
+        planner_rank,
+        promotion_eligible,
+        summary,
+        classification,
+        confidence,
+        upstreamability_score,
+        reasons,
+        score_breakdown,
+        signals,
+        plan,
+        validation_status,
+        validation_summary,
+        validation_failure_category
+      )
+      VALUES (
+        @cycle_observation_id,
+        @observation_version,
+        @fix_candidate_id,
+        @patch_id,
+        @strategy,
+        @status,
+        @planner_rank,
+        @promotion_eligible,
+        @summary,
+        @classification,
+        @confidence,
+        @upstreamability_score,
+        @reasons,
+        @score_breakdown,
+        @signals,
+        @plan,
+        @validation_status,
+        @validation_summary,
+        @validation_failure_category
+      )
+    `),
+    getCandidateObservationsByCycleObservationId: database.prepare(`
+      SELECT * FROM candidate_observations
+      WHERE cycle_observation_id = ?
+      ORDER BY planner_rank ASC, id ASC
     `),
 
     // Patch Replays
@@ -676,6 +942,18 @@ export const getCyclesByScanId = {
   all: (...args: Parameters<ReturnType<typeof createStatements>['getCyclesByScanId']['all']>) =>
     getStatements().getCyclesByScanId.all(...args),
 };
+export const addCycleObservation = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addCycleObservation']['run']>) =>
+    getStatements().addCycleObservation.run(...args),
+};
+export const getCycleObservationsByScanId = {
+  all: (...args: Parameters<ReturnType<typeof createStatements>['getCycleObservationsByScanId']['all']>) =>
+    getStatements().getCycleObservationsByScanId.all(...args),
+};
+export const getLatestCycleObservationByCycleId = {
+  get: (...args: Parameters<ReturnType<typeof createStatements>['getLatestCycleObservationByCycleId']['get']>) =>
+    getStatements().getLatestCycleObservationByCycleId.get(...args),
+};
 export const addFixCandidate = {
   run: (...args: Parameters<ReturnType<typeof createStatements>['addFixCandidate']['run']>) =>
     getStatements().addFixCandidate.run(...args),
@@ -695,6 +973,15 @@ export const getPatch = {
 export const getPatchesByFixCandidateId = {
   all: (...args: Parameters<ReturnType<typeof createStatements>['getPatchesByFixCandidateId']['all']>) =>
     getStatements().getPatchesByFixCandidateId.all(...args),
+};
+export const addCandidateObservation = {
+  run: (...args: Parameters<ReturnType<typeof createStatements>['addCandidateObservation']['run']>) =>
+    getStatements().addCandidateObservation.run(...args),
+};
+export const getCandidateObservationsByCycleObservationId = {
+  all: (
+    ...args: Parameters<ReturnType<typeof createStatements>['getCandidateObservationsByCycleObservationId']['all']>
+  ) => getStatements().getCandidateObservationsByCycleObservationId.all(...args),
 };
 export const addPatchReplay = {
   run: (...args: Parameters<ReturnType<typeof createStatements>['addPatchReplay']['run']>) =>

--- a/db/observationReports.ts
+++ b/db/observationReports.ts
@@ -1,0 +1,529 @@
+import type { Database as DatabaseType } from 'better-sqlite3';
+import { getDb } from './index.js';
+
+const DEFAULT_LIMIT = 15;
+
+interface CycleObservationRow {
+  id: number;
+  cycle_id: number;
+  normalized_path: string;
+  cycle_shape: string | null;
+  cycle_size: number;
+  feature_vector: string | null;
+  repo_profile: string | null;
+  selected_classification: string | null;
+  fallback_classification: string | null;
+  fallback_reasons: string | null;
+}
+
+interface CandidateObservationRow {
+  strategy: string | null;
+  status: string;
+  promotion_eligible: number;
+  confidence: number | null;
+  upstreamability_score: number | null;
+  validation_status: string | null;
+  validation_failure_category: string | null;
+  patch_id: number | null;
+  review_status: string | null;
+  cycle_shape: string | null;
+  cycle_size: number;
+  feature_vector: string | null;
+  repo_profile: string | null;
+}
+
+interface AcceptanceSummaryRow {
+  classification: string;
+  total_cases: number;
+  accepted_cases: number;
+  rejected_cases: number;
+  needs_review_cases: number;
+}
+
+interface RepoProfileShape {
+  packageManager?: string;
+  workspaceMode?: string;
+  validationCommandCount?: number;
+}
+
+interface FeatureVectorShape {
+  hasBarrelFile?: boolean;
+  hasSharedModuleFile?: boolean;
+  packageManager?: string;
+  workspaceMode?: string;
+}
+
+export interface PatternReport {
+  summary: {
+    cycleObservations: number;
+    candidateObservations: number;
+  };
+  cycleShapes: Array<{
+    cycleShape: string;
+    cycleSize: number;
+    hasBarrelFile: boolean;
+    hasSharedModuleFile: boolean;
+    packageManager: string;
+    workspaceMode: string;
+    count: number;
+  }>;
+  failureClusters: Array<{
+    strategy: string;
+    failureCategory: string;
+    cycleShape: string;
+    packageManager: string;
+    workspaceMode: string;
+    count: number;
+    averageConfidence: number | null;
+    averageUpstreamability: number | null;
+  }>;
+  unsupportedClusters: Array<{
+    classification: string;
+    cycleShape: string;
+    cycleSize: number;
+    hasBarrelFile: boolean;
+    packageManager: string;
+    workspaceMode: string;
+    count: number;
+    samplePaths: string[];
+    reasons: string[];
+  }>;
+}
+
+export interface StrategyPerformanceReport {
+  byRepositoryProfile: Array<{
+    strategy: string;
+    packageManager: string;
+    workspaceMode: string;
+    attempts: number;
+    promoted: number;
+    passedValidations: number;
+    failedValidations: number;
+    approvedReviews: number;
+    rejectedReviews: number;
+    prCandidates: number;
+    ignoredReviews: number;
+  }>;
+  acceptanceByStrategy: Array<{
+    strategy: string;
+    classification: string;
+    totalCases: number;
+    acceptedCases: number;
+    rejectedCases: number;
+    needsReviewCases: number;
+    acceptanceRate: number | null;
+  }>;
+}
+
+export function getPatternReport(database: DatabaseType = getDb()): PatternReport {
+  const cycleRows = database
+    .prepare(
+      `
+        WITH latest_cycle_observations AS (
+          SELECT co.*
+          FROM cycle_observations co
+          INNER JOIN (
+            SELECT cycle_id, MAX(observation_version) AS max_version
+            FROM cycle_observations
+            GROUP BY cycle_id
+          ) latest
+            ON latest.cycle_id = co.cycle_id
+           AND latest.max_version = co.observation_version
+        )
+        SELECT *
+        FROM latest_cycle_observations
+        ORDER BY id ASC
+      `,
+    )
+    .all() as CycleObservationRow[];
+
+  const candidateRows = database
+    .prepare(
+      `
+        WITH latest_cycle_observations AS (
+          SELECT co.*
+          FROM cycle_observations co
+          INNER JOIN (
+            SELECT cycle_id, MAX(observation_version) AS max_version
+            FROM cycle_observations
+            GROUP BY cycle_id
+          ) latest
+            ON latest.cycle_id = co.cycle_id
+           AND latest.max_version = co.observation_version
+        )
+        SELECT
+          cobs.strategy,
+          cobs.status,
+          cobs.promotion_eligible,
+          cobs.confidence,
+          cobs.upstreamability_score,
+          cobs.validation_status,
+          cobs.validation_failure_category,
+          cobs.patch_id,
+          rd.decision AS review_status,
+          co.cycle_shape,
+          co.cycle_size,
+          co.feature_vector,
+          co.repo_profile
+        FROM candidate_observations cobs
+        INNER JOIN latest_cycle_observations co ON co.id = cobs.cycle_observation_id
+        LEFT JOIN review_decisions rd ON rd.patch_id = cobs.patch_id
+        ORDER BY cobs.id ASC
+      `,
+    )
+    .all() as CandidateObservationRow[];
+
+  return {
+    summary: {
+      cycleObservations: cycleRows.length,
+      candidateObservations: candidateRows.length,
+    },
+    cycleShapes: buildCycleShapeSummary(cycleRows),
+    failureClusters: buildFailureClusters(candidateRows),
+    unsupportedClusters: buildUnsupportedClusters(cycleRows),
+  };
+}
+
+export function getStrategyPerformanceReport(database: DatabaseType = getDb()): StrategyPerformanceReport {
+  const candidateRows = database
+    .prepare(
+      `
+        WITH latest_cycle_observations AS (
+          SELECT co.*
+          FROM cycle_observations co
+          INNER JOIN (
+            SELECT cycle_id, MAX(observation_version) AS max_version
+            FROM cycle_observations
+            GROUP BY cycle_id
+          ) latest
+            ON latest.cycle_id = co.cycle_id
+           AND latest.max_version = co.observation_version
+        )
+        SELECT
+          cobs.strategy,
+          cobs.status,
+          cobs.promotion_eligible,
+          cobs.confidence,
+          cobs.upstreamability_score,
+          cobs.validation_status,
+          cobs.validation_failure_category,
+          cobs.patch_id,
+          rd.decision AS review_status,
+          co.cycle_shape,
+          co.cycle_size,
+          co.feature_vector,
+          co.repo_profile
+        FROM candidate_observations cobs
+        INNER JOIN latest_cycle_observations co ON co.id = cobs.cycle_observation_id
+        LEFT JOIN review_decisions rd ON rd.patch_id = cobs.patch_id
+        ORDER BY cobs.id ASC
+      `,
+    )
+    .all() as CandidateObservationRow[];
+
+  const acceptanceRows = database
+    .prepare(
+      `
+        SELECT
+          classification,
+          COUNT(*) AS total_cases,
+          SUM(CASE WHEN acceptability = 'accepted' THEN 1 ELSE 0 END) AS accepted_cases,
+          SUM(CASE WHEN acceptability = 'rejected' THEN 1 ELSE 0 END) AS rejected_cases,
+          SUM(CASE WHEN acceptability = 'needs_review' OR acceptability IS NULL THEN 1 ELSE 0 END) AS needs_review_cases
+        FROM acceptance_benchmark_cases
+        GROUP BY classification
+        ORDER BY classification ASC
+      `,
+    )
+    .all() as AcceptanceSummaryRow[];
+
+  return {
+    byRepositoryProfile: buildStrategyPerformance(candidateRows),
+    acceptanceByStrategy: acceptanceRows.map((row) => ({
+      strategy: classificationToStrategy(row.classification),
+      classification: row.classification,
+      totalCases: row.total_cases,
+      acceptedCases: row.accepted_cases,
+      rejectedCases: row.rejected_cases,
+      needsReviewCases: row.needs_review_cases,
+      acceptanceRate: row.total_cases > 0 ? Number((row.accepted_cases / row.total_cases).toFixed(2)) : null,
+    })),
+  };
+}
+
+export function getUnsupportedClustersReport(database: DatabaseType = getDb()) {
+  return getPatternReport(database).unsupportedClusters;
+}
+
+function buildCycleShapeSummary(rows: CycleObservationRow[]): PatternReport['cycleShapes'] {
+  const counts = new Map<string, PatternReport['cycleShapes'][number]>();
+
+  for (const row of rows) {
+    const featureVector = parseJson(row.feature_vector, {} as FeatureVectorShape);
+    const repoProfile = parseJson(row.repo_profile, {} as RepoProfileShape);
+    const bucket = {
+      cycleShape: row.cycle_shape ?? 'unknown',
+      cycleSize: row.cycle_size,
+      hasBarrelFile: featureVector.hasBarrelFile === true,
+      hasSharedModuleFile: featureVector.hasSharedModuleFile === true,
+      packageManager: repoProfile.packageManager ?? featureVector.packageManager ?? 'unknown',
+      workspaceMode: repoProfile.workspaceMode ?? featureVector.workspaceMode ?? 'unknown',
+      count: 0,
+    };
+    const key = JSON.stringify(bucket);
+    const current = counts.get(key) ?? bucket;
+    current.count += 1;
+    counts.set(key, current);
+  }
+
+  return sortDescendingByNumber([...counts.values()], (row) => row.count).slice(0, DEFAULT_LIMIT);
+}
+
+function buildFailureClusters(rows: CandidateObservationRow[]): PatternReport['failureClusters'] {
+  const counts = new Map<
+    string,
+    {
+      strategy: string;
+      failureCategory: string;
+      cycleShape: string;
+      packageManager: string;
+      workspaceMode: string;
+      count: number;
+      confidenceTotal: number;
+      confidenceCount: number;
+      upstreamabilityTotal: number;
+      upstreamabilityCount: number;
+    }
+  >();
+
+  for (const row of rows) {
+    if (!row.strategy || !row.validation_failure_category) {
+      continue;
+    }
+
+    const featureVector = parseJson(row.feature_vector, {} as FeatureVectorShape);
+    const repoProfile = parseJson(row.repo_profile, {} as RepoProfileShape);
+    const bucket = {
+      strategy: row.strategy,
+      failureCategory: row.validation_failure_category,
+      cycleShape: row.cycle_shape ?? 'unknown',
+      packageManager: repoProfile.packageManager ?? featureVector.packageManager ?? 'unknown',
+      workspaceMode: repoProfile.workspaceMode ?? featureVector.workspaceMode ?? 'unknown',
+      count: 0,
+      confidenceTotal: 0,
+      confidenceCount: 0,
+      upstreamabilityTotal: 0,
+      upstreamabilityCount: 0,
+    };
+    const key = JSON.stringify({
+      strategy: bucket.strategy,
+      failureCategory: bucket.failureCategory,
+      cycleShape: bucket.cycleShape,
+      packageManager: bucket.packageManager,
+      workspaceMode: bucket.workspaceMode,
+    });
+    const current = counts.get(key) ?? bucket;
+    current.count += 1;
+    if (row.confidence !== null) {
+      current.confidenceTotal += row.confidence;
+      current.confidenceCount += 1;
+    }
+    if (row.upstreamability_score !== null) {
+      current.upstreamabilityTotal += row.upstreamability_score;
+      current.upstreamabilityCount += 1;
+    }
+    counts.set(key, current);
+  }
+
+  return sortDescendingByNumber(
+    [...counts.values()].map((row) => ({
+      strategy: row.strategy,
+      failureCategory: row.failureCategory,
+      cycleShape: row.cycleShape,
+      packageManager: row.packageManager,
+      workspaceMode: row.workspaceMode,
+      count: row.count,
+      averageConfidence:
+        row.confidenceCount > 0 ? Number((row.confidenceTotal / row.confidenceCount).toFixed(2)) : null,
+      averageUpstreamability:
+        row.upstreamabilityCount > 0 ? Number((row.upstreamabilityTotal / row.upstreamabilityCount).toFixed(2)) : null,
+    })),
+    (row) => row.count,
+  ).slice(0, DEFAULT_LIMIT);
+}
+
+function buildUnsupportedClusters(rows: CycleObservationRow[]): PatternReport['unsupportedClusters'] {
+  const counts = new Map<
+    string,
+    {
+      classification: string;
+      cycleShape: string;
+      cycleSize: number;
+      hasBarrelFile: boolean;
+      packageManager: string;
+      workspaceMode: string;
+      count: number;
+      samplePaths: string[];
+      reasons: string[];
+    }
+  >();
+
+  for (const row of rows) {
+    const classification = row.selected_classification ?? row.fallback_classification ?? 'unknown';
+    if (classification !== 'unsupported' && classification !== 'suggest_manual') {
+      continue;
+    }
+
+    const featureVector = parseJson(row.feature_vector, {} as FeatureVectorShape);
+    const repoProfile = parseJson(row.repo_profile, {} as RepoProfileShape);
+    const bucket = {
+      classification,
+      cycleShape: row.cycle_shape ?? 'unknown',
+      cycleSize: row.cycle_size,
+      hasBarrelFile: featureVector.hasBarrelFile === true,
+      packageManager: repoProfile.packageManager ?? featureVector.packageManager ?? 'unknown',
+      workspaceMode: repoProfile.workspaceMode ?? featureVector.workspaceMode ?? 'unknown',
+      count: 0,
+      samplePaths: [] as string[],
+      reasons: [] as string[],
+    };
+    const key = JSON.stringify({
+      classification: bucket.classification,
+      cycleShape: bucket.cycleShape,
+      cycleSize: bucket.cycleSize,
+      hasBarrelFile: bucket.hasBarrelFile,
+      packageManager: bucket.packageManager,
+      workspaceMode: bucket.workspaceMode,
+    });
+    const current = counts.get(key) ?? bucket;
+    current.count += 1;
+    if (current.samplePaths.length < 3) {
+      current.samplePaths.push(row.normalized_path);
+    }
+    const parsedReasons = parseJson(row.fallback_reasons, [] as string[]).filter(Boolean);
+    for (const reason of parsedReasons) {
+      if (current.reasons.length >= 3 || current.reasons.includes(reason)) {
+        continue;
+      }
+      current.reasons.push(reason);
+    }
+    counts.set(key, current);
+  }
+
+  return sortDescendingByNumber([...counts.values()], (row) => row.count).slice(0, DEFAULT_LIMIT);
+}
+
+function buildStrategyPerformance(rows: CandidateObservationRow[]): StrategyPerformanceReport['byRepositoryProfile'] {
+  const counts = new Map<string, StrategyPerformanceReport['byRepositoryProfile'][number]>();
+
+  for (const row of rows) {
+    if (!row.strategy || row.status !== 'candidate') {
+      continue;
+    }
+
+    const featureVector = parseJson(row.feature_vector, {} as FeatureVectorShape);
+    const repoProfile = parseJson(row.repo_profile, {} as RepoProfileShape);
+    const bucket = {
+      strategy: row.strategy,
+      packageManager: repoProfile.packageManager ?? featureVector.packageManager ?? 'unknown',
+      workspaceMode: repoProfile.workspaceMode ?? featureVector.workspaceMode ?? 'unknown',
+      attempts: 0,
+      promoted: 0,
+      passedValidations: 0,
+      failedValidations: 0,
+      approvedReviews: 0,
+      rejectedReviews: 0,
+      prCandidates: 0,
+      ignoredReviews: 0,
+    };
+    const key = JSON.stringify({
+      strategy: bucket.strategy,
+      packageManager: bucket.packageManager,
+      workspaceMode: bucket.workspaceMode,
+    });
+    const current = counts.get(key) ?? bucket;
+    current.attempts += 1;
+    if (row.promotion_eligible === 1) {
+      current.promoted += 1;
+    }
+    if (row.validation_status === 'passed') {
+      current.passedValidations += 1;
+    }
+    if (row.validation_status === 'failed') {
+      current.failedValidations += 1;
+    }
+    switch (row.review_status) {
+      case 'approved': {
+        current.approvedReviews += 1;
+        break;
+      }
+      case 'rejected': {
+        current.rejectedReviews += 1;
+        break;
+      }
+      case 'pr_candidate': {
+        current.prCandidates += 1;
+        break;
+      }
+      case 'ignored': {
+        current.ignoredReviews += 1;
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+    counts.set(key, current);
+  }
+
+  return sortDescendingByNumber([...counts.values()], (row) => row.attempts).slice(0, DEFAULT_LIMIT);
+}
+
+function classificationToStrategy(classification: string): string {
+  switch (classification) {
+    case 'autofix_import_type': {
+      return 'import_type';
+    }
+    case 'autofix_direct_import': {
+      return 'direct_import';
+    }
+    case 'autofix_extract_shared': {
+      return 'extract_shared';
+    }
+    case 'autofix_host_state_update': {
+      return 'host_state_update';
+    }
+    default: {
+      return 'unknown';
+    }
+  }
+}
+
+function parseJson<T>(value: string | null, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function sortDescendingByNumber<T>(rows: T[], getValue: (row: T) => number): T[] {
+  const sorted: T[] = [];
+
+  for (const row of rows) {
+    const value = getValue(row);
+    const insertAt = sorted.findIndex((existingRow) => getValue(existingRow) < value);
+    if (insertAt === -1) {
+      sorted.push(row);
+      continue;
+    }
+
+    sorted.splice(insertAt, 0, row);
+  }
+
+  return sorted;
+}


### PR DESCRIPTION
## Summary
- add cycle/candidate observation capture, reporting, rescoring, and retry-backed replay commands
- persist planner graph summaries and introduce a reusable semantic graph core for import/export/symbol analysis
- update docs and tests so the repo now centers the data-first workflow: detect -> extract features -> rank -> generate candidates -> validate -> review -> learn

## Verification
- ../../node_modules/.bin/eslint .
- ../../node_modules/.bin/biome check .
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/vitest run --config vitest.config.ts
- ../../node_modules/.bin/vite build