### PR TITLE
Restrict training data to JS/TS benchmark rows

### DIFF
--- a/DEPS.md
+++ b/DEPS.md
@@ -136,6 +136,7 @@ This means:
 - keep heuristic scoring as the baseline
 - store versioned features and outcomes
 - add offline dataset export first
+- keep mined benchmark samples scoped to commits that touched JS/TS files
 - analyze exported datasets with DuckDB + Parquet before introducing model tooling
 - only add model tooling when benchmark data is stable enough to justify it
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ pnpm run export:training-data -- --format parquet
 
 The runtime application still uses SQLite for scans, patches, and review state. Offline analytics should prefer DuckDB over exported Parquet datasets so ranking experiments and pattern mining stay fast without complicating the live app database.
 
+Training export is intentionally JS/TS-only. Benchmark cases mined from git history are only kept when the matching commit touched JavaScript or TypeScript files, and the exporter excludes benchmark rows that are not explicitly marked as JS/TS training-eligible.
+
 ## Engineering Principles
 
 - Prefer explainable ranking over opaque automation.

--- a/cli/benchmarkMiner.test.ts
+++ b/cli/benchmarkMiner.test.ts
@@ -19,6 +19,11 @@ function createFakeGit(): GitAdapter {
       title: 'Unrelated chore',
       body: 'Refresh docs and formatting only.',
     },
+    {
+      sha: 'jkl000',
+      title: 'Document circular dependency workaround',
+      body: 'Describe the approach in README without changing runtime code.',
+    },
   ];
 
   const logOutput = commits.map((commit) => `${commit.sha}\u001F${commit.title}\u001F${commit.body}\u001E`).join('');
