### PR TITLE
Export training data for DuckDB and Parquet analytics

### DIFF
--- a/DEPS.md
+++ b/DEPS.md
@@ -58,6 +58,7 @@ mise install
 |---|---|
 | `simple-git` | Clone, fetch, branch, and patch export workflows |
 | `commander` | CLI surface for scan, retry, export, and future reporting commands |
+| `@duckdb/node-api` | Offline analytics engine for converting exported training data into DuckDB-queryable Parquet datasets |
 
 ### Data and API surface
 
@@ -107,6 +108,7 @@ Current stack support:
 - `better-sqlite3`
 - `fastify`
 - `commander`
+- `@duckdb/node-api` for offline analytical export, not runtime transactional state
 
 ### 2. Graph and search infrastructure
 
@@ -134,6 +136,7 @@ This means:
 - keep heuristic scoring as the baseline
 - store versioned features and outcomes
 - add offline dataset export first
+- analyze exported datasets with DuckDB + Parquet before introducing model tooling
 - only add model tooling when benchmark data is stable enough to justify it
 
 No ML framework is a required dependency yet by design.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The medium-term technical direction is explicit:
 - compute symbol-level SCCs, import/export edges, re-export resolution, and side-effect risk
 - search over candidate graph edits instead of only applying fixed heuristics
 - use weighted edge scoring, def-use slicing, and clustering to find the cheapest safe cycle-breaking rewrites
-- export model-ready datasets and add learned ranking later, only for ranking already-safe candidates
+- export model-ready datasets and analyze them with DuckDB + Parquet before adding learned ranking
 
 ML is not the correctness mechanism. Validation and structural safety checks remain the correctness boundary.
 
@@ -115,9 +115,10 @@ pnpm run scan <repo-url-or-path>
 pnpm run scan:all
 pnpm run retry:failed
 pnpm run export:patches
