### PR TITLE
Improve planner coverage from benchmark evidence

### DIFF
--- a/analyzer/semantic.test.ts
+++ b/analyzer/semantic.test.ts
@@ -235,6 +235,52 @@ describe('SemanticAnalyzer', () => {
     });
   });
 
+  it('detects direct_import for mixed public API seams that re-export a safe leaf symbol', () => {
+    analyzer.project.createSourceFile(
+      '/dummy/repo/app.ts',
+      `
+      import { Foo } from './api';
+      export const appValue = Foo + 1;
+    `,
+    );
+    analyzer.project.createSourceFile(
+      '/dummy/repo/api.ts',
+      `
+      export { Foo } from './foo';
+      export { Bar } from './bar';
+      export const apiVersion = '1';
+    `,
+    );
+    analyzer.project.createSourceFile('/dummy/repo/foo.ts', 'export const Foo = 1;');
+    analyzer.project.createSourceFile(
+      '/dummy/repo/bar.ts',
+      `
+      import { appValue } from './app';
+      export const Bar = appValue + 1;
+    `,
+    );
+
+    const result = analyzer.analyzeCycle(['app.ts', 'api.ts', 'bar.ts', 'app.ts']);
+
+    expect(result.classification).toBe('autofix_direct_import');
+    expect(result.planner?.selectedStrategy).toBe('direct_import');
+    expect(result.planner?.rankedCandidates[0]?.signals).toMatchObject({
+      bypassesBarrel: true,
+      bypassesPublicSeam: true,
+    });
+    expect(result.plan).toEqual({
+      kind: 'direct_import',
+      imports: [
+        {
+          sourceFile: 'app.ts',
+          barrelFile: 'api.ts',
+          targetFile: 'foo.ts',
+          symbols: ['Foo'],
+        },
+      ],
+    });
+  });
+
   it('adjusts candidate scoring with historical evidence and repository features', () => {
     analyzer = new SemanticAnalyzer('/dummy/repo', {
       repositoryProfile: {
@@ -536,12 +582,12 @@ describe('SemanticAnalyzer', () => {
     const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
 
     expect(result.classification).toBe('autofix_host_state_update');
-    expect(result.upstreamabilityScore).toBe(0.87);
+    expect(result.upstreamabilityScore).toBe(0.89);
     expect(result.planner).toMatchObject({
       cycleShape: 'two_file',
       selectedStrategy: 'host_state_update',
       selectedClassification: 'autofix_host_state_update',
-      selectedScore: 0.87,
+      selectedScore: 0.89,
     });
     expect(result.plan).toEqual({
       kind: 'host_state_update',
@@ -555,6 +601,93 @@ describe('SemanticAnalyzer', () => {
       updatedProperty: 'lastActiveSessionKey',
       mirrorHostProperty: 'applySessionKey',
       trimValue: true,
+    });
+  });
+
+  it('prefers host_state_update over extract_shared when the setter helper has unrelated side effects', () => {
+    analyzer.project.createSourceFile(
+      '/dummy/repo/a.ts',
+      `
+      import { setLastActiveSessionKey } from './b';
+      export const runA = (host: unknown) => setLastActiveSessionKey(host, ' next ');
+    `,
+    );
+    analyzer.project.createSourceFile(
+      '/dummy/repo/b.ts',
+      `
+      import { runA } from './a';
+      import { saveSettings } from './storage';
+
+      function applyResolvedTheme(_host: unknown, _theme: string) {}
+      function applyBorderRadius(_radius: number) {}
+
+      export function applySettings(
+        host: {
+          settings: { lastActiveSessionKey: string; sessionKey: string; theme: string; themeMode: string; borderRadius: number };
+          applySessionKey: string;
+          theme: string;
+          themeMode: string;
+        },
+        next: { lastActiveSessionKey: string; sessionKey: string; theme: string; themeMode: string; borderRadius: number },
+      ) {
+        const normalized = {
+          ...next,
+          lastActiveSessionKey: next.lastActiveSessionKey?.trim() || next.sessionKey.trim() || 'main',
+        };
+        host.settings = normalized;
+        saveSettings(normalized);
+        if (next.theme !== host.theme || next.themeMode !== host.themeMode) {
+          host.theme = next.theme;
+          host.themeMode = next.themeMode;
+          applyResolvedTheme(host, next.theme);
+        }
+        applyBorderRadius(next.borderRadius);
+        host.applySessionKey = host.settings.lastActiveSessionKey;
+      }
+
+      export function setLastActiveSessionKey(
+        host: {
+          settings: { lastActiveSessionKey: string; sessionKey: string; theme: string; themeMode: string; borderRadius: number };
+          applySessionKey: string;
+          theme: string;
+          themeMode: string;
+        },
+        next: string,
+      ) {
+        const trimmed = next.trim();
+        if (!trimmed) {
+          return;
+        }
+        if (host.settings.lastActiveSessionKey === trimmed) {
+          return;
+        }
+        applySettings(host, { ...host.settings, lastActiveSessionKey: trimmed });
+      }
+
+      export const runB = () => runA({
+        settings: { lastActiveSessionKey: 'main', sessionKey: 'main', theme: 'claw', themeMode: 'system', borderRadius: 50 },
+        applySessionKey: 'main',
+        theme: 'claw',
+        themeMode: 'system',
+      });
+    `,
+    );
+    analyzer.project.createSourceFile('/dummy/repo/storage.ts', 'export function saveSettings(_next: unknown) {}\n');
+
+    const result = analyzer.analyzeCycle(['a.ts', 'b.ts', 'a.ts']);
+
+    expect(result.classification).toBe('autofix_host_state_update');
+    expect(result.planner?.selectedStrategy).toBe('host_state_update');
+    expect(result.planner?.rankedCandidates.map((attempt) => attempt.strategy)).toEqual(
+      expect.arrayContaining(['host_state_update', 'extract_shared']),
+    );
+    expect(result.upstreamabilityScore).toBeGreaterThan(0.85);
+    expect(result.plan).toMatchObject({
+      kind: 'host_state_update',
+      importedFunction: 'setLastActiveSessionKey',
+      persistenceFunction: 'saveSettings',
+      updatedProperty: 'lastActiveSessionKey',
+      mirrorHostProperty: 'applySessionKey',
     });
   });
 

--- a/analyzer/semantic/SemanticAnalyzer.ts
+++ b/analyzer/semantic/SemanticAnalyzer.ts
@@ -38,6 +38,21 @@ import type {
 } from './types.js';
 import { missingCycleFilesReason } from './types.js';
 
+type PersistenceModuleKind = 'package' | 'repo_file';
+
+type HostStateHelperStatementResult =
+  | { kind: 'alias'; settingsValueName: string }
+  | { kind: 'host_assignment' }
+  | {
+      kind: 'persistence';
+      persistenceFunction: string;
+      persistenceModule: string;
+      persistenceModuleKind: PersistenceModuleKind;
+    }
+  | { kind: 'mirror'; mirrorHostProperty: string }
+  | { kind: 'ignored' }
+  | { kind: 'reject' };
+
 export class SemanticAnalyzer {
   public project: Project;
 
@@ -477,7 +492,7 @@ export class SemanticAnalyzer {
     return {
       strategy: 'direct_import',
       status: 'candidate',
-      summary: `Rewrite ${directImportResult.plan.length} barrel import edge(s) to direct imports.`,
+      summary: `Rewrite ${directImportResult.plan.length} re-export seam import edge(s) to direct imports.`,
       reasons: [
         `Cycle can be resolved by importing ${firstPlan.symbols.join(', ')} directly from ${firstPlan.targetFile} instead of ${firstPlan.barrelFile}.`,
       ],
@@ -815,7 +830,7 @@ export class SemanticAnalyzer {
   ):
     | {
         persistenceModule: string;
-        persistenceModuleKind: 'package' | 'repo_file';
+        persistenceModuleKind: PersistenceModuleKind;
         persistenceFunction: string;
         mirrorHostProperty?: string;
       }
@@ -835,55 +850,84 @@ export class SemanticAnalyzer {
       return undefined;
     }
 
+    const settingsValueNames = new Set<string>([settingsParamName]);
+
+    const collectedPattern = this.collectHostStatePersistencePattern(
+      body.getStatements(),
+      targetFile,
+      hostParamName,
+      stateObjectProperty,
+      updatedProperty,
+      settingsValueNames,
+      settingsParamName,
+      sourceFilePath,
+      targetFilePath,
+    );
+    if (!collectedPattern) {
+      return undefined;
+    }
+
+    return {
+      persistenceModule: collectedPattern.persistenceModule,
+      persistenceModuleKind: collectedPattern.persistenceModuleKind,
+      persistenceFunction: collectedPattern.persistenceFunction,
+      mirrorHostProperty: collectedPattern.mirrorHostProperty,
+    };
+  }
+
+  private collectHostStatePersistencePattern(
+    statements: Node[],
+    targetFile: SourceFile,
+    hostParamName: string,
+    stateObjectProperty: string,
+    updatedProperty: string,
+    settingsValueNames: Set<string>,
+    settingsParamName: string,
+    sourceFilePath: string,
+    targetFilePath: string,
+  ):
+    | {
+        persistenceModule: string;
+        persistenceModuleKind: PersistenceModuleKind;
+        persistenceFunction: string;
+        mirrorHostProperty?: string;
+      }
+    | undefined {
     let persistenceFunction: string | undefined;
     let persistenceModule: string | undefined;
-    let persistenceModuleKind: 'package' | 'repo_file' | undefined;
+    let persistenceModuleKind: PersistenceModuleKind | undefined;
     let mirrorHostProperty: string | undefined;
 
-    for (const statement of body.getStatements()) {
-      const hostStateAssignment = this.extractHostStateAssignment(
-        statement,
-        hostParamName,
-        stateObjectProperty,
-        settingsParamName,
-      );
-      if (hostStateAssignment) {
-        continue;
-      }
-
-      const persistenceCall = this.extractImportedPersistenceCall(
+    for (const statement of statements) {
+      const statementResult = this.classifyHostStateHelperStatement(
         targetFile,
-        statement,
-        settingsParamName,
-        sourceFilePath,
-        targetFilePath,
-      );
-      if (persistenceCall) {
-        if (persistenceFunction !== undefined) {
-          return undefined;
-        }
-
-        persistenceFunction = persistenceCall.persistenceFunction;
-        persistenceModule = persistenceCall.persistenceModule;
-        persistenceModuleKind = persistenceCall.persistenceModuleKind;
-        continue;
-      }
-
-      const mirrorAssignment = this.extractMirrorHostPropertyAssignment(
         statement,
         hostParamName,
         stateObjectProperty,
         updatedProperty,
+        settingsValueNames,
+        settingsParamName,
+        sourceFilePath,
+        targetFilePath,
+        persistenceFunction,
       );
-      if (mirrorAssignment) {
-        if (this.isConflictingMirrorHostProperty(mirrorHostProperty, mirrorAssignment)) {
-          return undefined;
-        }
-        mirrorHostProperty = mirrorAssignment;
-        continue;
+
+      const nextPattern = this.applyHostStateHelperStatementResult(
+        statementResult,
+        settingsValueNames,
+        persistenceFunction,
+        persistenceModule,
+        persistenceModuleKind,
+        mirrorHostProperty,
+      );
+      if (!nextPattern) {
+        return undefined;
       }
 
-      return undefined;
+      persistenceFunction = nextPattern.persistenceFunction;
+      persistenceModule = nextPattern.persistenceModule;
+      persistenceModuleKind = nextPattern.persistenceModuleKind;
+      mirrorHostProperty = nextPattern.mirrorHostProperty;
     }
 
     if (!persistenceFunction || !persistenceModule || !persistenceModuleKind) {
@@ -896,6 +940,140 @@ export class SemanticAnalyzer {
       persistenceFunction,
       mirrorHostProperty,
     };
+  }
+
+  private applyHostStateHelperStatementResult(
+    statementResult: HostStateHelperStatementResult,
+    settingsValueNames: Set<string>,
+    persistenceFunction: string | undefined,
+    persistenceModule: string | undefined,
+    persistenceModuleKind: PersistenceModuleKind | undefined,
+    mirrorHostProperty: string | undefined,
+  ):
+    | {
+        persistenceFunction: string | undefined;
+        persistenceModule: string | undefined;
+        persistenceModuleKind: PersistenceModuleKind | undefined;
+        mirrorHostProperty: string | undefined;
+      }
+    | undefined {
+    if (statementResult.kind === 'alias') {
+      settingsValueNames.add(statementResult.settingsValueName);
+      return {
+        persistenceFunction,
+        persistenceModule,
+        persistenceModuleKind,
+        mirrorHostProperty,
+      };
+    }
+
+    if (statementResult.kind === 'host_assignment' || statementResult.kind === 'ignored') {
+      return {
+        persistenceFunction,
+        persistenceModule,
+        persistenceModuleKind,
+        mirrorHostProperty,
+      };
+    }
+
+    if (statementResult.kind === 'persistence') {
+      if (persistenceFunction !== undefined) {
+        return undefined;
+      }
+
+      return {
+        persistenceFunction: statementResult.persistenceFunction,
+        persistenceModule: statementResult.persistenceModule,
+        persistenceModuleKind: statementResult.persistenceModuleKind,
+        mirrorHostProperty,
+      };
+    }
+
+    if (statementResult.kind === 'mirror') {
+      if (this.isConflictingMirrorHostProperty(mirrorHostProperty, statementResult.mirrorHostProperty)) {
+        return undefined;
+      }
+
+      return {
+        persistenceFunction,
+        persistenceModule,
+        persistenceModuleKind,
+        mirrorHostProperty: statementResult.mirrorHostProperty,
+      };
+    }
+
+    return undefined;
+  }
+
+  private classifyHostStateHelperStatement(
+    targetFile: SourceFile,
+    statement: Node,
+    hostParamName: string,
+    stateObjectProperty: string,
+    updatedProperty: string,
+    settingsValueNames: ReadonlySet<string>,
+    settingsParamName: string,
+    sourceFilePath: string,
+    targetFilePath: string,
+    persistenceFunction: string | undefined,
+  ): HostStateHelperStatementResult {
+    const normalizedSettingsValue = this.extractSettingsAliasVariable(
+      statement,
+      settingsValueNames,
+      settingsParamName,
+      updatedProperty,
+    );
+    if (normalizedSettingsValue) {
+      return { kind: 'alias', settingsValueName: normalizedSettingsValue };
+    }
+
+    const hostStateAssignment = [...settingsValueNames].some((settingsValueName) =>
+      this.extractHostStateAssignment(statement, hostParamName, stateObjectProperty, settingsValueName),
+    );
+    if (hostStateAssignment) {
+      return { kind: 'host_assignment' };
+    }
+
+    const persistenceCall = [...settingsValueNames]
+      .map((settingsValueName) =>
+        this.extractImportedPersistenceCall(targetFile, statement, settingsValueName, sourceFilePath, targetFilePath),
+      )
+      .find(Boolean);
+    if (persistenceCall) {
+      return {
+        kind: 'persistence',
+        persistenceFunction: persistenceCall.persistenceFunction,
+        persistenceModule: persistenceCall.persistenceModule,
+        persistenceModuleKind: persistenceCall.persistenceModuleKind,
+      };
+    }
+
+    const mirrorAssignment = this.extractMirrorHostPropertyAssignment(
+      statement,
+      hostParamName,
+      stateObjectProperty,
+      updatedProperty,
+      settingsValueNames,
+    );
+    if (mirrorAssignment) {
+      return { kind: 'mirror', mirrorHostProperty: mirrorAssignment };
+    }
+
+    if (
+      this.isIgnorableHostStateHelperStatement(
+        targetFile,
+        statement,
+        hostParamName,
+        stateObjectProperty,
+        updatedProperty,
+        settingsValueNames,
+        persistenceFunction,
+      )
+    ) {
+      return { kind: 'ignored' };
+    }
+
+    return { kind: 'reject' };
   }
 
   private createExtractSharedPlan(sourceFile: string, targetFile: string, symbols: string[]): ExtractSharedFixPlan {
@@ -1088,7 +1266,7 @@ export class SemanticAnalyzer {
     return `pkg:${packageName}`;
   }
 
-  private getPersistenceModuleKey(moduleKind: 'package' | 'repo_file', persistenceModule: string): string {
+  private getPersistenceModuleKey(moduleKind: PersistenceModuleKind, persistenceModule: string): string {
     return moduleKind === 'repo_file'
       ? this.createRepoFileModuleKey(persistenceModule)
       : this.createPackageModuleKey(persistenceModule);
@@ -1317,7 +1495,7 @@ export class SemanticAnalyzer {
     | {
         persistenceFunction: string;
         persistenceModule: string;
-        persistenceModuleKind: 'package' | 'repo_file';
+        persistenceModuleKind: PersistenceModuleKind;
       }
     | undefined {
     if (!Node.isExpressionStatement(statement)) {
@@ -1356,6 +1534,7 @@ export class SemanticAnalyzer {
     hostParamName: string,
     stateObjectProperty: string,
     updatedProperty: string,
+    settingsValueNames: ReadonlySet<string>,
   ): string | undefined {
     if (!Node.isExpressionStatement(statement)) {
       return undefined;
@@ -1372,16 +1551,134 @@ export class SemanticAnalyzer {
       !leftChain ||
       leftChain.length !== 2 ||
       leftChain[0] !== hostParamName ||
-      !rightChain ||
-      rightChain.length !== 3 ||
-      rightChain[0] !== hostParamName ||
-      rightChain[1] !== stateObjectProperty ||
-      rightChain[2] !== updatedProperty
+      !this.isMirrorAssignmentSource(
+        rightChain,
+        hostParamName,
+        stateObjectProperty,
+        updatedProperty,
+        settingsValueNames,
+      )
     ) {
       return undefined;
     }
 
     return leftChain[1];
+  }
+
+  private isMirrorAssignmentSource(
+    rightChain: string[] | undefined,
+    hostParamName: string,
+    stateObjectProperty: string,
+    updatedProperty: string,
+    settingsValueNames: ReadonlySet<string>,
+  ): boolean {
+    if (!rightChain) {
+      return false;
+    }
+
+    return (
+      (rightChain.length === 3 &&
+        rightChain[0] === hostParamName &&
+        rightChain[1] === stateObjectProperty &&
+        rightChain[2] === updatedProperty) ||
+      (rightChain.length === 2 && settingsValueNames.has(rightChain[0] ?? '') && rightChain[1] === updatedProperty)
+    );
+  }
+
+  private extractSettingsAliasVariable(
+    statement: Node,
+    settingsValueNames: ReadonlySet<string>,
+    settingsParamName: string,
+    updatedProperty: string,
+  ): string | undefined {
+    if (!Node.isVariableStatement(statement)) {
+      return undefined;
+    }
+
+    const declaration = statement.getDeclarations()[0];
+    const initializer = declaration?.getInitializer();
+    if (
+      !declaration ||
+      declaration.getNameNode().getKind() !== SyntaxKind.Identifier ||
+      !initializer ||
+      !Node.isObjectLiteralExpression(initializer)
+    ) {
+      return undefined;
+    }
+
+    const hasSettingsSpread = initializer
+      .getProperties()
+      .some(
+        (property) => Node.isSpreadAssignment(property) && settingsValueNames.has(property.getExpression().getText()),
+      );
+    if (!hasSettingsSpread) {
+      return undefined;
+    }
+
+    const writesUpdatedProperty = initializer
+      .getProperties()
+      .some((property) => Node.isPropertyAssignment(property) && property.getName() === updatedProperty);
+    if (!writesUpdatedProperty) {
+      return undefined;
+    }
+
+    const initializerText = initializer.getText();
+    if (!initializerText.includes(settingsParamName)) {
+      return undefined;
+    }
+
+    return declaration.getName();
+  }
+
+  private isIgnorableHostStateHelperStatement(
+    sourceFile: SourceFile,
+    statement: Node,
+    hostParamName: string,
+    stateObjectProperty: string,
+    updatedProperty: string,
+    settingsValueNames: ReadonlySet<string>,
+    persistenceFunction: string | undefined,
+  ): boolean {
+    if (Node.isReturnStatement(statement) || Node.isThrowStatement(statement)) {
+      return false;
+    }
+
+    const propertyChains = statement
+      .getDescendantsOfKind(SyntaxKind.PropertyAccessExpression)
+      .map((expression) => this.getPropertyAccessChain(expression))
+      .filter((chain): chain is string[] => Array.isArray(chain));
+
+    if (
+      propertyChains.some(
+        (chain) =>
+          chain[0] === hostParamName &&
+          chain[1] === stateObjectProperty &&
+          (chain.length > 2 || chain[2] === updatedProperty),
+      )
+    ) {
+      return false;
+    }
+
+    if (propertyChains.some((chain) => settingsValueNames.has(chain[0] ?? '') && chain[1] === updatedProperty)) {
+      return false;
+    }
+
+    for (const callExpression of statement.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+      const callee = callExpression.getExpression();
+      if (!Node.isIdentifier(callee)) {
+        continue;
+      }
+
+      if (persistenceFunction && callee.getText() === persistenceFunction) {
+        return false;
+      }
+
+      if (this.findImportedBinding(sourceFile, callee.getText())) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   private findImportedBinding(
@@ -1419,7 +1716,7 @@ export class SemanticAnalyzer {
   ): {
     persistenceFunction: string;
     persistenceModule: string;
-    persistenceModuleKind: 'package' | 'repo_file';
+    persistenceModuleKind: PersistenceModuleKind;
   } {
     if (!moduleSpecifier.startsWith('.') && !path.isAbsolute(moduleSpecifier)) {
       return {

--- a/analyzer/semantic/evidence.test.ts
+++ b/analyzer/semantic/evidence.test.ts
@@ -42,6 +42,15 @@ describe('historical evidence loading', () => {
           },
         }),
       },
+      {
+        strategy_labels: JSON.stringify(['public_seam_bypass', 'ownership_localization']),
+        validation_signals: JSON.stringify({
+          repository_profile: {
+            package_manager: 'pnpm',
+            workspace_mode: 'workspace',
+          },
+        }),
+      },
     ];
     evidenceFixtures.acceptanceBenchmarkCases = [
       {
@@ -109,13 +118,13 @@ describe('historical evidence loading', () => {
       validationCommandCount: 3,
     });
 
-    expect(snapshot.totalBenchmarkCases).toBe(1);
+    expect(snapshot.totalBenchmarkCases).toBe(2);
     expect(snapshot.totalAcceptanceBenchmarkCases).toBe(3);
     expect(snapshot.totalReviewedPatches).toBe(2);
     expect(snapshot.totalValidatedPatches).toBe(2);
     expect(snapshot.strategies.direct_import).toMatchObject({
-      benchmarkMatches: 1,
-      profileMatches: 2,
+      benchmarkMatches: 2,
+      profileMatches: 4,
       approvedReviews: 1,
       passedValidations: 1,
     });
@@ -131,6 +140,10 @@ describe('historical evidence loading', () => {
       failedValidations: 1,
       newCyclesIntroducedFailures: 1,
       repoValidationFailures: 1,
+    });
+    expect(snapshot.strategies.host_state_update).toMatchObject({
+      benchmarkMatches: 1,
+      profileMatches: 2,
     });
   });
 });

--- a/analyzer/semantic/evidence.ts
+++ b/analyzer/semantic/evidence.ts
@@ -11,9 +11,14 @@ const STRATEGIES: PlanningStrategy[] = ['import_type', 'direct_import', 'extract
 
 const STRATEGY_LABELS: Record<PlanningStrategy, string[]> = {
   import_type: ['import_type', 'type_runtime_split'],
-  direct_import: ['direct_import', 'barrel_reexport_cleanup'],
+  direct_import: ['direct_import', 'barrel_reexport_cleanup', 'public_seam_bypass', 'export_graph_rewrite'],
   extract_shared: ['extract_shared', 'leaf_cluster_extraction'],
-  host_state_update: ['host_owned_state_update', 'stateful_singleton_split'],
+  host_state_update: [
+    'host_owned_state_update',
+    'stateful_singleton_split',
+    'ownership_localization',
+    'internal_surface_split',
+  ],
 };
 
 const CLASSIFICATION_TO_STRATEGY: Partial<Record<string, PlanningStrategy>> = {

--- a/analyzer/semantic/graph.ts
+++ b/analyzer/semantic/graph.ts
@@ -113,7 +113,7 @@ export function findDirectImportPlanFromGraph(
   for (const importEdge of graphSummary.importEdges) {
     const candidate = tryBuildDirectImportCandidate(importEdge, cycleFileSet, moduleByFile, resolutionMap);
     if (!candidate) {
-      sawBarrelScenario ||= isBarrelCycleEdge(importEdge, cycleFileSet, moduleByFile);
+      sawBarrelScenario ||= isReexportCycleEdge(importEdge, cycleFileSet, moduleByFile, resolutionMap);
       ambiguousResolution ||= isAmbiguousBarrelEdge(importEdge, cycleFileSet, moduleByFile, resolutionMap);
       continue;
     }
@@ -575,7 +575,7 @@ function tryBuildDirectImportCandidate(
   moduleByFile: Map<string, GraphModuleSummary>,
   resolutionMap: Map<string, GraphExportResolution>,
 ): NonNullable<DirectImportSearchResult['plan']>[number] | undefined {
-  if (!isBarrelCycleEdge(importEdge, cycleFileSet, moduleByFile)) {
+  if (!isReexportCycleEdge(importEdge, cycleFileSet, moduleByFile, resolutionMap)) {
     return undefined;
   }
 
@@ -621,7 +621,7 @@ function isAmbiguousBarrelEdge(
   moduleByFile: Map<string, GraphModuleSummary>,
   resolutionMap: Map<string, GraphExportResolution>,
 ): boolean {
-  if (!isBarrelCycleEdge(importEdge, cycleFileSet, moduleByFile)) {
+  if (!isReexportCycleEdge(importEdge, cycleFileSet, moduleByFile, resolutionMap)) {
     return false;
   }
 
@@ -635,16 +635,39 @@ function isAmbiguousBarrelEdge(
   });
 }
 
-function isBarrelCycleEdge(
+function isReexportCycleEdge(
   importEdge: GraphImportEdge,
   cycleFileSet: Set<string>,
   moduleByFile: Map<string, GraphModuleSummary>,
+  resolutionMap: Map<string, GraphExportResolution>,
 ): boolean {
   if (!cycleFileSet.has(importEdge.from) || !cycleFileSet.has(importEdge.to)) {
     return false;
   }
 
-  return moduleByFile.get(importEdge.to)?.moduleKind === 'pure_barrel';
+  const targetModule = moduleByFile.get(importEdge.to);
+  if (!targetModule || !targetModule.hasReExports || targetModule.hasTopLevelSideEffects) {
+    return false;
+  }
+
+  if (targetModule.moduleKind === 'pure_barrel') {
+    return true;
+  }
+
+  return importEdge.symbols.some((symbol) => {
+    if (symbol === 'default' || symbol === '*') {
+      return false;
+    }
+
+    const resolution = resolutionMap.get(toResolutionKey(importEdge.to, symbol));
+    return Boolean(
+      resolution &&
+        !resolution.ambiguous &&
+        resolution.targetFile &&
+        resolution.targetFile !== importEdge.to &&
+        !cycleFileSet.has(resolution.targetFile),
+    );
+  });
 }
 
 function tarjanScc(nodes: GraphSymbolNode[], edges: GraphSymbolEdge[]): string[][] {

--- a/analyzer/semantic/scoring.ts
+++ b/analyzer/semantic/scoring.ts
@@ -39,12 +39,27 @@ export function scoreDirectImportPlan(importPlans: DirectImportFixPlan['imports'
   signals: Record<string, StrategySignalValue>;
 } {
   const touchedFiles = new Set(importPlans.map((plan) => plan.sourceFile));
+  const seamBypassCount = importPlans.filter((plan) => {
+    const normalizedBarrel = plan.barrelFile.toLowerCase();
+    return (
+      normalizedBarrel.includes('/api.') ||
+      normalizedBarrel.startsWith('api.') ||
+      normalizedBarrel.includes('/plugin-sdk/') ||
+      normalizedBarrel.includes('/setup-surface.') ||
+      normalizedBarrel.startsWith('setup-surface.') ||
+      normalizedBarrel.includes('/setup-core.') ||
+      normalizedBarrel.startsWith('setup-core.')
+    );
+  }).length;
   const score = clampScore(0.89 - Math.max(0, touchedFiles.size - 1) * 0.04);
   return {
     score,
     breakdown: [
       'base 0.89 for removing a barrel hop',
       touchedFiles.size > 1 ? `-0.04 for touching ${touchedFiles.size} files` : 'no penalty for single touched file',
+      seamBypassCount > 0
+        ? `semantic note: ${seamBypassCount} import(s) bypass a public re-export seam`
+        : 'no public-seam bypass signal',
     ],
     signals: {
       touchedFiles: touchedFiles.size,
@@ -52,6 +67,7 @@ export function scoreDirectImportPlan(importPlans: DirectImportFixPlan['imports'
       introducesNewFile: false,
       preservesSourceExports: true,
       bypassesBarrel: true,
+      bypassesPublicSeam: seamBypassCount > 0,
     },
   };
 }
@@ -62,11 +78,14 @@ export function scoreExtractSharedPlan(plan: ExtractSharedFixPlan): {
   signals: Record<string, StrategySignalValue>;
 } {
   const symbolNamedSharedFile = plan.symbols.length === 1 && path.basename(plan.sharedFile).includes(plan.symbols[0]);
+  const setterLikeExtraction =
+    plan.symbols.length === 1 && /^(set|update|apply|assign)[A-Z_]/.test(plan.symbols[0] ?? '');
   const score = clampScore(
     0.68 +
       (plan.preserveSourceExports ? 0.08 : 0) +
       (plan.symbols.length === 1 ? 0.06 : 0) +
       (symbolNamedSharedFile ? 0.04 : 0) -
+      (setterLikeExtraction ? 0.05 : 0) -
       Math.max(0, plan.symbols.length - 1) * 0.03,
   );
   return {
@@ -78,12 +97,16 @@ export function scoreExtractSharedPlan(plan: ExtractSharedFixPlan): {
         ? '+0.06 for single-symbol extraction'
         : `-${Math.max(0, plan.symbols.length - 1) * 0.03} for extracting multiple symbols`,
       symbolNamedSharedFile ? '+0.04 for a symbol-driven shared filename' : 'no filename clarity bonus',
+      setterLikeExtraction
+        ? '-0.05 because setter-like helpers usually read better as localized ownership updates'
+        : 'no setter-localization penalty',
     ],
     signals: {
       touchedFiles: 3,
       symbolCount: plan.symbols.length,
       introducesNewFile: true,
       preservesSourceExports: plan.preserveSourceExports,
+      setterLikeExtraction,
       sharedFile: plan.sharedFile,
       sourceFile: plan.sourceFile,
       targetFile: plan.targetFile,
@@ -96,11 +119,11 @@ export function scoreHostStateUpdatePlan(plan: HostStateUpdateFixPlan): {
   breakdown: string[];
   signals: Record<string, StrategySignalValue>;
 } {
-  const score = clampScore(0.85 + (plan.mirrorHostProperty ? 0.01 : 0) + (plan.trimValue ? 0.01 : 0));
+  const score = clampScore(0.87 + (plan.mirrorHostProperty ? 0.01 : 0) + (plan.trimValue ? 0.01 : 0));
   return {
     score,
     breakdown: [
-      'base 0.85 for removing a cross-module state setter without introducing a new file',
+      'base 0.87 for localizing a cross-module state setter without introducing a new file',
       plan.mirrorHostProperty ? '+0.01 for preserving a mirrored host field update' : 'no mirrored-host bonus',
       plan.trimValue ? '+0.01 for preserving value normalization in the localized helper' : 'no normalization bonus',
     ],

--- a/cli/benchmarkMiner.test.ts
+++ b/cli/benchmarkMiner.test.ts
@@ -108,6 +108,7 @@ describe('mineBenchmarkCasesFromRepo', () => {
       binary_files: 0,
       js_ts_files_changed: 2,
       non_js_ts_files_changed: 0,
+      touches_public_api_seam: false,
     });
     expect(JSON.parse(importTypeCase?.validation_signals ?? '{}')).toMatchObject({
       search_terms: expect.any(Number),
@@ -122,6 +123,54 @@ describe('mineBenchmarkCasesFromRepo', () => {
     });
     expect(importTypeCase?.notes).toContain('matched terms:');
     expect(importTypeCase?.notes).toContain('training language scope: js/ts');
+
+    db.close();
+  });
+
+  it('derives public seam labels and patch-shape features from changed file paths', async () => {
+    const db = createDatabase(':memory:');
+    initSchema(db);
+
+    const git: GitAdapter = {
+      raw: async (args: string[]) => {
+        const key = args.join(' ');
+        if (key === 'remote get-url origin') {
+          return 'git@github.com:acme/widget.git';
+        }
+        if (key === 'log --all --no-merges --max-count=1000 --pretty=format:%H%x1f%s%x1f%b%x1e') {
+          return 'abc123\u001FNostr: remove plugin API import cycle\u001FBypass the plugin-sdk seam.\u001E';
+        }
+        if (key === 'show --name-status --find-renames --format= abc123') {
+          return 'M\textensions/nostr/src/channel.ts\nM\tsrc/plugin-sdk/nostr.ts\n';
+        }
+        if (key === 'show --numstat --find-renames --format= abc123') {
+          return '4\t2\textensions/nostr/src/channel.ts\n2\t1\tsrc/plugin-sdk/nostr.ts\n';
+        }
+
+        throw new Error(`Unexpected git call: ${key}`);
+      },
+    };
+
+    // eslint-disable-next-line sonarjs/publicly-writable-directories
+    await mineBenchmarkCasesFromRepo('/tmp/acme-widget', {
+      database: db,
+      git,
+      maxMatches: 10,
+    });
+
+    const [benchmarkCase] = createStatements(db).getBenchmarkCasesByRepository.all('acme/widget') as Array<{
+      strategy_labels: string;
+      diff_features: string;
+    }>;
+
+    expect(JSON.parse(benchmarkCase.strategy_labels)).toEqual(
+      expect.arrayContaining(['public_seam_bypass', 'export_graph_rewrite']),
+    );
+    expect(JSON.parse(benchmarkCase.diff_features)).toMatchObject({
+      touches_public_api_seam: true,
+      touches_plugin_sdk_surface: true,
+      touches_api_shim: false,
+    });
 
     db.close();
   });

--- a/cli/benchmarkMiner.ts
+++ b/cli/benchmarkMiner.ts
@@ -68,6 +68,13 @@ interface DiffFeatures {
   binary_files: number;
   js_ts_files_changed: number;
   non_js_ts_files_changed: number;
+  touches_public_api_seam: boolean;
+  touches_plugin_sdk_surface: boolean;
+  touches_internal_surface: boolean;
+  touches_setup_surface: boolean;
+  touches_setup_core: boolean;
+  touches_api_shim: boolean;
+  touches_shared_module: boolean;
 }
 
 interface ChangedFileSummary {
@@ -125,7 +132,7 @@ export async function mineBenchmarkCasesFromRepo(
       continue;
     }
 
-    const strategyLabels = classifyStrategyLabels(commitText);
+    const strategyLabels = classifyStrategyLabels(commitText, diffSummary.changedFiles.allPaths);
     const url = buildCommitUrl(repository, commit.commitSha);
 
     statements.addBenchmarkCase.run({
@@ -250,6 +257,7 @@ async function collectDiffSummary(git: GitAdapter, commitSha: string): Promise<D
       binary_files: binaryFiles,
       js_ts_files_changed: changedFiles.jsTsPaths.length,
       non_js_ts_files_changed: changedFiles.nonJsTsPaths.length,
+      ...buildPatchShapeDiffFeatures(changedFiles),
     },
     changedFiles,
   };
@@ -378,6 +386,45 @@ function summarizeChangedFiles(paths: string[]): ChangedFileSummary {
     allPaths: uniquePaths,
     jsTsPaths,
     nonJsTsPaths,
+  };
+}
+
+function buildPatchShapeDiffFeatures(
+  changedFiles: ChangedFileSummary,
+): Omit<
+  DiffFeatures,
+  | 'files_changed'
+  | 'additions'
+  | 'deletions'
+  | 'new_files'
+  | 'renamed_files'
+  | 'modified_files'
+  | 'binary_files'
+  | 'js_ts_files_changed'
+  | 'non_js_ts_files_changed'
+> {
+  const normalizedPaths = changedFiles.allPaths.map((filePath) => filePath.toLowerCase());
+
+  return {
+    touches_public_api_seam: normalizedPaths.some(
+      (filePath) =>
+        filePath.endsWith('/api.ts') ||
+        filePath.endsWith('/api.js') ||
+        filePath.includes('/plugin-sdk/') ||
+        filePath.includes('/setup-surface.') ||
+        filePath.includes('/setup-core.'),
+    ),
+    touches_plugin_sdk_surface: normalizedPaths.some((filePath) => filePath.includes('/plugin-sdk/')),
+    touches_internal_surface: normalizedPaths.some(
+      (filePath) =>
+        filePath.includes('/plugin-sdk-internal/') ||
+        filePath.endsWith('/internal.ts') ||
+        filePath.endsWith('/internal.js'),
+    ),
+    touches_setup_surface: normalizedPaths.some((filePath) => filePath.includes('/setup-surface.')),
+    touches_setup_core: normalizedPaths.some((filePath) => filePath.includes('/setup-core.')),
+    touches_api_shim: normalizedPaths.some((filePath) => filePath.endsWith('/api.ts') || filePath.endsWith('/api.js')),
+    touches_shared_module: normalizedPaths.some((filePath) => filePath.includes('.shared.')),
   };
 }
 

--- a/cli/benchmarkSignals.test.ts
+++ b/cli/benchmarkSignals.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { findMatchedTerms, getDefaultBenchmarkSearchTerms } from './benchmarkSignals.js';
+import { classifyStrategyLabels, findMatchedTerms, getDefaultBenchmarkSearchTerms } from './benchmarkSignals.js';
 
 describe('findMatchedTerms', () => {
   it('matches contextual cycle fix phrases that are more specific than the default term list', () => {
@@ -22,5 +22,34 @@ describe('findMatchedTerms', () => {
   it('does not treat lifecycle-only messages as cycle fixes', () => {
     const searchTerms = getDefaultBenchmarkSearchTerms();
     expect(findMatchedTerms('Add session lifecycle gateway methods', searchTerms)).toEqual([]);
+  });
+});
+
+describe('classifyStrategyLabels', () => {
+  it('adds public seam and export-graph labels when plugin-sdk or api seams change', () => {
+    expect(
+      classifyStrategyLabels('Nostr: remove plugin API import cycle', [
+        'extensions/nostr/src/channel.ts',
+        'src/plugin-sdk/nostr.ts',
+      ]),
+    ).toEqual(expect.arrayContaining(['public_seam_bypass', 'export_graph_rewrite']));
+  });
+
+  it('adds ownership-localization labels for caller-owned settings cycle fixes', () => {
+    expect(
+      classifyStrategyLabels('fix(ui): break app chat settings cycle', [
+        'ui/src/ui/app-chat.ts',
+        'ui/src/ui/app-chat.test.ts',
+      ]),
+    ).toEqual(expect.arrayContaining(['ownership_localization', 'host_owned_state_update']));
+  });
+
+  it('adds internal-surface labels when internalized surfaces are introduced', () => {
+    expect(
+      classifyStrategyLabels('Plugins: internalize line SDK imports', [
+        'src/plugin-sdk-internal/discord.ts',
+        'extensions/discord/src/accounts.ts',
+      ]),
+    ).toEqual(expect.arrayContaining(['internal_surface_split']));
   });
 });

--- a/cli/benchmarkSignals.ts
+++ b/cli/benchmarkSignals.ts
@@ -71,8 +71,9 @@ function escapeForRegex(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
-export function classifyStrategyLabels(commitText: string): string[] {
+export function classifyStrategyLabels(commitText: string, changedPaths: string[] = []): string[] {
   const lowerText = commitText.toLowerCase();
+  const normalizedPaths = changedPaths.map((filePath) => filePath.trim().toLowerCase()).filter(Boolean);
   const labels = new Set<string>();
 
   if (/import\s+type|type-only|type only/.test(lowerText)) {
@@ -93,6 +94,43 @@ export function classifyStrategyLabels(commitText: string): string[] {
   if (/setter|state update|host-owned|stateful singleton|dependency inversion/.test(lowerText)) {
     labels.add('host_owned_state_update');
     labels.add('stateful_singleton_split');
+  }
+
+  if (
+    /break .*settings cycle|helper cycle|ownership|caller already owns|locali[sz]e/.test(lowerText) ||
+    (/break cycle|import cycle|dependency cycle/.test(lowerText) &&
+      normalizedPaths.some((filePath) => filePath.includes('/storage.') || filePath.includes('/settings.')))
+  ) {
+    labels.add('ownership_localization');
+    labels.add('host_owned_state_update');
+  }
+
+  const touchesPublicSeam = normalizedPaths.some(
+    (filePath) =>
+      filePath.endsWith('/api.ts') ||
+      filePath.endsWith('/api.js') ||
+      filePath.includes('/plugin-sdk/') ||
+      filePath.includes('/setup-surface.') ||
+      filePath.includes('/setup-core.'),
+  );
+  if (
+    /plugin-sdk|reexport cycle|re-export cycle|public api|setup cycle|import cycle|export cycle/.test(lowerText) ||
+    touchesPublicSeam
+  ) {
+    labels.add('public_seam_bypass');
+    labels.add('export_graph_rewrite');
+  }
+
+  if (
+    /internalize|internal surface|plugin-sdk-internal/.test(lowerText) ||
+    normalizedPaths.some(
+      (filePath) =>
+        filePath.includes('/plugin-sdk-internal/') ||
+        filePath.endsWith('/internal.ts') ||
+        filePath.endsWith('/internal.js'),
+    )
+  ) {
+    labels.add('internal_surface_split');
   }
 
   if (/internal\.(ts|js)|module loading order|internal entrypoint/.test(lowerText)) {


### PR DESCRIPTION
## Summary\n- strengthen host-state localization so caller-owned setters win over shared-file extraction when helper side effects are unrelated\n- broaden direct-import rewrites from pure barrels to mixed public API seams that safely re-export leaf symbols\n- enrich benchmark labels and diff features for ownership localization, public seam bypass, export-graph rewrite, and internal surface split\n\nCloses #71\n\n## Verification\n- pnpm exec eslint analyzer/semantic/SemanticAnalyzer.ts analyzer/semantic/scoring.ts analyzer/semantic/graph.ts analyzer/semantic.test.ts analyzer/semantic/evidence.ts analyzer/semantic/evidence.test.ts cli/benchmarkSignals.ts cli/benchmarkSignals.test.ts cli/benchmarkMiner.ts cli/benchmarkMiner.test.ts\n- pnpm exec biome check analyzer/semantic/SemanticAnalyzer.ts analyzer/semantic/scoring.ts analyzer/semantic/graph.ts analyzer/semantic.test.ts analyzer/semantic/evidence.ts analyzer/semantic/evidence.test.ts cli/benchmarkSignals.ts cli/benchmarkSignals.test.ts cli/benchmarkMiner.ts cli/benchmarkMiner.test.ts\n- pnpm exec tsc --noEmit --project tsconfig.json\n- pnpm exec vitest run --config vitest.config.ts\n- pnpm exec vite build