@@ -28,6 +33,8 @@ function createFakeGit(): GitAdapter {
     ['show --numstat --find-renames --format= abc123', '4\t2\tfile-a.ts\n3\t0\tfile-b.ts\n'],
     ['show --name-status --find-renames --format= def456', 'M\tshared.ts\nR100\told.ts\tnew.ts\n'],
     ['show --numstat --find-renames --format= def456', '6\t1\tshared.ts\n2\t2\tnew.ts\n'],
+    ['show --name-status --find-renames --format= jkl000', 'M\tREADME.md\nA\tdocs/cycles.md\n'],
+    ['show --numstat --find-renames --format= jkl000', '8\t0\tREADME.md\n4\t0\tdocs/cycles.md\n'],
   ]);
 
   return {
@@ -75,8 +82,8 @@ describe('mineBenchmarkCasesFromRepo', () => {
 
     expect(result).toMatchObject({
       repository: 'acme/widget',
-      scannedCommits: 3,
-      matchedCommits: 2,
+      scannedCommits: 4,
+      matchedCommits: 3,
       insertedCases: 2,
     });
     expect(result.matchedTerms).toEqual(expect.arrayContaining(['circular dependency', 'import type', 'barrel']));
@@ -99,12 +106,22 @@ describe('mineBenchmarkCasesFromRepo', () => {
       renamed_files: 0,
       modified_files: 1,
       binary_files: 0,
+      js_ts_files_changed: 2,
+      non_js_ts_files_changed: 0,
     });
     expect(JSON.parse(importTypeCase?.validation_signals ?? '{}')).toMatchObject({
       search_terms: expect.any(Number),
       matched_terms: expect.any(Array),
+      language_scope: {
+        training_language: 'js_ts',
+        eligible: true,
+        js_ts_changed_files: ['file-a.ts', 'file-b.ts'],
+        non_js_ts_changed_files: [],
+        total_changed_paths: 2,
+      },
     });
     expect(importTypeCase?.notes).toContain('matched terms:');
+    expect(importTypeCase?.notes).toContain('training language scope: js/ts');
 
     db.close();
   });
@@ -156,6 +173,30 @@ describe('mineBenchmarkCasesFromRepo', () => {
     expect(result.insertedCases).toBe(1);
     expect(cases).toHaveLength(1);
     expect(cases[0].commit_sha).toBe('abc123');
+
+    db.close();
+  });
+
+  it('skips matched commits that only touch non-JS/TS files', async () => {
+    const db = createDatabase(':memory:');
+    initSchema(db);
+    const git = createFakeGit();
+
+    // eslint-disable-next-line sonarjs/publicly-writable-directories
+    const result = await mineBenchmarkCasesFromRepo('/tmp/acme-widget', {
+      database: db,
+      git,
+      maxMatches: 10,
+      searchTerms: ['circular dependency'],
+    });
+
+    const cases = createStatements(db).getBenchmarkCasesByRepository.all('acme/widget') as Array<{
+      commit_sha: string;
+    }>;
+
+    expect(result.matchedCommits).toBe(2);
+    expect(result.insertedCases).toBe(1);
+    expect(cases.map((entry) => ({ commit_sha: entry.commit_sha }))).toEqual([{ commit_sha: 'abc123' }]);
 
     db.close();
   });

--- a/cli/benchmarkMiner.ts
+++ b/cli/benchmarkMiner.ts
@@ -77,7 +77,22 @@ interface DiffFeatures {
   renamed_files: number;
   modified_files: number;
   binary_files: number;
+  js_ts_files_changed: number;
+  non_js_ts_files_changed: number;
 }
+
+interface ChangedFileSummary {
+  allPaths: string[];
+  jsTsPaths: string[];
+  nonJsTsPaths: string[];
+}
+
+interface DiffSummary {
+  diffFeatures: DiffFeatures;
+  changedFiles: ChangedFileSummary;
+}
+
+const TRAINING_CODE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mts', '.cts']);
 
 export async function mineBenchmarkCasesFromRepo(
   repoPath: string,
@@ -116,7 +131,11 @@ export async function mineBenchmarkCasesFromRepo(
       matchedTerms.add(term);
     }
 
-    const diffFeatures = await collectDiffFeatures(git, commit.commitSha);
+    const diffSummary = await collectDiffSummary(git, commit.commitSha);
+    if (diffSummary.changedFiles.jsTsPaths.length === 0) {
+      continue;
+    }
+
     const strategyLabels = classifyStrategyLabels(commitText);
     const url = buildCommitUrl(repository, commit.commitSha);
 
@@ -134,11 +153,12 @@ export async function mineBenchmarkCasesFromRepo(
         matched_terms: commitMatchedTerms,
         search_terms: searchTerms.length,
         commit_text_length: commitText.length,
+        language_scope: buildLanguageScopeSignals(diffSummary.changedFiles),
         ...buildBenchmarkContextSignals(options.caseContext),
       }),
-      diff_features: JSON.stringify(diffFeatures),
+      diff_features: JSON.stringify(diffSummary.diffFeatures),
       matched_terms: JSON.stringify(commitMatchedTerms),
-      notes: buildBenchmarkNote(commitMatchedTerms, diffFeatures, strategyLabels, options.caseContext),
+      notes: buildBenchmarkNote(commitMatchedTerms, diffSummary, strategyLabels, options.caseContext),
     });
 
     insertedCases += 1;
@@ -182,7 +202,7 @@ function findMatchedTerms(text: string, searchTerms: string[]): string[] {
   return searchTerms.filter((term) => lowerText.includes(term));
 }
 
