### PR TITLE
Broaden benchmark commit matching

### DIFF
--- a/cli/benchmarkSignals.test.ts
+++ b/cli/benchmarkSignals.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { findMatchedTerms, getDefaultBenchmarkSearchTerms } from './benchmarkSignals.js';
+
+describe('findMatchedTerms', () => {
+  it('matches contextual cycle fix phrases that are more specific than the default term list', () => {
+    const searchTerms = getDefaultBenchmarkSearchTerms();
+
+    expect(findMatchedTerms('fix(ui): break app chat settings cycle', searchTerms)).toEqual(
+      expect.arrayContaining(['break cycle']),
+    );
+    expect(findMatchedTerms('Nostr: remove plugin API import cycle', searchTerms)).toEqual(
+      expect.arrayContaining(['import cycle']),
+    );
+    expect(findMatchedTerms('fix: break Synology Chat plugin-sdk reexport cycle', searchTerms)).toEqual(
+      expect.arrayContaining(['export cycle', 'break cycle', 'reexport']),
+    );
+    expect(
+      findMatchedTerms('Plugins: fix signal SDK circular re-exports and reserved commands TDZ', searchTerms),
+    ).toEqual(expect.arrayContaining(['circular', 're-export']));
+  });
+
+  it('does not treat lifecycle-only messages as cycle fixes', () => {
+    const searchTerms = getDefaultBenchmarkSearchTerms();
+    expect(findMatchedTerms('Add session lifecycle gateway methods', searchTerms)).toEqual([]);
+  });
+});

--- a/cli/benchmarkSignals.ts
+++ b/cli/benchmarkSignals.ts
@@ -1,6 +1,7 @@
 const DEFAULT_SEARCH_TERMS = [
   'circular dependency',
   'cyclic dependency',
+  'circular import',
   'import type',
   'type-only',
   'barrel',
@@ -25,7 +26,49 @@ export function normalizeSearchTerms(terms: string[]): string[] {
 
 export function findMatchedTerms(text: string, searchTerms: string[]): string[] {
   const lowerText = text.toLowerCase();
-  return searchTerms.filter((term) => lowerText.includes(term));
+  const matchedTerms = new Set(searchTerms.filter((term) => lowerText.includes(term)));
+
+  if (containsWholeWord(lowerText, 'circular')) {
+    matchedTerms.add('circular');
+  }
+  if (containsWholeWord(lowerText, 'cyclic')) {
+    matchedTerms.add('cyclic');
+  }
+  if (containsCycleContext(lowerText, ['import'])) {
+    matchedTerms.add('import cycle');
+  }
+  if (containsCycleContext(lowerText, ['export', 're-export', 'reexport'])) {
+    matchedTerms.add('export cycle');
+  }
+  if (containsCycleContext(lowerText, ['barrel'])) {
+    matchedTerms.add('barrel cycle');
+  }
+  if (containsCycleContext(lowerText, ['dependency', 'dependencies'])) {
+    matchedTerms.add('dependency cycle');
+  }
+  if (containsCycleContext(lowerText, ['break'])) {
+    matchedTerms.add('break cycle');
+  }
+
+  return [...matchedTerms];
+}
+
+function containsWholeWord(text: string, word: string): boolean {
+  return new RegExp(String.raw`\b${escapeForRegex(word)}\b`, 'i').test(text);
+}
+
+function containsCycleContext(text: string, keywords: string[]): boolean {
+  return text.split('\n').some((segment) => {
+    if (!/\bcycles?\b/i.test(segment)) {
+      return false;
+    }
+
+    return keywords.some((keyword) => segment.includes(keyword));
+  });
+}
+
+function escapeForRegex(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 export function classifyStrategyLabels(commitText: string): string[] {


### PR DESCRIPTION
## Summary
- add contextual benchmark-term matching for commit messages like `break ... cycle`, `import cycle`, and `reexport cycle`
- keep the matcher precise enough to avoid `lifecycle` noise
- add regression tests for the real commit-message shapes we saw in openclaw

Closes #69

## Real result
- rerunning benchmark mining on `openclaw` increased stored benchmark cases from `41` to `51`

## Verification
- ../../node_modules/.bin/eslint cli/benchmarkSignals.ts cli/benchmarkSignals.test.ts cli/benchmarkMiner.ts
- ../../node_modules/.bin/vitest run --config vitest.config.ts cli/benchmarkSignals.test.ts cli/benchmarkMiner.test.ts
- ../../node_modules/.bin/tsc --noEmit --project tsconfig.json
- ../../node_modules/.bin/biome check cli/benchmarkSignals.ts cli/benchmarkSignals.test.ts cli/benchmarkMiner.ts