### PR TITLE
Import external benchmark datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ pnpm run dev
 ## Current CLI Surface
 
 ```bash
+pnpm run benchmark:import <dataset-path> -- --dataset swe-bench-multilingual --format parquet
 pnpm run scan <repo-url-or-path>
 pnpm run scan:all
 pnpm run retry:failed
@@ -121,6 +122,8 @@ pnpm run export:training-data -- --format parquet
 The runtime application still uses SQLite for scans, patches, and review state. Offline analytics should prefer DuckDB over exported Parquet datasets so ranking experiments and pattern mining stay fast without complicating the live app database.
 
 Training export is intentionally JS/TS-only. Benchmark cases mined from git history are only kept when the matching commit touched JavaScript or TypeScript files, and the exporter excludes benchmark rows that are not explicitly marked as JS/TS training-eligible.
+
+External dataset import follows the same rule. Imported benchmark rows are only stored when they touch JS/TS files, and by default they must also look cycle-related based on the benchmark search terms so the benchmark table stays useful for circular-dependency ranking instead of filling with unrelated bugfixes.
 
 ## Engineering Principles
 

--- a/cli/benchmarkMiner.ts
+++ b/cli/benchmarkMiner.ts
@@ -2,24 +2,13 @@ import path from 'node:path';
 import type { Database as DatabaseType } from 'better-sqlite3';
 import simpleGit from 'simple-git';
 import { createStatements, getDb } from '../db/index.js';
+import {
+  classifyStrategyLabels,
+  findMatchedTerms,
+  getDefaultBenchmarkSearchTerms,
+  normalizeSearchTerms,
+} from './benchmarkSignals.js';
 import type { RepositoryProfile } from './repoProfile.js';
-
-const DEFAULT_SEARCH_TERMS = [
-  'circular dependency',
-  'cyclic dependency',
-  'import type',
-  'type-only',
-  'barrel',
-  're-export',
-  'reexport',
-  'index.ts',
-  'index.js',
-  'extract shared',
-  'move helper',
-  'break cycle',
-  'internal.ts',
-  'internal.js',
-];
 
 const LOG_RECORD_SEPARATOR = '\u001E';
 const LOG_FIELD_SEPARATOR = '\u001F';
@@ -102,7 +91,7 @@ export async function mineBenchmarkCasesFromRepo(
   const statements = createStatements(database);
   const git = options.git ?? simpleGit(repoPath);
   const repository = options.repositoryLabel ?? (await resolveRepositoryLabel(git, repoPath));
-  const searchTerms = normalizeSearchTerms(options.searchTerms ?? DEFAULT_SEARCH_TERMS);
+  const searchTerms = normalizeSearchTerms(options.searchTerms ?? getDefaultBenchmarkSearchTerms());
   const maxCommits = options.maxCommits ?? 1000;
   const maxMatches = options.maxMatches ?? 25;
 
@@ -177,10 +166,6 @@ export async function mineBenchmarkCasesFromRepo(
   };
 }
 
-function normalizeSearchTerms(terms: string[]): string[] {
-  return [...new Set(terms.map((term) => term.trim().toLowerCase()).filter(Boolean))];
-}
-
 function parseCommitRecords(logOutput: string): ParsedCommitRecord[] {
   return logOutput
     .split(LOG_RECORD_SEPARATOR)
@@ -195,11 +180,6 @@ function parseCommitRecords(logOutput: string): ParsedCommitRecord[] {
       };
     })
     .filter((record) => record.commitSha.length > 0);
-}
-
-function findMatchedTerms(text: string, searchTerms: string[]): string[] {
-  const lowerText = text.toLowerCase();
-  return searchTerms.filter((term) => lowerText.includes(term));
 }
 
 async function collectDiffSummary(git: GitAdapter, commitSha: string): Promise<DiffSummary> {
@@ -273,41 +253,6 @@ async function collectDiffSummary(git: GitAdapter, commitSha: string): Promise<D
     },
     changedFiles,
   };
-}
-
-function classifyStrategyLabels(commitText: string): string[] {
-  const lowerText = commitText.toLowerCase();
-  const labels = new Set<string>();
-
-  if (/import\s+type|type-only|type only/.test(lowerText)) {
-    labels.add('import_type');
-    labels.add('type_runtime_split');
-  }
-
-  if (/barrel|re-?export|index\.(ts|tsx|js|jsx)/.test(lowerText)) {
-    labels.add('barrel_reexport_cleanup');
-    labels.add('direct_import');
-  }
-
-  if (/extract shared|shared module|shared file|move helper|split helper|leaf-like/.test(lowerText)) {
-    labels.add('extract_shared');
-    labels.add('leaf_cluster_extraction');
-  }
-
-  if (/setter|state update|host-owned|stateful singleton|dependency inversion/.test(lowerText)) {
-    labels.add('host_owned_state_update');
-    labels.add('stateful_singleton_split');
-  }
-
-  if (/internal\.(ts|js)|module loading order|internal entrypoint/.test(lowerText)) {
-    labels.add('internal_entrypoint_pattern');
-  }
-
-  if (labels.size === 0) {
-    labels.add('unclassified');
-  }
-
-  return [...labels];
 }
 
 function buildBenchmarkNote(

--- a/cli/benchmarkSignals.ts
+++ b/cli/benchmarkSignals.ts
@@ -1,0 +1,64 @@
+const DEFAULT_SEARCH_TERMS = [
+  'circular dependency',
+  'cyclic dependency',
+  'import type',
+  'type-only',
+  'barrel',
+  're-export',
+  'reexport',
+  'index.ts',
+  'index.js',
+  'extract shared',
+  'move helper',
+  'break cycle',
+  'internal.ts',
+  'internal.js',
+];
+
+export function getDefaultBenchmarkSearchTerms(): string[] {
+  return [...DEFAULT_SEARCH_TERMS];
+}
+
+export function normalizeSearchTerms(terms: string[]): string[] {
+  return [...new Set(terms.map((term) => term.trim().toLowerCase()).filter(Boolean))];
+}
+
+export function findMatchedTerms(text: string, searchTerms: string[]): string[] {
+  const lowerText = text.toLowerCase();
+  return searchTerms.filter((term) => lowerText.includes(term));
+}
+
+export function classifyStrategyLabels(commitText: string): string[] {
+  const lowerText = commitText.toLowerCase();
+  const labels = new Set<string>();
+
+  if (/import\s+type|type-only|type only/.test(lowerText)) {
+    labels.add('import_type');
+    labels.add('type_runtime_split');
+  }
+
+  if (/barrel|re-?export|index\.(ts|tsx|js|jsx)/.test(lowerText)) {
+    labels.add('barrel_reexport_cleanup');
+    labels.add('direct_import');
+  }
+
+  if (/extract shared|shared module|shared file|move helper|split helper|leaf-like/.test(lowerText)) {
+    labels.add('extract_shared');
+    labels.add('leaf_cluster_extraction');
+  }
+
+  if (/setter|state update|host-owned|stateful singleton|dependency inversion/.test(lowerText)) {
+    labels.add('host_owned_state_update');
+    labels.add('stateful_singleton_split');
+  }
+
+  if (/internal\.(ts|js)|module loading order|internal entrypoint/.test(lowerText)) {
+    labels.add('internal_entrypoint_pattern');
+  }
+
+  if (labels.size === 0) {
+    labels.add('unclassified');
+  }
+
+  return [...labels];
+}

--- a/cli/importBenchmarkDataset.test.ts
+++ b/cli/importBenchmarkDataset.test.ts
@@ -1,0 +1,160 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type BenchmarkCaseDTO, createDatabase, createStatements, initSchema } from '../db/index.js';
+import { importBenchmarkDataset } from './importBenchmarkDataset.js';
+
+describe('importBenchmarkDataset', () => {
+  let db: ReturnType<typeof createDatabase>;
+  let outputDir: string;
+
+  beforeEach(async () => {
+    db = createDatabase(':memory:');
+    initSchema(db);
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'benchmark-import-'));
+  });
+
+  afterEach(async () => {
+    db.close();
+    await fs.rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('imports JSONL rows that are both JS/TS and cycle-related', async () => {
+    const inputPath = path.join(outputDir, 'swebench.jsonl');
+    await fs.writeFile(
+      inputPath,
+      [
+        JSON.stringify({
+          repo: 'acme/widget',
+          base_commit: 'abc123',
+          problem_statement: 'Fix circular dependency in the TS planner by converting an import to import type.',
+          patch: [
+            'diff --git a/src/planner.ts b/src/planner.ts',
+            '--- a/src/planner.ts',
+            '+++ b/src/planner.ts',
+            '@@',
+            "-import { Node } from './types'",
+            "+import type { Node } from './types'",
+          ].join('\n'),
+        }),
+        JSON.stringify({
+          repo: 'acme/widget',
+          base_commit: 'def456',
+          problem_statement: 'Document the circular dependency workaround in the README.',
+          patch: ['diff --git a/README.md b/README.md', '--- a/README.md', '+++ b/README.md'].join('\n'),
+        }),
+        JSON.stringify({
+          repo: 'acme/widget',
+          base_commit: 'ghi789',
+          problem_statement: 'Fix a rendering bug in the TS app shell.',
+          patch: ['diff --git a/src/app.ts b/src/app.ts', '--- a/src/app.ts', '+++ b/src/app.ts'].join('\n'),
+        }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = await importBenchmarkDataset(inputPath, {
+      database: db,
+      datasetName: 'swe-bench-multilingual',
+    });
+
+    const cases = createStatements(db).getBenchmarkCases.all() as BenchmarkCaseDTO[];
+
+    expect(result).toMatchObject({
+      format: 'jsonl',
+      totalRows: 3,
+      jsTsRows: 2,
+      relatedRows: 1,
+      insertedCases: 1,
+      skippedNonJsTs: 1,
+      skippedUnrelated: 1,
+    });
+    expect(cases).toHaveLength(1);
+    expect(cases[0]).toMatchObject({
+      repository: 'acme/widget',
+      source: 'dataset:swe-bench-multilingual',
+      commit_sha: 'abc123',
+    });
+    expect(JSON.parse(cases[0].strategy_labels)).toEqual(expect.arrayContaining(['import_type', 'type_runtime_split']));
+    expect(JSON.parse(cases[0].validation_signals)).toMatchObject({
+      dataset_name: 'swe-bench-multilingual',
+      imported: true,
+      language_scope: {
+        training_language: 'js_ts',
+        eligible: true,
+        js_ts_changed_files: ['src/planner.ts'],
+      },
+      matched_terms: expect.arrayContaining(['circular dependency', 'import type']),
+    });
+  });
+
+  it('imports Parquet rows through DuckDB', async () => {
+    const parquetPath = path.join(outputDir, 'fixjs.parquet');
+    await writeParquetFixture(parquetPath, [
+      {
+        repository: 'acme/core',
+        instance_id: 'case-1',
+        title: 'Break cyclic dependency with barrel cleanup',
+        patch: [
+          'diff --git a/src/index.ts b/src/index.ts',
+          '--- a/src/index.ts',
+          '+++ b/src/index.ts',
+          'diff --git a/src/runtime.ts b/src/runtime.ts',
+          '--- a/src/runtime.ts',
+          '+++ b/src/runtime.ts',
+        ].join('\n'),
+      },
+    ]);
+
+    const result = await importBenchmarkDataset(parquetPath, {
+      database: db,
+      datasetName: 'fixjs-derived',
+    });
+
+    const cases = createStatements(db).getBenchmarkCases.all() as BenchmarkCaseDTO[];
+
+    expect(result).toMatchObject({
+      format: 'parquet',
+      totalRows: 1,
+      jsTsRows: 1,
+      relatedRows: 1,
+      insertedCases: 1,
+    });
+    expect(cases).toHaveLength(1);
+    expect(cases[0]).toMatchObject({
+      repository: 'acme/core',
+      source: 'dataset:fixjs-derived',
+      commit_sha: 'case-1',
+    });
+    expect(JSON.parse(cases[0].matched_terms)).toEqual(expect.arrayContaining(['cyclic dependency', 'barrel']));
+  });
+});
+
+async function writeParquetFixture(outputPath: string, rows: Array<Record<string, unknown>>) {
+  const instance = await DuckDBInstance.create(':memory:');
+  try {
+    const connection = await instance.connect();
+    try {
+      const jsonlPath = path.join(path.dirname(outputPath), 'fixture.jsonl');
+      await fs.writeFile(`${jsonlPath}`, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+      await connection.run('LOAD json');
+      await connection.run('LOAD parquet');
+      await connection.run(`
+        CREATE TABLE fixture_rows AS
+        SELECT *
+        FROM read_json_auto('${jsonlPath.replaceAll('\\', '/')}', format = 'newline_delimited')
+      `);
+      await connection.run(`
+        COPY fixture_rows
+        TO '${outputPath.replaceAll('\\', '/')}'
+        (FORMAT parquet, COMPRESSION zstd)
+      `);
+    } finally {
+      connection.closeSync();
+    }
+  } finally {
+    instance.closeSync();
+  }
+}

--- a/cli/importBenchmarkDataset.ts
+++ b/cli/importBenchmarkDataset.ts
@@ -1,0 +1,411 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { DuckDBInstance } from '@duckdb/node-api';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import { createStatements, getDb } from '../db/index.js';
+import {
+  classifyStrategyLabels,
+  findMatchedTerms,
+  getDefaultBenchmarkSearchTerms,
+  normalizeSearchTerms,
+} from './benchmarkSignals.js';
+
+const TRAINING_CODE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mts', '.cts']);
+
+export type BenchmarkDatasetFormat = 'json' | 'jsonl' | 'parquet';
+
+export interface ImportBenchmarkDatasetOptions {
+  database?: DatabaseType;
+  datasetName?: string;
+  source?: string;
+  format?: BenchmarkDatasetFormat;
+  searchTerms?: string[];
+  maxRows?: number;
+  relatedOnly?: boolean;
+}
+
+export interface ImportBenchmarkDatasetResult {
+  inputPath: string;
+  datasetName: string;
+  source: string;
+  format: BenchmarkDatasetFormat;
+  totalRows: number;
+  jsTsRows: number;
+  relatedRows: number;
+  insertedCases: number;
+  skippedNonJsTs: number;
+  skippedUnrelated: number;
+}
+
+interface ImportedDatasetRow {
+  repository: string;
+  commitSha: string;
+  title: string;
+  body: string | null;
+  url: string | null;
+  prNumber: number | null;
+  issueNumber: number | null;
+  text: string;
+  changedFiles: ChangedFileSummary;
+  diffFeatures: Record<string, unknown>;
+  validationSignals: Record<string, unknown>;
+}
+
+interface ChangedFileSummary {
+  allPaths: string[];
+  jsTsPaths: string[];
+  nonJsTsPaths: string[];
+}
+
+export async function importBenchmarkDataset(
+  inputPath: string,
+  options: ImportBenchmarkDatasetOptions = {},
+): Promise<ImportBenchmarkDatasetResult> {
+  const database = options.database ?? getDb();
+  const statements = createStatements(database);
+  const resolvedInputPath = path.resolve(inputPath);
+  const format = options.format ?? detectDatasetFormat(resolvedInputPath);
+  const datasetName = options.datasetName?.trim() || path.basename(resolvedInputPath, path.extname(resolvedInputPath));
+  const source = options.source?.trim() || `dataset:${datasetName}`;
+  const relatedOnly = options.relatedOnly ?? true;
+  const searchTerms = normalizeSearchTerms(options.searchTerms ?? getDefaultBenchmarkSearchTerms());
+  const rawRows = await loadDatasetRows(resolvedInputPath, format);
+
+  let totalRows = 0;
+  let jsTsRows = 0;
+  let relatedRows = 0;
+  let insertedCases = 0;
+  let skippedNonJsTs = 0;
+  let skippedUnrelated = 0;
+
+  for (const [index, rawRow] of rawRows.entries()) {
+    if (typeof options.maxRows === 'number' && totalRows >= options.maxRows) {
+      break;
+    }
+
+    totalRows += 1;
+    const normalizedRow = normalizeImportedRow(rawRow, datasetName, source, index);
+    if (normalizedRow.changedFiles.jsTsPaths.length === 0) {
+      skippedNonJsTs += 1;
+      continue;
+    }
+
+    jsTsRows += 1;
+    const matchedTerms = findMatchedTerms(normalizedRow.text, searchTerms);
+    if (matchedTerms.length > 0) {
+      relatedRows += 1;
+    } else if (relatedOnly) {
+      skippedUnrelated += 1;
+      continue;
+    }
+
+    statements.addBenchmarkCase.run({
+      repository: normalizedRow.repository,
+      source,
+      commit_sha: normalizedRow.commitSha,
+      title: normalizedRow.title,
+      body: normalizedRow.body,
+      url: normalizedRow.url,
+      pr_number: normalizedRow.prNumber,
+      issue_number: normalizedRow.issueNumber,
+      strategy_labels: JSON.stringify(classifyStrategyLabels(normalizedRow.text)),
+      validation_signals: JSON.stringify({
+        ...normalizedRow.validationSignals,
+        dataset_name: datasetName,
+        imported: true,
+        language_scope: buildLanguageScopeSignals(normalizedRow.changedFiles),
+        matched_terms: matchedTerms,
+        search_terms: searchTerms.length,
+      }),
+      diff_features: JSON.stringify(normalizedRow.diffFeatures),
+      matched_terms: JSON.stringify(matchedTerms),
+      notes: buildImportNote(datasetName, matchedTerms, normalizedRow.changedFiles),
+    });
+
+    insertedCases += 1;
+  }
+
+  return {
+    inputPath: resolvedInputPath,
+    datasetName,
+    source,
+    format,
+    totalRows,
+    jsTsRows,
+    relatedRows,
+    insertedCases,
+    skippedNonJsTs,
+    skippedUnrelated,
+  };
+}
+
+function detectDatasetFormat(inputPath: string): BenchmarkDatasetFormat {
+  const lowerPath = inputPath.toLowerCase();
+  if (lowerPath.endsWith('.jsonl')) {
+    return 'jsonl';
+  }
+  if (lowerPath.endsWith('.parquet')) {
+    return 'parquet';
+  }
+
+  return 'json';
+}
+
+async function loadDatasetRows(inputPath: string, format: BenchmarkDatasetFormat): Promise<Record<string, unknown>[]> {
+  if (format === 'json') {
+    const contents = await fs.readFile(inputPath, 'utf8');
+    const parsed = JSON.parse(contents) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.filter((entry): entry is Record<string, unknown> => isRecord(entry));
+    }
+    if (isRecord(parsed) && Array.isArray(parsed.rows)) {
+      return parsed.rows.filter((entry): entry is Record<string, unknown> => isRecord(entry));
+    }
+
+    throw new Error(`JSON benchmark dataset must be an array or contain a "rows" array: ${inputPath}`);
+  }
+
+  if (format === 'jsonl') {
+    const contents = await fs.readFile(inputPath, 'utf8');
+    return contents
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as unknown)
+      .filter((entry): entry is Record<string, unknown> => isRecord(entry));
+  }
+
+  const instance = await DuckDBInstance.create(':memory:');
+  try {
+    const connection = await instance.connect();
+    try {
+      const reader = await connection.runAndReadAll(`
+        SELECT *
+        FROM read_parquet('${escapeSqlString(normalizeForDuckDb(inputPath))}')
+      `);
+      return (reader.getRowObjectsJson() as unknown[]).filter((entry): entry is Record<string, unknown> =>
+        isRecord(entry),
+      );
+    } finally {
+      connection.closeSync();
+    }
+  } finally {
+    instance.closeSync();
+  }
+}
+
+function normalizeImportedRow(
+  row: Record<string, unknown>,
+  datasetName: string,
+  source: string,
+  index: number,
+): ImportedDatasetRow {
+  const textParts = collectTextParts(row);
+  const text = textParts.join('\n\n').trim();
+  const changedFiles = extractChangedFiles(row);
+  const repository =
+    firstString(row.repository, row.repo, row.repo_name, row.project, row.project_name, row.slug) ??
+    `dataset/${datasetName}`;
+  const title = firstString(row.title, row.issue_title, row.summary, row.problem_title) ?? fallbackTitle(text, index);
+  const body =
+    firstString(row.body, row.problem_statement, row.description, row.issue_body, row.message, row.commit_message) ??
+    null;
+  const commitSha =
+    firstString(row.commit_sha, row.base_commit, row.sha, row.instance_id, row.id, row.record_id) ??
+    buildSyntheticIdentifier(source, repository, title, index);
+  const url = firstString(row.url, row.html_url, row.pull_request_url, row.issue_url) ?? null;
+  const prNumber = firstInteger(row.pr_number, row.pull_request_number, row.pr, row.pull_number);
+  const issueNumber = firstInteger(row.issue_number, row.issue, row.issue_id);
+  const patch = firstString(row.patch, row.test_patch, row.diff) ?? '';
+
+  return {
+    repository,
+    commitSha,
+    title,
+    body,
+    url,
+    prNumber,
+    issueNumber,
+    text,
+    changedFiles,
+    diffFeatures: {
+      files_changed: changedFiles.allPaths.length,
+      js_ts_files_changed: changedFiles.jsTsPaths.length,
+      non_js_ts_files_changed: changedFiles.nonJsTsPaths.length,
+      patch_length: patch.length,
+      text_length: text.length,
+    },
+    validationSignals: {
+      source_fields: Object.keys(row),
+      row_identifier:
+        firstString(row.instance_id, row.id, row.record_id, row.base_commit, row.commit_sha, row.sha) ??
+        `row-${index + 1}`,
+      has_patch: patch.length > 0,
+    },
+  };
+}
+
+function collectTextParts(row: Record<string, unknown>): string[] {
+  return [
+    firstString(row.title, row.issue_title, row.summary, row.problem_title),
+    firstString(row.problem_statement, row.body, row.description, row.issue_body),
+    firstString(row.commit_message, row.message),
+    firstString(row.patch, row.test_patch, row.diff),
+  ].filter(Boolean) as string[];
+}
+
+function extractChangedFiles(row: Record<string, unknown>): ChangedFileSummary {
+  const pathSet = new Set<string>();
+
+  for (const field of [row.file_path, row.path, row.file, row.changed_files, row.files, row.paths]) {
+    for (const filePath of extractPathsFromField(field)) {
+      pathSet.add(filePath);
+    }
+  }
+
+  for (const patchText of [row.patch, row.test_patch, row.diff]) {
+    for (const filePath of extractPathsFromPatch(firstString(patchText) ?? '')) {
+      pathSet.add(filePath);
+    }
+  }
+
+  const allPaths = [...pathSet];
+  const jsTsPaths: string[] = [];
+  const nonJsTsPaths: string[] = [];
+
+  for (const filePath of allPaths) {
+    if (isJavaScriptOrTypeScriptPath(filePath)) {
+      jsTsPaths.push(filePath);
+      continue;
+    }
+
+    nonJsTsPaths.push(filePath);
+  }
+
+  return {
+    allPaths,
+    jsTsPaths,
+    nonJsTsPaths,
+  };
+}
+
+function extractPathsFromField(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]/)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => firstString(entry)).filter((entry): entry is string => entry !== undefined);
+  }
+
+  return [];
+}
+
+function extractPathsFromPatch(patch: string): string[] {
+  const pathSet = new Set<string>();
+  for (const line of patch.split('\n')) {
+    const diffGitMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (diffGitMatch) {
+      pathSet.add(diffGitMatch[2]);
+      continue;
+    }
+
+    const fileMatch = line.match(/^(?:\+\+\+|---) [ab]\/(.+)$/);
+    if (fileMatch) {
+      pathSet.add(fileMatch[1]);
+    }
+  }
+
+  return [...pathSet].map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+}
+
+function buildLanguageScopeSignals(changedFiles: ChangedFileSummary): Record<string, unknown> {
+  return {
+    training_language: 'js_ts',
+    eligible: true,
+    js_ts_changed_files: changedFiles.jsTsPaths,
+    non_js_ts_changed_files: changedFiles.nonJsTsPaths,
+    total_changed_paths: changedFiles.allPaths.length,
+  };
+}
+
+function buildImportNote(datasetName: string, matchedTerms: string[], changedFiles: ChangedFileSummary): string {
+  const relatedNote = matchedTerms.length > 0 ? matchedTerms.join(', ') : 'none';
+  return [
+    `dataset: ${datasetName}`,
+    `matched terms: ${relatedNote}`,
+    `js/ts files: ${changedFiles.jsTsPaths.length}`,
+    `other files: ${changedFiles.nonJsTsPaths.length}`,
+  ].join('; ');
+}
+
+function fallbackTitle(text: string, index: number): string {
+  const normalizedText = text.replaceAll(/\s+/g, ' ').trim();
+  if (normalizedText.length > 0) {
+    return normalizedText.slice(0, 120);
+  }
+
+  return `Imported benchmark row ${index + 1}`;
+}
+
+function buildSyntheticIdentifier(source: string, repository: string, title: string, index: number): string {
+  return createHash('sha256')
+    .update(`${source}\u001F${repository}\u001F${title}\u001F${index}`)
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function isJavaScriptOrTypeScriptPath(filePath: string): boolean {
+  const normalizedPath = filePath.trim().toLowerCase();
+  if (!normalizedPath) {
+    return false;
+  }
+
+  return TRAINING_CODE_EXTENSIONS.has(path.extname(normalizedPath));
+}
+
+function normalizeForDuckDb(filePath: string): string {
+  return filePath.replaceAll('\\', '/');
+}
+
+function escapeSqlString(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function firstInteger(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isInteger(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isInteger(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -17,6 +17,7 @@ import { mineBenchmarkCasesFromRepo } from './benchmarkMiner.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
 import { exportTrainingData } from './exportTrainingData.js';
+import { importBenchmarkDataset } from './importBenchmarkDataset.js';
 import { createProgram } from './index.js';
 import { getOperationalMetrics } from './metrics.js';
 import { profileRepository } from './repoProfile.js';
@@ -439,6 +440,21 @@ vi.mock('./exportTrainingData.js', () => ({
   }),
 }));
 
+vi.mock('./importBenchmarkDataset.js', () => ({
+  importBenchmarkDataset: vi.fn().mockResolvedValue({
+    inputPath: path.join(fixtureRoot, 'datasets', 'swebench.parquet'),
+    datasetName: 'swe-bench-multilingual',
+    source: 'dataset:swe-bench-multilingual',
+    format: 'parquet',
+    totalRows: 10,
+    jsTsRows: 4,
+    relatedRows: 2,
+    insertedCases: 2,
+    skippedNonJsTs: 6,
+    skippedUnrelated: 2,
+  }),
+}));
+
 vi.mock('./metrics.js', () => ({
   getOperationalMetrics: vi.fn().mockReturnValue({
     repositories: {
@@ -626,6 +642,42 @@ describe('CLI', () => {
       maxCommits: undefined,
       maxMatches: undefined,
     });
+    consoleSpy.mockRestore();
+  });
+
+  it('benchmark:import command imports external dataset rows', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'benchmark:import',
+      path.join(fixtureRoot, 'datasets', 'swebench.parquet'),
+      '--dataset',
+      'swe-bench-multilingual',
+      '--format',
+      'parquet',
+      '--search-term',
+      'circular import',
+    ]);
+
+    expect(vi.mocked(importBenchmarkDataset)).toHaveBeenCalledWith(
+      path.join(fixtureRoot, 'datasets', 'swebench.parquet'),
+      {
+        datasetName: 'swe-bench-multilingual',
+        source: undefined,
+        format: 'parquet',
+        maxRows: undefined,
+        searchTerms: ['circular import'],
+        relatedOnly: true,
+      },
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"datasetName": "swe-bench-multilingual"'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"insertedCases": 2'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"format": "parquet"'));
+
     consoleSpy.mockRestore();
   });
 
@@ -1202,6 +1254,7 @@ describe('CLI', () => {
     expect(commandNames).toContain('benchmark:acceptance');
     expect(commandNames).toContain('benchmark:acceptance:report');
     expect(commandNames).toContain('benchmark:acceptance:annotate');
+    expect(commandNames).toContain('benchmark:import');
     expect(commandNames).toContain('scan');
     expect(commandNames).toContain('explain');
     expect(commandNames).toContain('profile:repo');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -15,6 +15,7 @@ import { mineBenchmarkCasesFromRepo } from './benchmarkMiner.js';
 import { createPullRequestForPatch } from './createPullRequest.js';
 import { exportApprovedPatches } from './exportPatches.js';
 import { exportTrainingData, type TrainingDataFormat } from './exportTrainingData.js';
+import { type BenchmarkDatasetFormat, importBenchmarkDataset } from './importBenchmarkDataset.js';
 import { getOperationalMetrics } from './metrics.js';
 import {
   createConcurrencyLimiter,
@@ -169,6 +170,44 @@ export function createProgram(): Command {
           console.log(JSON.stringify(result, null, 2));
         } catch (error) {
           console.error(`Failed to annotate acceptance benchmark case ${caseId}:`, error);
+          process.exit(1);
+        }
+      },
+    );
+
+  program
+    .command('benchmark:import <inputPath>')
+    .description('Import external benchmark dataset rows into the benchmark database')
+    .option('--dataset <name>', 'Dataset label to persist alongside imported rows')
+    .option('--source <source>', 'Override the stored benchmark source label')
+    .option('--format <format>', 'Import format: json, jsonl, or parquet', parseBenchmarkDatasetFormat)
+    .option('--max-rows <count>', 'Limit how many dataset rows are processed', parseInteger)
+    .option('--search-term <term>', 'Additional cycle-related search term to match', collectString, [])
+    .option('--allow-unrelated', 'Import JS/TS rows even when they do not match cycle-related terms')
+    .action(
+      async (
+        inputPath: string,
+        options: {
+          dataset?: string;
+          source?: string;
+          format?: BenchmarkDatasetFormat;
+          maxRows?: number;
+          searchTerm: string[];
+          allowUnrelated?: boolean;
+        },
+      ) => {
+        try {
+          const result = await importBenchmarkDataset(inputPath, {
+            datasetName: options.dataset,
+            source: options.source,
+            format: options.format,
+            maxRows: options.maxRows,
+            searchTerms: options.searchTerm.length > 0 ? options.searchTerm : undefined,
+            relatedOnly: !options.allowUnrelated,
+          });
+          console.log(JSON.stringify(result, null, 2));
+        } catch (error) {
+          console.error(`Failed to import benchmark dataset ${inputPath}:`, error);
           process.exit(1);
         }
       },
@@ -564,6 +603,14 @@ function parseTrainingDataFormat(value: string): TrainingDataFormat {
   }
 
   throw new Error(`Expected a training-data export format of json, jsonl, or parquet. Received: ${value}`);
+}
+
+function parseBenchmarkDatasetFormat(value: string): BenchmarkDatasetFormat {
+  if (value === 'json' || value === 'jsonl' || value === 'parquet') {
+    return value;
+  }
+
+  throw new Error(`Expected a benchmark dataset format of json, jsonl, or parquet. Received: ${value}`);
 }
 
 // Run when executed directly

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "explain": "tsx cli/index.ts explain",
     "profile:repo": "tsx cli/index.ts profile:repo",
     "metrics:report": "tsx cli/index.ts metrics:report",
+    "benchmark:import": "tsx cli/index.ts benchmark:import",
     "mine:corpus": "tsx cli/index.ts mine:corpus",
     "mine:repo-history": "tsx cli/index.ts mine:repo-history",
     "scan:all": "tsx cli/index.ts scan:all",


### PR DESCRIPTION
## Summary
- add a generic external benchmark importer for JSON, JSONL, and Parquet datasets
- keep imports JS/TS-only and cycle-related by default so imported rows stay useful for circular-dependency ranking
- wire the importer into the CLI and document the new benchmark seeding path

Closes #67

## Verification
- ../../node_modules/.bin/vitest run --config vitest.config.ts
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/eslint .
- ../../node_modules/.bin/biome check .
- ../../node_modules/.bin/vite build