-async function collectDiffFeatures(git: GitAdapter, commitSha: string): Promise<DiffFeatures> {
+async function collectDiffSummary(git: GitAdapter, commitSha: string): Promise<DiffSummary> {
   const [nameStatusOutput, numstatOutput] = await Promise.all([
     git.raw(['show', '--name-status', '--find-renames', '--format=', commitSha]),
     git.raw(['show', '--numstat', '--find-renames', '--format=', commitSha]),
@@ -204,9 +224,10 @@ async function collectDiffFeatures(git: GitAdapter, commitSha: string): Promise<
   let renamedFiles = 0;
   let modifiedFiles = 0;
   let binaryFiles = 0;
+  const changedPaths = new Set<string>();
 
   for (const line of nameStatusLines) {
-    const [status] = line.split('\t');
+    const [status, ...rawPaths] = line.split('\t');
     if (!status) {
       continue;
     }
@@ -218,6 +239,10 @@ async function collectDiffFeatures(git: GitAdapter, commitSha: string): Promise<
       renamedFiles += 1;
     } else if (status.startsWith('M')) {
       modifiedFiles += 1;
+    }
+
+    for (const filePath of rawPaths.map((value) => value.trim()).filter(Boolean)) {
+      changedPaths.add(filePath);
     }
   }
 
@@ -232,14 +257,21 @@ async function collectDiffFeatures(git: GitAdapter, commitSha: string): Promise<
     deletions += Number(deletes ?? 0);
   }
 
+  const changedFiles = summarizeChangedFiles([...changedPaths]);
+
   return {
-    files_changed: filesChanged,
-    additions,
-    deletions,
-    new_files: newFiles,
-    renamed_files: renamedFiles,
-    modified_files: modifiedFiles,
-    binary_files: binaryFiles,
+    diffFeatures: {
+      files_changed: filesChanged,
+      additions,
+      deletions,
+      new_files: newFiles,
+      renamed_files: renamedFiles,
+      modified_files: modifiedFiles,
+      binary_files: binaryFiles,
+      js_ts_files_changed: changedFiles.jsTsPaths.length,
+      non_js_ts_files_changed: changedFiles.nonJsTsPaths.length,
+    },
+    changedFiles,
   };
 }
 
@@ -280,7 +312,7 @@ function classifyStrategyLabels(commitText: string): string[] {
 
 function buildBenchmarkNote(
   matchedTerms: string[],
-  diffFeatures: DiffFeatures,
+  diffSummary: DiffSummary,
   labels: string[],
   context?: BenchmarkCaseContext,
 ): string {
@@ -308,9 +340,20 @@ function buildBenchmarkNote(
   return [
     `matched terms: ${matchedTerms.join(', ')}`,
     `labels: ${labels.join(', ')}`,
-    `files changed: ${diffFeatures.files_changed}`,
+    `files changed: ${diffSummary.diffFeatures.files_changed}`,
+    `training language scope: js/ts (${diffSummary.changedFiles.jsTsPaths.length} code files)`,
     ...contextParts,
   ].join('; ');
+}
+
+function buildLanguageScopeSignals(changedFiles: ChangedFileSummary): Record<string, unknown> {
+  return {
+    training_language: 'js_ts',
+    eligible: true,
+    js_ts_changed_files: changedFiles.jsTsPaths,
+    non_js_ts_changed_files: changedFiles.nonJsTsPaths,
+    total_changed_paths: changedFiles.allPaths.length,
+  };
 }
 
 function buildBenchmarkContextSignals(context?: BenchmarkCaseContext): Record<string, unknown> {
@@ -370,4 +413,34 @@ function buildCommitUrl(repository: string, commitSha: string): string | null {
   }
 
   return `https://github.com/${repository}/commit/${commitSha}`;
+}
+
+function summarizeChangedFiles(paths: string[]): ChangedFileSummary {
+  const uniquePaths = [...new Set(paths.map((filePath) => filePath.trim()).filter(Boolean))];
+  const jsTsPaths: string[] = [];
+  const nonJsTsPaths: string[] = [];
+
+  for (const filePath of uniquePaths) {
+    if (isJavaScriptOrTypeScriptPath(filePath)) {
+      jsTsPaths.push(filePath);
+      continue;
+    }
+
+    nonJsTsPaths.push(filePath);
+  }
+
+  return {
+    allPaths: uniquePaths,
+    jsTsPaths,
+    nonJsTsPaths,
+  };
+}
+
+function isJavaScriptOrTypeScriptPath(filePath: string): boolean {
+  const normalizedPath = filePath.trim().toLowerCase();
+  if (!normalizedPath) {
+    return false;
+  }
+
+  return TRAINING_CODE_EXTENSIONS.has(path.extname(normalizedPath));
 }

--- a/cli/exportTrainingData.test.ts
+++ b/cli/exportTrainingData.test.ts
@@ -63,6 +63,8 @@ describe('exportTrainingData', () => {
         expect.objectContaining({ rowType: 'benchmark_case' }),
       ]),
     );
+    const benchmarkRows = rows.filter((row) => row.rowType === 'benchmark_case');
+    expect(benchmarkRows).toHaveLength(1);
   });
 
   it('exports Parquet training rows through DuckDB', async () => {
@@ -228,9 +230,41 @@ function seedTrainingRows(statements: ReturnType<typeof createStatements>) {
     pr_number: null,
     issue_number: null,
     strategy_labels: JSON.stringify(['import_type']),
-    validation_signals: JSON.stringify({ repository_profile: { package_manager: 'pnpm' } }),
+    validation_signals: JSON.stringify({
+      repository_profile: { package_manager: 'pnpm' },
+      language_scope: {
+        training_language: 'js_ts',
+        eligible: true,
+        js_ts_changed_files: ['src/a.ts'],
+        non_js_ts_changed_files: ['README.md'],
+        total_changed_paths: 2,
+      },
+    }),
     diff_features: JSON.stringify({ filesTouched: 1 }),
     matched_terms: JSON.stringify(['circular dependency', 'import type']),
     notes: 'Seed benchmark sample',
+  });
+  statements.addBenchmarkCase.run({
+    repository: 'acme/widget',
+    source: 'git_history',
+    commit_sha: 'ghi789',
+    title: 'Document circular dependency workaround',
+    body: 'Docs-only follow-up.',
+    url: 'https://example.com/commit/ghi789',
+    pr_number: null,
+    issue_number: null,
+    strategy_labels: JSON.stringify(['unclassified']),
+    validation_signals: JSON.stringify({
+      language_scope: {
+        training_language: 'js_ts',
+        eligible: false,
+        js_ts_changed_files: [],
+        non_js_ts_changed_files: ['README.md'],
+        total_changed_paths: 1,
+      },
+    }),
+    diff_features: JSON.stringify({ filesTouched: 1 }),
+    matched_terms: JSON.stringify(['circular dependency']),
+    notes: 'Should be filtered from training export',
   });
 }