+pnpm run export:training-data -- --format parquet
 ```
 
-Planned additions include rescoring, reporting, and corpus-analysis commands that make the data loop directly inspectable.
+The runtime application still uses SQLite for scans, patches, and review state. Offline analytics should prefer DuckDB over exported Parquet datasets so ranking experiments and pattern mining stay fast without complicating the live app database.
 
 ## Engineering Principles
 

--- a/cli/exportTrainingData.test.ts
+++ b/cli/exportTrainingData.test.ts
@@ -1,0 +1,236 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDatabase, createStatements, initSchema } from '../db/index.js';
+import { exportTrainingData } from './exportTrainingData.js';
+
+const fixtureRoot = path.join(process.cwd(), '.test-fixtures', 'training-export');
+
+describe('exportTrainingData', () => {
+  let db: ReturnType<typeof createDatabase>;
+  let statements: ReturnType<typeof createStatements>;
+  let outputDir: string;
+
+  beforeEach(async () => {
+    db = createDatabase(':memory:');
+    initSchema(db);
+    statements = createStatements(db);
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'training-export-'));
+  });
+
+  afterEach(async () => {
+    db.close();
+    await fs.rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('exports JSONL training rows from observations and benchmark tables', async () => {
+    seedTrainingRows(statements);
+
+    const outputPath = path.join(outputDir, 'training-data.jsonl');
+    const result = await exportTrainingData(outputPath, {
+      database: db,
+      format: 'jsonl',
+    });
+
+    const contents = await fs.readFile(outputPath, 'utf8');
+    const rows = contents
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { rowType: string; repository?: { slug?: string } });
+
+    expect(result).toMatchObject({
+      outputPath,
+      format: 'jsonl',
+      totalRows: 4,
+      cycleObservationRows: 1,
+      candidateObservationRows: 1,
+      acceptanceBenchmarkRows: 1,
+      benchmarkCaseRows: 1,
+    });
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rowType: 'cycle_observation',
+          repository: expect.objectContaining({ slug: 'acme/widget' }),
+        }),
+        expect.objectContaining({
+          rowType: 'candidate_observation',
+          repository: expect.objectContaining({ slug: 'acme/widget' }),
+        }),
+        expect.objectContaining({ rowType: 'acceptance_benchmark' }),
+        expect.objectContaining({ rowType: 'benchmark_case' }),
+      ]),
+    );
+  });
+
+  it('exports Parquet training rows through DuckDB', async () => {
+    seedTrainingRows(statements);
+
+    const outputPath = path.join(outputDir, 'training-data.parquet');
+    const result = await exportTrainingData(outputPath, {
+      database: db,
+      format: 'parquet',
+    });
+
+    expect(result).toMatchObject({
+      outputPath,
+      format: 'parquet',
+      totalRows: 4,
+    });
+
+    const instance = await DuckDBInstance.create(':memory:');
+    try {
+      const connection = await instance.connect();
+      try {
+        const reader = await connection.runAndReadAll(`
+          SELECT
+            COUNT(*) AS total_rows,
+            SUM(CASE WHEN rowType = 'candidate_observation' THEN 1 ELSE 0 END) AS candidate_rows
+          FROM read_parquet('${outputPath.replaceAll('\\', '/')}')
+        `);
+        const rows = reader.getRowObjectsJson() as Array<{
+          total_rows: string | number;
+          candidate_rows: string | number;
+        }>;
+
+        expect(rows[0]).toMatchObject({
+          total_rows: '4',
+          candidate_rows: '1',
+        });
+      } finally {
+        connection.closeSync();
+      }
+    } finally {
+      instance.closeSync();
+    }
+  });
+});
+
+function seedTrainingRows(statements: ReturnType<typeof createStatements>) {
+  const repositoryInfo = statements.addRepository.run({
+    owner: 'acme',
+    name: 'widget',
+    default_branch: 'main',
+    local_path: path.join(fixtureRoot, 'repo'),
+  });
+  const scanInfo = statements.addScan.run({
+    repository_id: repositoryInfo.lastInsertRowid,
+    commit_sha: 'abc123',
+    status: 'completed',
+  });
+  const cycleInfo = statements.addCycle.run({
+    scan_id: scanInfo.lastInsertRowid,
+    normalized_path: 'a.ts -> b.ts -> a.ts',
+    participating_files: JSON.stringify(['a.ts', 'b.ts', 'a.ts']),
+    raw_payload: JSON.stringify({
+      type: 'circular',
+      path: ['a.ts', 'b.ts', 'a.ts'],
+    }),
+  });
+  const cycleObservationInfo = statements.addCycleObservation.run({
+    cycle_id: cycleInfo.lastInsertRowid,
+    scan_id: scanInfo.lastInsertRowid,
+    repository_id: repositoryInfo.lastInsertRowid,
+    observation_version: 1,
+    normalized_path: 'a.ts -> b.ts -> a.ts',
+    cycle_shape: 'two_file',
+    cycle_size: 2,
+    cycle_signals: JSON.stringify({ explicitImportEdges: 2 }),
+    feature_vector: JSON.stringify({ cycleSize: 2, packageManager: 'pnpm' }),
+    graph_summary: JSON.stringify({ metrics: { symbolSccCount: 1 } }),
+    repo_profile: JSON.stringify({ packageManager: 'pnpm', workspaceMode: 'workspace' }),
+    planner_summary: 'Selected import_type after ranking one candidate.',
+    planner_attempts: JSON.stringify([{ strategy: 'import_type', status: 'candidate' }]),
+    selected_strategy: 'import_type',
+    selected_classification: 'autofix_import_type',
+    selected_score: 0.94,
+    fallback_classification: 'autofix_import_type',
+    fallback_confidence: 0.9,
+    fallback_reasons: JSON.stringify(['Cycle can be resolved by converting imports to type-only.']),
+  });
+  const fixCandidateInfo = statements.addFixCandidate.run({
+    cycle_id: cycleInfo.lastInsertRowid,
+    strategy: 'import_type',
+    planner_rank: 1,
+    classification: 'autofix_import_type',
+    confidence: 0.9,
+    upstreamability_score: 0.94,
+    reasons: JSON.stringify(['Cycle can be resolved by converting imports to type-only.']),
+    summary: 'Convert import to type-only.',
+    score_breakdown: JSON.stringify(['base 0.97']),
+    signals: JSON.stringify({ importEdges: 2 }),
+  });
+  const patchInfo = statements.addPatch.run({
+    fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+    patch_text: '--- a.ts\n+++ a.ts\n',
+    touched_files: JSON.stringify(['a.ts']),
+    validation_status: 'passed',
+    validation_summary: 'Validation passed.',
+  });
+  statements.addReviewDecision.run({
+    patch_id: patchInfo.lastInsertRowid,
+    decision: 'approved',
+    notes: 'Looks good',
+  });
+  statements.addCandidateObservation.run({
+    cycle_observation_id: cycleObservationInfo.lastInsertRowid,
+    observation_version: 1,
+    fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+    patch_id: patchInfo.lastInsertRowid,
+    strategy: 'import_type',
+    status: 'candidate',
+    planner_rank: 1,
+    promotion_eligible: 1,
+    summary: 'Convert import to type-only.',
+    classification: 'autofix_import_type',
+    confidence: 0.9,
+    upstreamability_score: 0.94,
+    reasons: JSON.stringify(['Cycle can be resolved by converting imports to type-only.']),
+    score_breakdown: JSON.stringify(['base 0.97']),
+    signals: JSON.stringify({ importEdges: 2 }),
+    plan: JSON.stringify({ kind: 'import_type', imports: [{ sourceFile: 'a.ts', targetFile: 'b.ts' }] }),
+    validation_status: 'passed',
+    validation_summary: 'Validation passed.',
+    validation_failure_category: null,
+  });
+  statements.upsertAcceptanceBenchmarkCase.run({
+    repository: 'acme/widget',
+    local_path: path.join(fixtureRoot, 'repo'),
+    commit_sha: 'abc123',
+    scan_id: scanInfo.lastInsertRowid,
+    cycle_id: cycleInfo.lastInsertRowid,
+    fix_candidate_id: fixCandidateInfo.lastInsertRowid,
+    patch_id: patchInfo.lastInsertRowid,
+    normalized_path: 'a.ts -> b.ts -> a.ts',
+    classification: 'autofix_import_type',
+    confidence: 0.9,
+    upstreamability_score: 0.94,
+    validation_status: 'passed',
+    validation_summary: 'Validation passed.',
+    review_status: 'approved',
+    touched_files: JSON.stringify(['a.ts']),
+    feature_vector: JSON.stringify({ packageManager: 'pnpm' }),
+    planner_summary: 'Selected import_type.',
+    planner_attempts: JSON.stringify([{ strategy: 'import_type', status: 'candidate' }]),
+    acceptability: 'accepted',
+    rejection_reason: null,
+    acceptability_note: 'Accepted training sample',
+  });
+  statements.addBenchmarkCase.run({
+    repository: 'acme/widget',
+    source: 'git_history',
+    commit_sha: 'def456',
+    title: 'Break circular dependency via type-only import',
+    body: 'Converts a runtime import into import type.',
+    url: 'https://example.com/commit/def456',
+    pr_number: null,
+    issue_number: null,
+    strategy_labels: JSON.stringify(['import_type']),
+    validation_signals: JSON.stringify({ repository_profile: { package_manager: 'pnpm' } }),
+    diff_features: JSON.stringify({ filesTouched: 1 }),
+    matched_terms: JSON.stringify(['circular dependency', 'import type']),
+    notes: 'Seed benchmark sample',
+  });
+}

--- a/cli/exportTrainingData.ts
+++ b/cli/exportTrainingData.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DuckDBInstance } from '@duckdb/node-api';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import { getDb } from '../db/index.js';
+import { getTrainingDataExport } from '../db/trainingData.js';
+
+const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), 'exports', 'training-data');
+
+export type TrainingDataFormat = 'json' | 'jsonl' | 'parquet';
+
+export interface ExportTrainingDataOptions {
+  database?: DatabaseType;
+  format?: TrainingDataFormat;
+}
+
+export interface ExportTrainingDataResult {
+  outputPath: string;
+  format: TrainingDataFormat;
+  totalRows: number;
+  cycleObservationRows: number;
+  candidateObservationRows: number;
+  acceptanceBenchmarkRows: number;
+  benchmarkCaseRows: number;
+}
+
+export async function exportTrainingData(
+  outputPath?: string,
+  options: ExportTrainingDataOptions = {},
+): Promise<ExportTrainingDataResult> {
+  const format = options.format ?? 'jsonl';
+  const database = options.database ?? getDb();
+  const exportData = getTrainingDataExport(database);
+  const resolvedOutputPath = outputPath ?? defaultOutputPath(format);
+  await fs.mkdir(path.dirname(resolvedOutputPath), { recursive: true });
+  await writeExport(resolvedOutputPath, format, exportData);
+
+  return {
+    outputPath: resolvedOutputPath,
+    format,
+    totalRows: exportData.summary.totalRows,
+    cycleObservationRows: exportData.summary.cycleObservationRows,
+    candidateObservationRows: exportData.summary.candidateObservationRows,
+    acceptanceBenchmarkRows: exportData.summary.acceptanceBenchmarkRows,
+    benchmarkCaseRows: exportData.summary.benchmarkCaseRows,
+  };
+}
+
+async function writeExport(
+  outputPath: string,
+  format: TrainingDataFormat,
+  exportData: ReturnType<typeof getTrainingDataExport>,
+): Promise<void> {
+  if (format === 'json') {
+    await fs.writeFile(outputPath, JSON.stringify(exportData, null, 2), 'utf8');
+    return;
+  }
+
+  const jsonl = serializeJsonl(exportData.rows);
+  if (format === 'jsonl') {
+    await fs.writeFile(outputPath, jsonl, 'utf8');
+    return;
+  }
+
+  await writeParquet(outputPath, jsonl);
+}
+
+function serializeJsonl(rows: unknown[]): string {
+  if (rows.length === 0) {
+    return '';
+  }
+
+  return `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`;
+}
+
+function defaultOutputPath(format: TrainingDataFormat): string {
+  return path.join(DEFAULT_OUTPUT_DIR, `training-data.${format}`);
+}
+
+async function writeParquet(outputPath: string, jsonl: string): Promise<void> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'autofix-training-data-'));
+  const jsonlPath = path.join(tempDir, 'training-data.jsonl');
+
+  try {
+    await fs.writeFile(jsonlPath, jsonl, 'utf8');
+
+    const instance = await DuckDBInstance.create(':memory:');
+    try {
+      const connection = await instance.connect();
+      try {
+        await connection.run('LOAD json');
+        await connection.run('LOAD parquet');
+        await connection.run(`
+          CREATE TABLE training_data AS
+          SELECT *
+          FROM read_json_auto('${escapeSqlString(normalizeForDuckDb(jsonlPath))}', format = 'newline_delimited')
+        `);
+        await connection.run(`
+          COPY training_data
+          TO '${escapeSqlString(normalizeForDuckDb(outputPath))}'
+          (FORMAT parquet, COMPRESSION zstd)
+        `);
+      } finally {
+        connection.closeSync();
+      }
+    } finally {
+      instance.closeSync();
+    }
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function normalizeForDuckDb(filePath: string): string {
+  return filePath.replaceAll('\\', '/');
+}
+
+function escapeSqlString(value: string): string {
+  return value.replaceAll("'", "''");
+}

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -16,6 +16,7 @@ import { mineBenchmarkCasesFromCorpus } from './benchmarkCorpus.js';
 import { mineBenchmarkCasesFromRepo } from './benchmarkMiner.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
+import { exportTrainingData } from './exportTrainingData.js';
 import { createProgram } from './index.js';
 import { getOperationalMetrics } from './metrics.js';
 import { profileRepository } from './repoProfile.js';
@@ -423,6 +424,18 @@ vi.mock('./exportPatches.js', () => ({
     outputDir: exportedDir,
     exportedCount: 2,
     files: [path.join(exportedDir, 'a.patch'), path.join(exportedDir, 'b.patch')],
+  }),
+}));
+
+vi.mock('./exportTrainingData.js', () => ({
+  exportTrainingData: vi.fn().mockResolvedValue({
+    outputPath: path.join(exportedDir, 'training-data.parquet'),
+    format: 'parquet',
+    totalRows: 12,
+    cycleObservationRows: 3,
+    candidateObservationRows: 6,
+    acceptanceBenchmarkRows: 2,
+    benchmarkCaseRows: 1,
   }),
 }));
 
@@ -943,6 +956,31 @@ describe('CLI', () => {
     consoleSpy.mockRestore();
   });
 
+  it('export:training-data command prints export metadata as JSON', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'export:training-data',
+      path.join(exportedDir, 'dataset.parquet'),
+      '--format',
+      'parquet',
+    ]);
+
+    expect(vi.mocked(exportTrainingData)).toHaveBeenCalledWith(path.join(exportedDir, 'dataset.parquet'), {
+      format: 'parquet',
+    });
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      outputPath: path.join(exportedDir, 'training-data.parquet'),
+      format: 'parquet',
+      totalRows: 12,
+    });
+    consoleSpy.mockRestore();
+  });
+
   it('create:pr command creates a pull request from a stored patch', async () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const program = createProgram();
@@ -1178,5 +1216,6 @@ describe('CLI', () => {
     expect(commandNames).toContain('retry:failed');
     expect(commandNames).toContain('create:pr');
     expect(commandNames).toContain('export:patches');
+    expect(commandNames).toContain('export:training-data');
   });
 });

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -14,6 +14,7 @@ import { mineBenchmarkCasesFromCorpus } from './benchmarkCorpus.js';
 import { mineBenchmarkCasesFromRepo } from './benchmarkMiner.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
+import { exportTrainingData, type TrainingDataFormat } from './exportTrainingData.js';
 import { getOperationalMetrics } from './metrics.js';
 import {
   createConcurrencyLimiter,
@@ -475,6 +476,23 @@ export function createProgram(): Command {
       console.log(`Exported ${result.exportedCount} patch file(s) to ${result.outputDir}`);
     });
 
+  program
+    .command('export:training-data')
+    .argument('[outputPath]', 'Path to write the exported training dataset to')
+    .option('--format <format>', 'Export format: jsonl, json, or parquet', parseTrainingDataFormat, 'jsonl')
+    .description('Export model-ready training data from observations, benchmarks, and reviews')
+    .action(async (outputPath: string | undefined, options: { format: TrainingDataFormat }) => {
+      try {
+        const result = await exportTrainingData(outputPath, {
+          format: options.format,
+        });
+        console.log(JSON.stringify(result, null, 2));
+      } catch (error) {
+        console.error('Failed to export training data:', error);
+        process.exit(1);
+      }
+    });
+
   return program;
 }
 
@@ -538,6 +556,14 @@ function parseAcceptanceRejectionReason(
   throw new Error(
     `Expected a rejection reason of diff_noisy, validation_weak, semantic_wrong, repo_conventions_mismatch, or other. Received: ${value}`,
   );
+}
+
+function parseTrainingDataFormat(value: string): TrainingDataFormat {
+  if (value === 'json' || value === 'jsonl' || value === 'parquet') {
+    return value;
+  }
+
+  throw new Error(`Expected a training-data export format of json, jsonl, or parquet. Received: ${value}`);
 }
 
 // Run when executed directly

--- a/db/trainingData.ts
+++ b/db/trainingData.ts
@@ -1,0 +1,540 @@
+import type { Database as DatabaseType } from 'better-sqlite3';
+import type { AcceptanceBenchmarkCaseDTO, BenchmarkCaseDTO } from './index.js';
+import { getDb } from './index.js';
+
+interface CycleObservationExportRow {
+  id: number;
+  cycle_id: number;
+  scan_id: number;
+  repository_id: number;
+  observation_version: number;
+  normalized_path: string;
+  cycle_shape: string | null;
+  cycle_size: number;
+  cycle_signals: string | null;
+  feature_vector: string | null;
+  graph_summary: string | null;
+  repo_profile: string | null;
+  planner_summary: string | null;
+  planner_attempts: string;
+  selected_strategy: string | null;
+  selected_classification: string | null;
+  selected_score: number | null;
+  fallback_classification: string | null;
+  fallback_confidence: number | null;
+  fallback_reasons: string | null;
+  owner: string;
+  name: string;
+  commit_sha: string | null;
+}
+
+interface CandidateObservationExportRow {
+  id: number;
+  cycle_observation_id: number;
+  observation_version: number;
+  fix_candidate_id: number | null;
+  patch_id: number | null;
+  strategy: string | null;
+  status: string;
+  planner_rank: number;
+  promotion_eligible: number;
+  summary: string | null;
+  classification: string | null;
+  confidence: number | null;
+  upstreamability_score: number | null;
+  reasons: string | null;
+  score_breakdown: string | null;
+  signals: string | null;
+  plan: string | null;
+  validation_status: string | null;
+  validation_summary: string | null;
+  validation_failure_category: string | null;
+  review_status: string | null;
+  review_notes: string | null;
+  touched_files: string | null;
+  patch_text: string | null;
+  cycle_id: number;
+  scan_id: number;
+  repository_id: number;
+  normalized_path: string;
+  cycle_shape: string | null;
+  cycle_size: number;
+  cycle_signals: string | null;
+  feature_vector: string | null;
+  graph_summary: string | null;
+  repo_profile: string | null;
+  planner_summary: string | null;
+  selected_strategy: string | null;
+  selected_classification: string | null;
+  fallback_classification: string | null;
+  owner: string;
+  name: string;
+  commit_sha: string | null;
+}
+
+export interface TrainingDataExport {
+  summary: {
+    totalRows: number;
+    cycleObservationRows: number;
+    candidateObservationRows: number;
+    acceptanceBenchmarkRows: number;
+    benchmarkCaseRows: number;
+  };
+  rows: TrainingDataRow[];
+}
+
+export type TrainingDataRow =
+  | CycleObservationTrainingRow
+  | CandidateObservationTrainingRow
+  | AcceptanceBenchmarkTrainingRow
+  | BenchmarkCaseTrainingRow;
+
+export interface CycleObservationTrainingRow {
+  rowType: 'cycle_observation';
+  rowId: string;
+  repository: {
+    id: number;
+    slug: string;
+  };
+  scanId: number;
+  commitSha: string | null;
+  cycleId: number;
+  observationId: number;
+  observationVersion: number;
+  normalizedPath: string;
+  cycleShape: string | null;
+  cycleSize: number;
+  cycleSignals: Record<string, unknown>;
+  featureVector: Record<string, unknown>;
+  graphSummary: Record<string, unknown>;
+  repoProfile: Record<string, unknown>;
+  planner: {
+    summary: string | null;
+    attempts: unknown[];
+    selectedStrategy: string | null;
+    selectedClassification: string | null;
+    selectedScore: number | null;
+    fallbackClassification: string | null;
+    fallbackConfidence: number | null;
+    fallbackReasons: string[];
+  };
+}
+
+export interface CandidateObservationTrainingRow {
+  rowType: 'candidate_observation';
+  rowId: string;
+  repository: {
+    id: number;
+    slug: string;
+  };
+  scanId: number;
+  commitSha: string | null;
+  cycleId: number;
+  observationId: number;
+  observationVersion: number;
+  candidateObservationId: number;
+  fixCandidateId: number | null;
+  patchId: number | null;
+  normalizedPath: string;
+  cycleShape: string | null;
+  cycleSize: number;
+  cycleSignals: Record<string, unknown>;
+  featureVector: Record<string, unknown>;
+  graphSummary: Record<string, unknown>;
+  repoProfile: Record<string, unknown>;
+  planner: {
+    summary: string | null;
+    selectedStrategy: string | null;
+    selectedClassification: string | null;
+    fallbackClassification: string | null;
+  };
+  candidate: {
+    strategy: string | null;
+    status: string;
+    plannerRank: number;
+    promotionEligible: boolean;
+    summary: string | null;
+    classification: string | null;
+    confidence: number | null;
+    upstreamabilityScore: number | null;
+    reasons: string[];
+    scoreBreakdown: string[];
+    signals: Record<string, unknown>;
+    plan: Record<string, unknown> | null;
+  };
+  validation: {
+    status: string | null;
+    summary: string | null;
+    failureCategory: string | null;
+  };
+  review: {
+    status: string | null;
+    notes: string | null;
+  };
+  patch: {
+    touchedFiles: string[];
+    patchText: string | null;
+  };
+}
+
+export interface AcceptanceBenchmarkTrainingRow {
+  rowType: 'acceptance_benchmark';
+  rowId: string;
+  repository: {
+    slug: string;
+    localPath: string | null;
+  };
+  commitSha: string;
+  scanId: number | null;
+  cycleId: number | null;
+  fixCandidateId: number | null;
+  patchId: number | null;
+  normalizedPath: string;
+  classification: string;
+  confidence: number;
+  upstreamabilityScore: number | null;
+  validation: {
+    status: string | null;
+    summary: string | null;
+  };
+  reviewStatus: string | null;
+  touchedFiles: string[];
+  featureVector: Record<string, unknown>;
+  plannerSummary: string | null;
+  plannerAttempts: unknown[];
+  acceptability: {
+    decision: string | null;
+    rejectionReason: string | null;
+    note: string | null;
+  };
+}
+
+export interface BenchmarkCaseTrainingRow {
+  rowType: 'benchmark_case';
+  rowId: string;
+  repository: string;
+  source: string;
+  commitSha: string;
+  title: string;
+  body: string | null;
+  url: string | null;
+  prNumber: number | null;
+  issueNumber: number | null;
+  strategyLabels: string[];
+  validationSignals: Record<string, unknown>;
+  diffFeatures: Record<string, unknown>;
+  matchedTerms: string[];
+  notes: string | null;
+}
+
+export function getTrainingDataExport(database: DatabaseType = getDb()): TrainingDataExport {
+  const cycleObservationRows = loadLatestCycleObservationRows(database);
+  const candidateObservationRows = loadLatestCandidateObservationRows(database);
+  const acceptanceRows = loadAcceptanceBenchmarkRows(database);
+  const benchmarkRows = loadBenchmarkCaseRows(database);
+
+  const rows: TrainingDataRow[] = [
+    ...cycleObservationRows.map((row) => mapCycleObservationRow(row)),
+    ...candidateObservationRows.map((row) => mapCandidateObservationRow(row)),
+    ...acceptanceRows.map((row) => mapAcceptanceBenchmarkRow(row)),
+    ...benchmarkRows.map((row) => mapBenchmarkCaseRow(row)),
+  ];
+
+  return {
+    summary: {
+      totalRows: rows.length,
+      cycleObservationRows: cycleObservationRows.length,
+      candidateObservationRows: candidateObservationRows.length,
+      acceptanceBenchmarkRows: acceptanceRows.length,
+      benchmarkCaseRows: benchmarkRows.length,
+    },
+    rows,
+  };
+}
+
+function loadLatestCycleObservationRows(database: DatabaseType): CycleObservationExportRow[] {
+  return database
+    .prepare(
+      `
+        WITH latest_cycle_observations AS (
+          SELECT co.*
+          FROM cycle_observations co
+          INNER JOIN (
+            SELECT cycle_id, MAX(observation_version) AS max_version
+            FROM cycle_observations
+            GROUP BY cycle_id
+          ) latest
+            ON latest.cycle_id = co.cycle_id
+           AND latest.max_version = co.observation_version
+        )
+        SELECT
+          co.*,
+          r.owner,
+          r.name,
+          s.commit_sha
+        FROM latest_cycle_observations co
+        INNER JOIN repositories r ON r.id = co.repository_id
+        INNER JOIN scans s ON s.id = co.scan_id
+        ORDER BY r.owner ASC, r.name ASC, co.cycle_id ASC, co.id ASC
+      `,
+    )
+    .all() as CycleObservationExportRow[];
+}
+
+function loadLatestCandidateObservationRows(database: DatabaseType): CandidateObservationExportRow[] {
+  return database
+    .prepare(
+      `
+        WITH latest_cycle_observations AS (
+          SELECT co.*
+          FROM cycle_observations co
+          INNER JOIN (
+            SELECT cycle_id, MAX(observation_version) AS max_version
+            FROM cycle_observations
+            GROUP BY cycle_id
+          ) latest
+            ON latest.cycle_id = co.cycle_id
+           AND latest.max_version = co.observation_version
+        )
+        SELECT
+          cobs.*,
+          co.cycle_id,
+          co.scan_id,
+          co.repository_id,
+          co.normalized_path,
+          co.cycle_shape,
+          co.cycle_size,
+          co.cycle_signals,
+          co.feature_vector,
+          co.graph_summary,
+          co.repo_profile,
+          co.planner_summary,
+          co.selected_strategy,
+          co.selected_classification,
+          co.fallback_classification,
+          r.owner,
+          r.name,
+          s.commit_sha,
+          p.touched_files,
+          p.patch_text,
+          rd.decision AS review_status,
+          rd.notes AS review_notes
+        FROM candidate_observations cobs
+        INNER JOIN latest_cycle_observations co ON co.id = cobs.cycle_observation_id
+        INNER JOIN repositories r ON r.id = co.repository_id
+        INNER JOIN scans s ON s.id = co.scan_id
+        LEFT JOIN patches p ON p.id = cobs.patch_id
+        LEFT JOIN review_decisions rd ON rd.id = (
+          SELECT id
+          FROM review_decisions
+          WHERE patch_id = cobs.patch_id
+          ORDER BY created_at DESC, id DESC
+          LIMIT 1
+        )
+        ORDER BY r.owner ASC, r.name ASC, co.cycle_id ASC, cobs.planner_rank ASC, cobs.id ASC
+      `,
+    )
+    .all() as CandidateObservationExportRow[];
+}
+
+function loadAcceptanceBenchmarkRows(database: DatabaseType): AcceptanceBenchmarkCaseDTO[] {
+  return database
+    .prepare(
+      `
+        SELECT *
+        FROM acceptance_benchmark_cases
+        ORDER BY repository ASC, id ASC
+      `,
+    )
+    .all() as AcceptanceBenchmarkCaseDTO[];
+}
+
+function loadBenchmarkCaseRows(database: DatabaseType): BenchmarkCaseDTO[] {
+  return database
+    .prepare(
+      `
+        SELECT *
+        FROM benchmark_cases
+        ORDER BY repository ASC, id ASC
+      `,
+    )
+    .all() as BenchmarkCaseDTO[];
+}
+
+function mapCycleObservationRow(row: CycleObservationExportRow): CycleObservationTrainingRow {
+  return {
+    rowType: 'cycle_observation',
+    rowId: `cycle-observation:${row.id}`,
+    repository: {
+      id: row.repository_id,
+      slug: `${row.owner}/${row.name}`,
+    },
+    scanId: row.scan_id,
+    commitSha: row.commit_sha,
+    cycleId: row.cycle_id,
+    observationId: row.id,
+    observationVersion: row.observation_version,
+    normalizedPath: row.normalized_path,
+    cycleShape: row.cycle_shape,
+    cycleSize: row.cycle_size,
+    cycleSignals: parseJsonRecord(row.cycle_signals),
+    featureVector: parseJsonRecord(row.feature_vector),
+    graphSummary: parseJsonRecord(row.graph_summary),
+    repoProfile: parseJsonRecord(row.repo_profile),
+    planner: {
+      summary: row.planner_summary,
+      attempts: parseJsonArray(row.planner_attempts),
+      selectedStrategy: row.selected_strategy,
+      selectedClassification: row.selected_classification,
+      selectedScore: row.selected_score,
+      fallbackClassification: row.fallback_classification,
+      fallbackConfidence: row.fallback_confidence,
+      fallbackReasons: parseJsonStringArray(row.fallback_reasons),
+    },
+  };
+}
+
+function mapCandidateObservationRow(row: CandidateObservationExportRow): CandidateObservationTrainingRow {
+  return {
+    rowType: 'candidate_observation',
+    rowId: `candidate-observation:${row.id}`,
+    repository: {
+      id: row.repository_id,
+      slug: `${row.owner}/${row.name}`,
+    },
+    scanId: row.scan_id,
+    commitSha: row.commit_sha,
+    cycleId: row.cycle_id,
+    observationId: row.cycle_observation_id,
+    observationVersion: row.observation_version,
+    candidateObservationId: row.id,
+    fixCandidateId: row.fix_candidate_id,
+    patchId: row.patch_id,
+    normalizedPath: row.normalized_path,
+    cycleShape: row.cycle_shape,
+    cycleSize: row.cycle_size,
+    cycleSignals: parseJsonRecord(row.cycle_signals),
+    featureVector: parseJsonRecord(row.feature_vector),
+    graphSummary: parseJsonRecord(row.graph_summary),
+    repoProfile: parseJsonRecord(row.repo_profile),
+    planner: {
+      summary: row.planner_summary,
+      selectedStrategy: row.selected_strategy,
+      selectedClassification: row.selected_classification,
+      fallbackClassification: row.fallback_classification,
+    },
+    candidate: {
+      strategy: row.strategy,
+      status: row.status,
+      plannerRank: row.planner_rank,
+      promotionEligible: row.promotion_eligible === 1,
+      summary: row.summary,
+      classification: row.classification,
+      confidence: row.confidence,
+      upstreamabilityScore: row.upstreamability_score,
+      reasons: parseJsonStringArray(row.reasons),
+      scoreBreakdown: parseJsonStringArray(row.score_breakdown),
+      signals: parseJsonRecord(row.signals),
+      plan: parseJsonNullableRecord(row.plan),
+    },
+    validation: {
+      status: row.validation_status,
+      summary: row.validation_summary,
+      failureCategory: row.validation_failure_category,
+    },
+    review: {
+      status: row.review_status,
+      notes: row.review_notes,
+    },
+    patch: {
+      touchedFiles: parseJsonStringArray(row.touched_files),
+      patchText: row.patch_text,
+    },
+  };
+}
+
+function mapAcceptanceBenchmarkRow(row: AcceptanceBenchmarkCaseDTO): AcceptanceBenchmarkTrainingRow {
+  return {
+    rowType: 'acceptance_benchmark',
+    rowId: `acceptance-benchmark:${row.id}`,
+    repository: {
+      slug: row.repository,
+      localPath: row.local_path,
+    },
+    commitSha: row.commit_sha,
+    scanId: row.scan_id,
+    cycleId: row.cycle_id,
+    fixCandidateId: row.fix_candidate_id,
+    patchId: row.patch_id,
+    normalizedPath: row.normalized_path,
+    classification: row.classification,
+    confidence: row.confidence,
+    upstreamabilityScore: row.upstreamability_score,
+    validation: {
+      status: row.validation_status,
+      summary: row.validation_summary,
+    },
+    reviewStatus: row.review_status,
+    touchedFiles: parseJsonStringArray(row.touched_files),
+    featureVector: parseJsonRecord(row.feature_vector),
+    plannerSummary: row.planner_summary,
+    plannerAttempts: parseJsonArray(row.planner_attempts),
+    acceptability: {
+      decision: row.acceptability,
+      rejectionReason: row.rejection_reason,
+      note: row.acceptability_note,
+    },
+  };
+}
+
+function mapBenchmarkCaseRow(row: BenchmarkCaseDTO): BenchmarkCaseTrainingRow {
+  return {
+    rowType: 'benchmark_case',
+    rowId: `benchmark-case:${row.id}`,
+    repository: row.repository,
+    source: row.source,
+    commitSha: row.commit_sha,
+    title: row.title,
+    body: row.body,
+    url: row.url,
+    prNumber: row.pr_number,
+    issueNumber: row.issue_number,
+    strategyLabels: parseJsonStringArray(row.strategy_labels),
+    validationSignals: parseJsonRecord(row.validation_signals),
+    diffFeatures: parseJsonRecord(row.diff_features),
+    matchedTerms: parseJsonStringArray(row.matched_terms),
+    notes: row.notes,
+  };
+}
+
+function parseJsonRecord(value: string | null): Record<string, unknown> {
+  return parseJsonValue<Record<string, unknown>>(value, {});
+}
+
+function parseJsonNullableRecord(value: string | null): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+
+  return parseJsonValue<Record<string, unknown>>(value, {});
+}
+
+function parseJsonArray(value: string | null): unknown[] {
+  return parseJsonValue<unknown[]>(value, []);
+}
+
+function parseJsonStringArray(value: string | null): string[] {
+  return parseJsonArray(value).filter((item): item is string => typeof item === 'string');
+}
+
+function parseJsonValue<T>(value: string | null, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "retry:failed": "tsx cli/index.ts retry:failed",
     "create:pr": "tsx cli/index.ts create:pr",
     "export:patches": "tsx cli/index.ts export:patches",
+    "export:training-data": "tsx cli/index.ts export:training-data",
     "prepare": "husky"
   },
   "dependencies": {
+    "@duckdb/node-api": "1.5.0-r.1",
     "@fastify/cors": "^11.0.1",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@duckdb/node-api':
+        specifier: 1.5.0-r.1
+        version: 1.5.0-r.1
       '@fastify/cors':
         specifier: ^11.0.1
         version: 11.2.0
@@ -471,6 +474,42 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@duckdb/node-api@1.5.0-r.1':
+    resolution: {integrity: sha512-VjvjqlCyqUJ22bydG/+9Jj5l0CEvx9QUn1SATBkKFY0+x6n4uHzt0kp/FKwXK9LNduXX6KCKtdF+6v5BcHScfA==}
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.0-r.1':
+    resolution: {integrity: sha512-s7CB9Y10f3dg2W4jdp6zipogxamq1pPQVt/r+YigZrHqk7HvytUeRH1VOI/3wuGTTlR8mAnIXj2MJIrmMujX4w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-darwin-x64@1.5.0-r.1':
+    resolution: {integrity: sha512-2KxnGvg9o/Y915hwr1Mpb6Cbfrvt/w+/Fv0RZ2VXeQuxqNCMOoJd/7yQ8ffWXJRuOFU/vRmsR88koIjW+yJibA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-linux-arm64@1.5.0-r.1':
+    resolution: {integrity: sha512-FpmcfJqhKoInjEa1o5dsWPQAFWYgu1eZgJP94nz6d+cKfdXEZKT6vGIwokZRzDqKLG1ZAOBZO2IhxzmW8IbbfA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@duckdb/node-bindings-linux-x64@1.5.0-r.1':
+    resolution: {integrity: sha512-A4Zgsaq6szEKiMyF1eWkoaHw0OMA0a8Zl8Ev0GcZSRjI4iGHgBQ1f/Zi/w3QKyz7OtjIiZ+pQ1XYyG4QoF6OKA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@duckdb/node-bindings-win32-arm64@1.5.0-r.1':
+    resolution: {integrity: sha512-ctCJ2HWpyiN3FNiCQ40RWALZLwKtJ8Aq4Anen2ush1I0a2E52T//jitLzl7DcX0quzew5eci1MQ+H5T1nVhzFA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@duckdb/node-bindings-win32-x64@1.5.0-r.1':
+    resolution: {integrity: sha512-725LoefejBlyG/bUcMfqVJkZ8KnZRLa0xOkszw9Q+V5G26iagJY3dgtGJAvwTeVJvXigSEVc5yD9Cj6kWR67vA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@duckdb/node-bindings@1.5.0-r.1':
+    resolution: {integrity: sha512-ViyoHROp0HhQ0ATT8z6h7SV6vEOxNjN8mJcdkst+3rJIU3Rd/gKs8exJO23LxFsjBuAiDpndpEwFihTAdfwJZg==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -3853,6 +3892,37 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@duckdb/node-api@1.5.0-r.1':
+    dependencies:
+      '@duckdb/node-bindings': 1.5.0-r.1
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-darwin-x64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-arm64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-x64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings@1.5.0-r.1':
+    optionalDependencies:
+      '@duckdb/node-bindings-darwin-arm64': 1.5.0-r.1
+      '@duckdb/node-bindings-darwin-x64': 1.5.0-r.1
+      '@duckdb/node-bindings-linux-arm64': 1.5.0-r.1
+      '@duckdb/node-bindings-linux-x64': 1.5.0-r.1
+      '@duckdb/node-bindings-win32-arm64': 1.5.0-r.1
+      '@duckdb/node-bindings-win32-x64': 1.5.0-r.1
 
   '@emnapi/core@1.9.0':
     dependencies:


### PR DESCRIPTION
## Summary
- add model-ready observation and benchmark export rows plus a new `export:training-data` CLI command
- support `json`, `jsonl`, and `parquet` output, using DuckDB to generate Parquet for offline analytics
- document the SQLite-for-runtime / DuckDB+Parquet-for-analysis split

Closes #64

## Verification
- `../../node_modules/.bin/eslint .`
- `../../node_modules/.bin/biome check .`
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `../../node_modules/.bin/vitest run --config vitest.config.ts`
- `../../node_modules/.bin/vite build`