--- a/db/trainingData.ts
+++ b/db/trainingData.ts
@@ -231,7 +231,7 @@ export function getTrainingDataExport(database: DatabaseType = getDb()): Trainin
   const cycleObservationRows = loadLatestCycleObservationRows(database);
   const candidateObservationRows = loadLatestCandidateObservationRows(database);
   const acceptanceRows = loadAcceptanceBenchmarkRows(database);
-  const benchmarkRows = loadBenchmarkCaseRows(database);
+  const benchmarkRows = loadBenchmarkCaseRows(database).filter((row) => isTrainingEligibleBenchmarkCase(row));
 
   const rows: TrainingDataRow[] = [
     ...cycleObservationRows.map((row) => mapCycleObservationRow(row)),
@@ -507,6 +507,13 @@ function mapBenchmarkCaseRow(row: BenchmarkCaseDTO): BenchmarkCaseTrainingRow {
   };
 }
 
+function isTrainingEligibleBenchmarkCase(row: BenchmarkCaseDTO): boolean {
+  const signals = parseJsonRecord(row.validation_signals);
+  const languageScope = asRecord(signals.language_scope);
+
+  return languageScope?.training_language === 'js_ts' && languageScope.eligible === true;
+}
+
 function parseJsonRecord(value: string | null): Record<string, unknown> {
   return parseJsonValue<Record<string, unknown>>(value, {});
 }
@@ -517,6 +524,14 @@ function parseJsonNullableRecord(value: string | null): Record<string, unknown> 
   }
 
   return parseJsonValue<Record<string, unknown>>(value, {});
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
 }
 
 function parseJsonArray(value: string | null): unknown[] {


### PR DESCRIPTION
## Summary
- restrict mined benchmark cases to commits that actually touch JS/TS files
- mark benchmark rows with JS/TS language-scope metadata and filter training export to eligible rows only
- document the JS/TS-only training-data guarantee

## Verification
- ../../node_modules/.bin/vitest run --config vitest.config.ts
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/eslint .
- ../../node_modules/.bin/biome check .
- ../../node_modules/.bin/vite build